### PR TITLE
meta-wpe: normalize GitHub SRC_URI in recipes for default protocol/branch

### DIFF
--- a/recipes-wpe/wpebackend-mesa/wpebackend-mesa_0.1.bb
+++ b/recipes-wpe/wpebackend-mesa/wpebackend-mesa_0.1.bb
@@ -4,7 +4,7 @@ DEPENDS += "wpewebkit glib-2.0 libxkbcommon wayland virtual/libgl"
 
 SRCREV = "de843e2536f3a445737ce39ab643516a23531d5e"
 
-SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEBackend-mesa.git;protocol=http;branch=master"
+SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEBackend-mesa.git"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-wpe/wpebackend-rdk/wpebackend-rdk_0.1.bb
+++ b/recipes-wpe/wpebackend-rdk/wpebackend-rdk_0.1.bb
@@ -4,7 +4,7 @@ DEPENDS += "wpewebkit glib-2.0"
 
 SRCREV = "b009236d5b7b2c0d1c9418cbb5c27141dda801b6"
 
-SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEBackend-rdk.git;protocol=http;branch=master"
+SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEBackend-rdk.git"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-wpe/wpebackend/wpebackend_0.1.bb
+++ b/recipes-wpe/wpebackend/wpebackend_0.1.bb
@@ -3,7 +3,7 @@ DEPENDS += "virtual/egl"
 
 SRCREV = "8e5b96fadea9d32515ee590417925878dfa49045"
 
-SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEBackend.git;protocol=http;branch=master"
+SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEBackend.git"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-wpe/wpeframework/wpeframework-plugins_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-plugins_git.bb
@@ -5,7 +5,7 @@ PR = "r1"
 
 require wpeframework-plugins.inc
 
-SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEFrameworkPlugins.git;protocol=git;branch=master \
+SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEFrameworkPlugins.git \
            file://index.html \
            file://0003-RemoteControl-Snapshot-Fix-refsw-include-paths.patch \
            file://0001-WebKitBrowser-Guard-webautomation-APIs-for-WebKits-t.patch \

--- a/recipes-wpe/wpeframework/wpeframework-ui_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-ui_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 require wpeframework-plugins.inc
 
-SRC_URI = "git://git@github.com/WebPlatformForEmbedded/WPEFrameworkUI.git;protocol=ssh;branch=master"
+SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEFrameworkUI.git"
 SRCREV = "c0b3857405947d443313cb875160d0828ad0448c"
 
 do_configure[noexec] = "1"

--- a/recipes-wpe/wpeframework/wpeframework_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework_git.bb
@@ -12,7 +12,7 @@ DEPENDS_append_libc-musl = " libexecinfo"
 
 PV = "3.0+git${SRCPV}"
 
-SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEFramework.git;protocol=git;branch=master \
+SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEFramework.git \
            file://wpeframework-init \
            file://wpeframework.service.in \
            file://0001-Thread.cpp-Include-limits.h-for-PTHREAD_STACK_MIN-de.patch \

--- a/recipes-wpe/wpewebkit/wpewebkit_2.20.bb
+++ b/recipes-wpe/wpewebkit/wpewebkit_2.20.bb
@@ -20,7 +20,7 @@ PV = "2.20+git${SRCPV}"
 CCACHE = "${STAGING_DIR_NATIVE}${bindir}/ccache "
 
 SRCREV ?= "d3c3f5df97ff93669877db3f1c5376bfcc16f3e8"
-BASE_URI ?= "git://github.com/WebPlatformForEmbedded/WPEWebKit.git;protocol=git;branch=master"
+BASE_URI ?= "git://github.com/WebPlatformForEmbedded/WPEWebKit.git"
 SRC_URI = "${BASE_URI} \
            file://0001-Define-MESA_EGL_NO_X11_HEADERS-when-not-using-GLX.patch \
            file://0001-Fix-build-with-musl.patch \


### PR DESCRIPTION
Normalize the GitHub SRC_URI of the recipes:

    gstreamer1.0-openwebrtc wpebackend-mesa wpebackend-rdk
    wpebackend wpeframework-plugins wpeframework-ui wpeframework wpewebkit

for accessing GitHub URIs using standard git protocol. Fixes the following warning:

    WARNING: wpeframework-ui-3.0+gitrAUTOINC+c0b3857405-r0 do_fetch:
    Failed to fetch URL git://git@github.com/WebPlatformForEmbedded/WPEFrameworkUI.git;protocol=ssh;branch=master,
    attempting MIRRORS if available

because of the fetcher trying to use SSH protocol without credentials. We can't assume
everyone has SSH keys configured, so just use the standard git protocol (the default).
Also, there is no need to specify the master branch as this is also a default in the fetcher.
