### PR TITLE
wpeframework-ui: Don't use ssh protocol in git SRC_URI

### DIFF
--- a/recipes-wpe/wpeframework/wpeframework-ui_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-ui_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 require wpeframework-plugins.inc
 
-SRC_URI = "git://git@github.com/WebPlatformForEmbedded/WPEFrameworkUI.git;protocol=ssh;branch=master"
+SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEFrameworkUI.git;protocol=git;branch=master"
 SRCREV = "8b17a00032760d6257b45bdecccf29285896960c"
 
 do_configure[noexec] = "1"


### PR DESCRIPTION
Avoid forcing the use of ssh protocol for git fetching the
wpeframework-ui sources, as that implies having an ssh key setup in
github, not a reality for all the builders out there.

Instead, use the git protocol, as being done for other WPE framework
related components.