### PR TITLE
wpewebkit: fix armv6 build (fixes #210)

### DIFF
--- a/recipes-wpe/wpewebkit/files/0003-Improve-checking-if-libatomic-is-needed-for-armv6-pr.patch
+++ b/recipes-wpe/wpewebkit/files/0003-Improve-checking-if-libatomic-is-needed-for-armv6-pr.patch
@@ -1,0 +1,53 @@
+From 5ddafade7ecbb47d751c9d2af33c7b68832695a9 Mon Sep 17 00:00:00 2001
+From: Hugo Hromic <hhromic@gmail.com>
+Date: Fri, 6 Jul 2018 23:11:54 +0100
+Subject: [PATCH] Improve checking if libatomic is needed for armv6 processors.
+
+From Khem Raj:
+> This patch is a correct way of detecting feature support for atomics, that does not
+> depend upon architecture but on compiler being able to support it.
+> Different compilers can provide different kind of support e.g. these atomics may not
+> exist on i586 for clang but might for gcc and so on.
+
+Fixes:
+
+UnifiedSource69.cpp:(.text._ZN3JSC25uniqueSecurityOriginTokenEv+0x20): undefined reference to `__atomic_fetch_add_8'
+collect2: error: ld returned 1 exit status
+
+during do_install() for armv6, e.g. raspberrypi0 machine.
+
+Upstream-Status: Pending
+Signed-off-by: Hugo Hromic <hhromic@gmail.com>
+---
+ Source/JavaScriptCore/CMakeLists.txt | 17 +++++++++--------
+ 1 file changed, 9 insertions(+), 8 deletions(-)
+
+diff --git a/Source/JavaScriptCore/CMakeLists.txt b/Source/JavaScriptCore/CMakeLists.txt
+index 26e3b5388d7..9a7948393b2 100644
+--- a/Source/JavaScriptCore/CMakeLists.txt
++++ b/Source/JavaScriptCore/CMakeLists.txt
+@@ -116,15 +116,16 @@ set(JavaScriptCore_LIBRARIES
+     ${LLVM_LIBRARIES}
+ )
+ 
+-# Since r228149, on MIPS we need to link with -latomic, because
+-# __atomic_fetch_add_8 is not available as a compiler intrinsic. It is
+-# available on other platforms (including 32-bit Arm), so the link with
+-# libatomic is only neede on MIPS.
+-if (WTF_CPU_MIPS)
+-    list(APPEND JavaScriptCore_LIBRARIES
+-        -latomic
+-    )
++# Check if libatomic is needed in order to use std::atomic, and add
++# it to the list of JavaScriptCore libraries.
++file(WRITE ${CMAKE_BINARY_DIR}/test_atomic.cpp
++    "#include <atomic>\n"
++    "int main() { std::atomic<int64_t> i(0); i++; return 0; }\n")
++try_compile(ATOMIC_BUILD_SUCCEEDED ${CMAKE_BINARY_DIR} ${CMAKE_BINARY_DIR}/test_atomic.cpp)
++if (NOT ATOMIC_BUILD_SUCCEEDED)
++    list(APPEND JavaScriptCore_LIBRARIES -latomic)
+ endif ()
++file(REMOVE ${CMAKE_BINARY_DIR}/test_atomic.cpp)
+ 
+ set(JavaScriptCore_SCRIPTS_SOURCES_DIR "${JAVASCRIPTCORE_DIR}/Scripts")
+ 

--- a/recipes-wpe/wpewebkit/wpewebkit_2.20.bb
+++ b/recipes-wpe/wpewebkit/wpewebkit_2.20.bb
@@ -102,6 +102,9 @@ ARM_INSTRUCTION_SET_armv7r = "thumb"
 ARM_INSTRUCTION_SET_armv7m = "thumb"
 ARM_INSTRUCTION_SET_armv7ve = "thumb"
 
+# JSC JIT doesn't currently compile on ARMv6, disable it.
+EXTRA_OECMAKE_append_armv6 = " -DENABLE_JIT=OFF"
+
 do_compile() {
     ${STAGING_BINDIR_NATIVE}/ninja ${PARALLEL_MAKE} -C ${B} libWPEWebKit.so libWPEWebInspectorResources.so WPEWebProcess WPENetworkProcess WPEStorageProcess WPEWebDriver
 }

--- a/recipes-wpe/wpewebkit/wpewebkit_2.20.bb
+++ b/recipes-wpe/wpewebkit/wpewebkit_2.20.bb
@@ -25,7 +25,8 @@ SRC_URI = "${BASE_URI} \
            file://0001-Define-MESA_EGL_NO_X11_HEADERS-when-not-using-GLX.patch \
            file://0001-Fix-build-with-musl.patch \
            file://0002-include-GraphicsContext3D.h-for-DONT_CARE-definition.patch \
-          "
+           file://0003-Improve-checking-if-libatomic-is-needed-for-armv6-pr.patch \
+           "
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
After the discussion in #210 , this PR fixes the build issues reported there using two changes:
1. disable the JSC JIT for armv6 processors
2. fix the detection of libatomic in JSC for armv6 processors via a patch

kudos to @kraj for the help debugging this, was difficult !