### PR TITLE
wpeframework: Bump to acec632796c2

### DIFF
--- a/recipes-wpe/wpeframework/wpeframework_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework_git.bb
@@ -17,7 +17,7 @@ SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEFramework.git;protocol=git
            file://wpeframework.service.in \
            file://0001-Thread.cpp-Include-limits.h-for-PTHREAD_STACK_MIN-de.patch \
 "
-SRCREV = "e7756de2c1d49db55b87322001b21a18a54851c4"
+SRCREV = "acec632796c2c27e3f12f0e94ee6843be8d70093"
 
 inherit cmake pkgconfig systemd update-rc.d
 


### PR DESCRIPTION
Update wpeframework to 'acec632796c2c27e3f12f0e94ee6843be8d70093',
required to get a rework done in ITVControl. Otherwise causing build
failures on clients of ITVControl that already depend on the new
interface.