### PR TITLE
base-files: restrict bbappend to rpi

### DIFF
--- a/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-core/base-files/base-files_%.bbappend
@@ -1,6 +1,4 @@
-COMPATIBLE_MACHINE = "rpi"
-
-do_install_append () {
+do_install_append_rpi () {
     cat >> ${D}${sysconfdir}/fstab <<EOF
 
 # Mount boot directory


### PR DESCRIPTION
**NOTE: this was a build breaking bug present in master, rocko, and pyro, please get it applied to all 3 of those branches**

The intention was clearly to restrict the bbappend customizations to
rpi, not to restrict the whole base-files recipe to only rpi machine...

  ERROR: Nothing PROVIDES 'base-files'
  base-files was skipped: incompatible with machine $ANYTHING_BUT_RPI (not in COMPATIBLE_MACHINE)

To get the desired result, make the do_install_append() conditional on
rpi platform, rather than setting COMPATIBLE_MACHINE