### PR TITLE
wpewebkit: fix SRCREV typo

### DIFF
--- a/recipes-wpe/wpewebkit/wpewebkit_20170728.bb
+++ b/recipes-wpe/wpewebkit/wpewebkit_20170728.bb
@@ -21,7 +21,7 @@ CCACHE = "${STAGING_DIR_NATIVE}${bindir}/ccache "
 #CCACHE_DISABLE = "False"
 #OECMAKE_CCACHE="-DCMAKE_C_COMPILER_LAUNCHER=${CCACHE} -DCMAKE_CXX_COMPILER_LAUNCHER=${CCACHE}"
 
-SRCREV ?= c6f57338384c9c5c73c754d8c03c9f960ca9c288""
+SRCREV ?= "c6f57338384c9c5c73c754d8c03c9f960ca9c288"
 BASE_URI ?= "git://github.com/WebPlatformForEmbedded/WPEWebKit.git;protocol=git;branch=wpe-20170728"
 SRC_URI = "${BASE_URI}"
 SRC_URI += "file://0001-mse-Print-MediaTime-consistently-using-s.patch"


### PR DESCRIPTION
somehow SRCREV begin quote got moved when the BASE_URI in line below
was being updated

typo only seems to appear rocko branch, so fix is only applicable in this branch