### PR TITLE
faad2 now requires commercial license to be whitelisted

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -36,6 +36,9 @@ LICENSE_FLAGS_WHITELIST += "commercial_gstreamer1.0-plugins-ugly"
 LICENSE_FLAGS_WHITELIST += "commercial_libomxil"
 LICENSE_FLAGS_WHITELIST += "commercial_gstreamer1.0-omx"
 
+# WPE needs gstreamer plugins that need faad2
+LICENSE_FLAGS_WHITELIST += "commercial_faad2"
+
 # initramfs bits for rpi builds
 #INITRAMFS_IMAGE_BUNDLE_rpi = "1"
 #INITRAMFS_IMAGE_rpi = "wpe-initramfs-image"


### PR DESCRIPTION
Fixes build error:

    ERROR: Nothing PROVIDES 'faad2' (but [...]/gstreamer1.0-plugins-bad_1.14.2.bb DEPENDS on or otherwise requires it)
    faad2 was skipped: because it has a restricted license not whitelisted in LICENSE_FLAGS_WHITELIST
