### PR TITLE
libepoxy: rebase patches after upstream upgrade

### DIFF
--- a/recipes-graphics/libepoxy/libepoxy/0001_make_graphic_libs_configurable.patch
+++ b/recipes-graphics/libepoxy/libepoxy/0001_make_graphic_libs_configurable.patch
@@ -1,27 +1,28 @@
-index 72cda4c..7aafb58 100644
+index e2bb186..dd57a33 100644
 --- a/src/dispatch_common.c
 +++ b/src/dispatch_common.c
-@@ -173,13 +173,16 @@
-
+@@ -173,6 +173,9 @@
+ 
  #include "dispatch_common.h"
-
+ 
 +#define xstr(a) str(a)
 +#define str(a) #a
 +
  #ifdef __APPLE__
  #define GLX_LIB "/opt/X11/lib/libGL.1.dylib"
- #elif defined(__ANDROID__)
+ #define OPENGL_LIB "/System/Library/Frameworks/OpenGL.framework/Versions/Current/OpenGL"
+@@ -180,7 +183,7 @@
  #define GLX_LIB "libGLESv2.so"
  #else
  #define GLVND_GLX_LIB "libGLX.so.1"
 -#define GLX_LIB "libGL.so.1"
 +#define GLX_LIB xstr(GLX_LIB_NAME)
  #endif
-
+ 
  #ifdef __ANDROID__
-@@ -191,9 +194,9 @@
- #define GLES1_LIB "libGLES_CM.dll"
+@@ -193,9 +196,9 @@
  #define GLES2_LIB "libGLESv2.dll"
+ #define OPENGL_LIB "OPENGL32"
  #else
 -#define EGL_LIB "libEGL.so.1"
 -#define GLES1_LIB "libGLESv1_CM.so.1"
@@ -31,3 +32,4 @@ index 72cda4c..7aafb58 100644
 +#define GLES2_LIB xstr(GLES2_LIB_NAME)
  #define OPENGL_LIB "libOpenGL.so.0"
  #endif
+ 


### PR DESCRIPTION
Upstream libepoxy was upgraded and the patches no longer apply. Fixes:

    Applying patch 0001_make_graphic_libs_configurable.patch
    patching file src/dispatch_common.c
    Hunk #1 FAILED at 173.
    Hunk #2 succeeded at 193 with fuzz 2 (offset 2 lines).
    1 out of 2 hunks FAILED -- rejects in file src/dispatch_common.c
    Patch 0001_make_graphic_libs_configurable.patch does not apply (enforce with -f)
