### PR TITLE
wpeframework-plugins: Fix 'devinput' in default PACKAGECONFIG

### DIFF
--- a/recipes-wpe/wpeframework/wpeframework-plugins_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-plugins_git.bb
@@ -55,7 +55,7 @@ PACKAGECONFIG ?= " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'bluetooth', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wpeframework', '${WPE_COMPOSITOR} network', '', d)} \
     ${@bb.utils.contains('MACHINE_FEATURES', 'wifi', 'network wifi', '', d)} \
-    deviceinfo dictionary locationsync monitor remote remote-uinput timesync tracing ux virtualinput webkitbrowser webserver youtube \
+    deviceinfo dictionary locationsync monitor remote remote-devinput timesync tracing ux virtualinput webkitbrowser webserver youtube \
 "
 
 PACKAGECONFIG[bluetooth]      = "-DWPEFRAMEWORK_PLUGIN_BLUETOOTH=ON -DWPEFRAMEWORK_PLUGIN_BLUETOOTH_AUTOSTART=false,-DWPEFRAMEWORK_PLUGIN_BLUETOOTH=OFF,,dbus-glib bluez5"


### PR DESCRIPTION
Commit 129c8c648219 ("wpeframework-plugins: align remote control
changes") changed the PACKAGECONFIG option name for enabling the
'devinput' remote control device from "remote-uinput" to
"remote-devinput".

However, the previous option name "remote-uinput" was left in the
default value for the plugins PACKAGECONFIG, which causes the 'devinput'
device no no longer be enabled by default. Fix this by using the new
name there as well.

Forked from the morty branch, so not tested on other branches.