### PR TITLE
wpe-image,wpe-westeros-image: use dropbear instead of openssh for sshd

### DIFF
--- a/recipes-core/images/wpe-image.bb
+++ b/recipes-core/images/wpe-image.bb
@@ -8,8 +8,8 @@ include recipes-core/images/rpi-basic-image.bb
 require wpe-image.inc
 
 IMAGE_FEATURES += " \
-	hwcodecs \
-    ssh-server-openssh \
+    hwcodecs \
+    ssh-server-dropbear \
     package-management \
 "
 

--- a/recipes-core/images/wpe-westeros-image.bb
+++ b/recipes-core/images/wpe-westeros-image.bb
@@ -16,7 +16,7 @@ SPLASH_rpi = "psplash-raspberrypi"
 
 IMAGE_FEATURES += "hwcodecs \
                    package-management \
-                   ssh-server-openssh \
+                   ssh-server-dropbear \
                    splash \
 "
 


### PR DESCRIPTION
Its smaller in size, moreover openssh daemon does not work well with thumb2 ISA

Signed-off-by: Khem Raj <raj.khem@gmail.com>