### PR TITLE
simplify rpi-config bbappend and move all config to layer.conf instead

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -28,18 +28,125 @@ LICENSE_FLAGS_WHITELIST += "commercial_gstreamer1.0-omx"
 
 BB_DANGLINGAPPENDS_WARNONLY ?= "1"
 
-# Enable Turbo mode on Rpi2
-ARM_FREQ = "1000"
-CORE_FREQ = "500"
-SDRAM_FREQ = "500"
-OVER_VOLTAGE = "6"
+#########################################################################################
+# Boot settings
+#
+# disable_splash: If set to 1, the rainbow splash screen will not be
+#                 shown on boot. The default value is 0.
+#
+# boot_delay: Instructs to wait for a given number of seconds in start.elf before
+#             loading the kernel. The default value is 1.
+#
+# Source:
+# https://www.raspberrypi.org/documentation/configuration/config-txt/boot.md
 
-# Set GPU/CPU memory split
-GPU_MEM_256 = "128"
-GPU_MEM_512 = "196"
-GPU_MEM_1024 = "396"
+DISABLE_SPLASH ?= "1"
+BOOT_DELAY ?= "0"
 
+#########################################################################################
+# Video settings
+#
+# hdmi_group: Defines the HDMI output group to be either CEA (Consumer Electronics
+#             Association, the standard typically used by TVs) or DMT (Display
+#             Monitor Timings, the standard typically used by monitors).
+#
+#             Value  Result
+#             0      Auto-detect from EDID
+#             1      CEA
+#             2      DMT
+#
+# hdmi_mode: Defines the HDMI output format. Common values for CEA group below.
+#            More values for CEA and DMT are in the source document.
+#
+#             Value  Resolution  Refresh
+#             4      720p        60Hz
+#             16     1080p       60Hz
+#             19     720p        50Hz
+#             31     1080p       50Hz
+#
+# disable_overscan: Set to 1 to disable overscan.
+#
+# Source:
+# https://www.raspberrypi.org/documentation/configuration/config-txt/video.md
+
+HDMI_GROUP ?= "1"
+HDMI_MODE ?= "4"
+DISABLE_OVERSCAN ?= "1"
+
+#########################################################################################
+# Overclocking settings
+#
+# arm_freq: Frequency of the ARM CPU in MHz.
+#           The default value is 1000 for the Pi Zero and Pi Zero W,
+#           700 for Pi 1, 900 for Pi 2, 1200 for the Pi 3.
+#
+# gpu_freq: Sets core_freq, h264_freq, isp_freq, and v3d_freq together.
+#           On Pi 1/Pi 2 the default value is 250 for all items,
+#           on Pi 3/Pi Zero /Pi Zero W core_freq defaults to 400 and
+#           h264_freq, isp_freq and v3d_freqdefault to 300.
+#
+# sdram_freq: Frequency of the SDRAM in MHz.
+#             The default value is 400 for the Pi 1 and Pi 2,
+#             450 on the Pi 3, Pi Zero and Pi Zero W.
+#
+# over_voltage: CPU/GPU core voltage adjustment.
+#               The defaults are in the table below.
+#
+#               Model       Default Overvoltage  Setting
+#               Pi 1        1.2V                 0
+#               Pi 2        1.2-1.3125V          0
+#               Pi 3        1.2-1.3125V          0
+#               Pi Zero(W)  1.35V                6
+#
+# Source:
+# https://www.raspberrypi.org/documentation/configuration/config-txt/overclocking.md
+
+# Raspberry Pi Zero
+ARM_FREQ_raspberrypi0 ?= "1000"
+GPU_FREQ_raspberrypi0 ?= "500"
+SDRAM_FREQ_raspberrypi0 ?= "500"
+OVER_VOLTAGE_raspberrypi0 ?= "6"
+
+# Raspberry Pi Zero W
+ARM_FREQ_raspberrypi0-wifi ?= "1000"
+GPU_FREQ_raspberrypi0-wifi ?= "500"
+SDRAM_FREQ_raspberrypi0-wifi ?= "500"
+OVER_VOLTAGE_raspberrypi0-wifi ?= "6"
+
+# Raspberry Pi (original)
+ARM_FREQ_raspberrypi ?= "1000"
+GPU_FREQ_raspberrypi ?= "500"
+SDRAM_FREQ_raspberrypi ?= "500"
+OVER_VOLTAGE_raspberrypi ?= "6"
+
+# Raspberry Pi 2
+ARM_FREQ_raspberrypi2 ?= "1000"
+GPU_FREQ_raspberrypi2 ?= "500"
+SDRAM_FREQ_raspberrypi2 ?= "500"
+OVER_VOLTAGE_raspberrypi2 ?= "6"
+
+#########################################################################################
+# GPU/CPU memory split options
+#
+# gpu_mem_256: Sets the GPU memory in megabytes for the 256MB models.
+#              The maximum value is 192 and the default is not set.
+#
+# gpu_mem_512: Sets the GPU memory in megabytes for the 512MB models.
+#              The maximum value is 448 and the default is not set.
+#
+# gpu_mem_1024: Sets the GPU memory in megabytes for the 1024MB models.
+#               The maximum value is 944 and the default is not set.
+#
+# Source:
+# https://www.raspberrypi.org/documentation/configuration/config-txt/memory.md
+
+GPU_MEM_256 ?= "128"
+GPU_MEM_512 ?= "196"
+GPU_MEM_1024 ?= "396"
+
+#########################################################################################
 # initramfs bits for rpi builds
+
 #INITRAMFS_IMAGE_BUNDLE_rpi = "1"
 #INITRAMFS_IMAGE_rpi = "wpe-initramfs-image"
 #KERNEL_INITRAMFS = "-initramfs"

--- a/recipes-bsp/bootfiles/rpi-config_git.bbappend
+++ b/recipes-bsp/bootfiles/rpi-config_git.bbappend
@@ -1,21 +1,21 @@
-HDMI_GROUP ?= "1"
-# for 720p use 4 (optimum) and for 1080p use 16
-HDMI_MODE ?= "4"
-
-do_deploy_prepend() {
-    ARM_FREQ=1000
-    GPU_MEM_256=128
-    GPU_MEM_512=196
-    GPU_MEM_1024=384
-    OVER_VOLTAGE=6
-    SDRAM_FREQ=500
-}
-
 do_deploy_append() {
-	sed -i '/#hdmi_group=/ c\hdmi_group=${HDMI_GROUP}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-	sed -i '/#hdmi_mode=/ c\hdmi_mode=${HDMI_MODE}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-    sed -i '/#disable_splash=/ c\disable_splash=1' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-    sed -i '/#gpu_freq=/ c\gpu_freq=500' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-    sed -i '/#disable_overscan=/ c\disable_overscan=1' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-    sed -i '/#boot_delay=/ c\boot_delay=0' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+    if [ -n "${GPU_FREQ}" ]; then
+        sed -i '/#gpu_freq=/ c\gpu_freq=${GPU_FREQ}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+    fi
+
+    if [ -n "${HDMI_GROUP}" ]; then
+        sed -i '/#hdmi_group=/ c\hdmi_group=${HDMI_GROUP}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+    fi
+
+    if [ -n "${HDMI_MODE}" ]; then
+        sed -i '/#hdmi_mode=/ c\hdmi_mode=${HDMI_MODE}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+    fi
+
+    if [ -n "${DISABLE_SPLASH}" ]; then
+        sed -i '/#disable_splash=/ c\disable_splash=${DISABLE_SPLASH}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+    fi
+
+    if [ -n "${BOOT_DELAY}" ]; then
+        sed -i '/#boot_delay=/ c\boot_delay=${BOOT_DELAY}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+    fi
 }


### PR DESCRIPTION
Hi guys !

Here is my PR to improve the handling of the `config.txt` file generation and to better modularise the `meta-wpe` layer in this regard. This started in Issue #177. The changes I implemented are: 

* Remove all static settings from the recipe append file. These are now configured in `layer.conf` and in `local.conf` as needed (more below).
* Properly implement config variables customisation for extra variables than the supported in `meta-raspberrypi` (such as `hdmi_mode` and `splash_screen`).
* Added the current defaults of the variables used by WPE to `layer.conf` so they remain pre-configured for a user-build.
* The overclocking variables (e.g. `arm_freq`, `gpu_freq`, etc.) are now conditional to the target machine (e.g. `raspberrypi2`). This means that for example RPI3 builds will not be overclocked (by default) while RPI1 and RPI2 will be. I used the standard recommended overclocking values for each RPI machine, but this can be further tuned per-machine and per user-build (including RPI3 if you really want).
* Because all the variables in `layer.conf` are assigned as defaults (using `=?`), they can be overriden in the `local.conf` file of each particular build. This allows for example to easily customise the HDMI mode (`hdmi_mode`) or the ARM freq for RPI2 (`ARM_FREQ_raspberrypi2`) in the `local.conf` build file while keeping the rest in their defaults.

I would suggest/advice that only certain variables be customised by the end-user, such as the GPU mem splits or the HDMI settings. Changing the overclocking settings can override the warranty, specially the over voltage variable.

I will document this functionality in the RPI Wiki page aswell for future end-users to easily build their WPE images.

I hope all these changes make the `meta-wpe` layer more robust and easy to use. I will keep working on small improvements there and here.. as I like to polish things =).
