### PR TITLE
gstreamer1.0-plugins-good: add autodetect switch

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good.inc
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good.inc
@@ -15,6 +15,7 @@ PACKAGECONFIG ??= " \
 
 X11DEPENDS = "virtual/libx11 libsm libxrender libxfixes libxdamage"
 
+PACKAGECONFIG[autodetect] = "--enable-autodetect,--disable-autodetect,"
 PACKAGECONFIG[cairo]      = "--enable-cairo,--disable-cairo,cairo"
 PACKAGECONFIG[dv1394]     = "--enable-dv1394,--disable-dv1394,libiec61883 libavc1394 libraw1394"
 PACKAGECONFIG[flac]       = "--enable-flac,--disable-flac,flac"


### PR DESCRIPTION
Needed for MIPS BRCM boxes to setup the video pipeline in WebKit without @modeveci 's AV sync factory patch.