### PR TITLE
layer.conf: add LAYERSERIES_COMPAT

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,6 +9,8 @@ BBFILE_COLLECTIONS += "wpe-layer"
 BBFILE_PATTERN_wpe-layer := "^${LAYERDIR}/"
 BBFILE_PRIORITY_wpe-layer = "20"
 
+LAYERSERIES_COMPAT_wpe-layer = "sumo"
+
 LAYERDEPENDS_wpe-layer = "core \
                           openembedded-layer \
                           multimedia-layer \


### PR DESCRIPTION
Yocto started to ask for `LAYERSERIES_COMPAT_x` to be explicitly set in 3rd-party layers for compatibility assurance.
This PR fixes the following warning by setting `LAYERSERIES_COMPAT_wpe-layer` to `sumo` in the `master` branch.

    WARNING: Layer wpe-layer should set LAYERSERIES_COMPAT_wpe-layer in its conf/layer.conf file to list the core layer names it is compatible with.

The commit in Poky is:
```
commit a0f22fd9712aa724f4e1e9a3ba4a2a9d6ce52403
Author: Richard Purdie <richard.purdie@linuxfoundation.org>
Date:   Fri Apr 6 10:58:48 2018 +0100

    bitbake: cookerdata: Issue warning if layer doesn't set LAYERSERIES_COMPAT_x

    We'd like layers to set this variable so that we know which layers are compatible
    with which others, even if the branch is a generic un-updated "master" branch.

    Start printing a warning to highlight this issue.

    (Bitbake rev: cca81e33b58c390dcf5cc3a31555a43b79177166)

    Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>
```
