### PR TITLE
tools: Fix buildbot job and workspace creation a nit

### DIFF
--- a/tools/manifests/96boards-yocto.xml
+++ b/tools/manifests/96boards-yocto.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <manifest>
-  <remote name="openembedded" fetch="git://git.openembedded.org/" />
+  <remote name="openembedded" fetch="git://github.com/openembedded" />
   <remote name="yocto" fetch="git://git.yoctoproject.org/" />
   <remote name="webplatformforembedded" fetch="git://github.com/webplatformforembedded" />
   <remote name="96boards" fetch="git://github.com/96boards" />
   <default remote="openembedded" revision="master" />
 
-  <project name="meta-openembedded" remote="openembedded" path="meta-openembedded" revision="rocko" />
-  <project name="poky" remote="yocto" path="poky" revision="rocko" />
+  <project name="meta-openembedded" remote="openembedded" path="meta-openembedded" revision="master" />
+  <project name="openembedded-core" remote="openembedded" path="openembedded-core" revision="master" />
+  <project name="bitbake" remote="openembedded" path="openembedded-core/bitbake" revision="master" />
   <project name="meta-96boards" remote="96boards" path="meta-96boards" revision="master" />
   <project name="meta-wpe" remote="webplatformforembedded" path="meta-wpe" />
 

--- a/tools/manifests/rpi-yocto.xml
+++ b/tools/manifests/rpi-yocto.xml
@@ -1,14 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <manifest>
-  <remote name="openembedded" fetch="git://git.openembedded.org/" />
+  <remote name="openembedded" fetch="git://github.com/openembedded" />
   <remote name="yocto" fetch="git://git.yoctoproject.org/" />
   <remote name="webplatformforembedded" fetch="git://github.com/webplatformforembedded" />
+  <remote name="raspberrypi" fetch="git://github.com/agherzan" />
   <default remote="openembedded" revision="master" />
 
   <project name="meta-openembedded" remote="openembedded" path="meta-openembedded" revision="master" />
-  <project name="poky" remote="yocto" path="poky" revision="master" />
-  <project name="meta-raspberrypi" remote="yocto" path="meta-raspberrypi" revision="master" />
+  <project name="openembedded-core" remote="openembedded" path="openembedded-core" revision="master" />
+  <project name="bitbake" remote="openembedded" path="openembedded-core/bitbake" revision="master" />
+  <project name="meta-raspberrypi" remote="raspberrypi" path="meta-raspberrypi" revision="master" />
   <project name="meta-wpe" remote="webplatformforembedded" path="meta-wpe" />
 
 </manifest>

--- a/tools/rpi-yocto-buildbot.sh
+++ b/tools/rpi-yocto-buildbot.sh
@@ -21,7 +21,6 @@ mkdir -p ~/rpi/downloads
 # fix permissions set by buildbot
 echo "Fixing permissions for buildbot"
 umask -S u=rwx,g=rx,o=rx
-chmod -R 755 .
 
 # bootstrap OE
 echo "Initialize OE build Environment"


### PR DESCRIPTION
- Switch to using oe-core/bitbake instead of poky
- Fetch OE from github mirrors, just better CDN for all world
- Disable serial console for rpi
- Fix typo in debug-tweaks and enable it
- Add code to run shared state pruning script after build
- Create symlink to reuse common downloads, dont have to download again and again
- Since EGLFS image is build remove wayland from DISTRO_FEATURES too
- Add and enahance debug comments

Signed-off-by: Khem Raj <raj.khem@gmail.com>