### PR TITLE
wpeframework,wpeframework-plugins: Add switches to control OpenCDM an…

### DIFF
--- a/recipes-wpe/wpeframework/wpeframework-ocdm-clearkey_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-ocdm-clearkey_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 require wpeframework-plugins.inc
 
-SRC_URI = "git://git@github.com/WebPlatformForEmbedded/OCDM-Clearkey.git;protocol=ssh;branch=master"
+SRC_URI = "git://git@github.com/WebPlatformForEmbedded/OCDM-Clearkey.git;protocol=https;branch=master"
 SRCREV = "3fb37d8ee90a8af941a6ebeff6309f89ead60fd4"
 
 FILES_${PN} = "${datadir}/WPEFramework/OCDM/*.drm"

--- a/recipes-wpe/wpeframework/wpeframework-ocdm-playready-nexus-svp_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-ocdm-playready-nexus-svp_git.bb
@@ -6,7 +6,7 @@ require wpeframework-plugins.inc
 
 DEPENDS += " broadcom-refsw"
 
-SRC_URI = "git://git@github.com/WebPlatformForEmbedded/OCDM-Playready-Nexus-SVP.git;protocol=ssh;branch=master"
+SRC_URI = "git://git@github.com/WebPlatformForEmbedded/OCDM-Playready-Nexus-SVP.git;protocol=https;branch=master"
 SRCREV = "02e67eec87fa7d2e8db6e5b331fd5687de2ca32a"
 
 FILES_${PN} = "${datadir}/WPEFramework/OCDM/*.drm"

--- a/recipes-wpe/wpeframework/wpeframework-ocdm-playready-nexus_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-ocdm-playready-nexus_git.bb
@@ -6,7 +6,7 @@ require wpeframework-plugins.inc
 
 DEPENDS += " broadcom-refsw"
 
-SRC_URI = "git://git@github.com/WebPlatformForEmbedded/OCDM-Playready-Nexus.git;protocol=ssh;branch=master"
+SRC_URI = "git://git@github.com/WebPlatformForEmbedded/OCDM-Playready-Nexus.git;protocol=https;branch=master"
 SRCREV = "55dd99220c5705c6dadc212501d75e0832bb36c0"
 
 FILES_${PN} = "${datadir}/WPEFramework/OCDM/*.drm"

--- a/recipes-wpe/wpeframework/wpeframework-ocdm-playready_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-ocdm-playready_git.bb
@@ -6,7 +6,7 @@ require wpeframework-plugins.inc
 
 DEPENDS += " playready"
 
-SRC_URI = "git://git@github.com/WebPlatformForEmbedded/OCDM-Playready.git;protocol=ssh;branch=master"
+SRC_URI = "git://git@github.com/WebPlatformForEmbedded/OCDM-Playready.git;protocol=https;branch=master"
 SRCREV = "e9d38d7ffddfe00c4715b140fb82ab6435cd3046"
 
 FILES_${PN} = "${datadir}/WPEFramework/OCDM/*.drm"

--- a/recipes-wpe/wpeframework/wpeframework-ocdm-widevine_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-ocdm-widevine_git.bb
@@ -6,7 +6,7 @@ require wpeframework-plugins.inc
 
 DEPENDS += " widevine"
 
-SRC_URI = "git://git@github.com/WebPlatformForEmbedded/OCDM-Widevine.git;protocol=ssh;branch=master"
+SRC_URI = "git://git@github.com/WebPlatformForEmbedded/OCDM-Widevine.git;protocol=https;branch=master"
 
 SRCREV = "15222ce093962317a8c4798e4682d27ae01ad57a"
 

--- a/recipes-wpe/wpeframework/wpeframework-plugins_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-plugins_git.bb
@@ -5,8 +5,6 @@ PR = "r1"
 
 require wpeframework-plugins.inc
 
-# file://0001-CMAKE-WPEWebKit-2.22-packageconfig-file-is-written-a.patch
-
 SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEFrameworkPlugins.git;protocol=git;branch=master \
            file://index.html \
            file://osmc-devinput-remote.json \
@@ -68,6 +66,17 @@ PACKAGECONFIG ?= " \
     deviceinfo dictionary locationsync monitor remote remote-devinput timesync tracing ux virtualinput webkitbrowser webserver youtube \
 "
 
+# OpenCDM related switches
+PACKAGECONFIG += " \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opencdm',              'opencdmi', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'clearkey',             'opencdmi_ck', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'playready',            'opencdmi_pr', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'playready_nexus',      'opencdmi_prnx', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'playready_nexus_svp',  'opencdmi_prnx_svp', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'playready_vg',         'opencdmi_vgrdm', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'widevine',             'opencdmi_wv', '', d)} \
+"
+
 PACKAGECONFIG[bluetooth]      = "-DWPEFRAMEWORK_PLUGIN_BLUETOOTH=ON -DWPEFRAMEWORK_PLUGIN_BLUETOOTH_AUTOSTART=false,-DWPEFRAMEWORK_PLUGIN_BLUETOOTH=OFF,,dbus-glib bluez5"
 PACKAGECONFIG[compositor]     = "-DWPEFRAMEWORK_PLUGIN_COMPOSITOR=ON -DWPEFRAMEWORK_PLUGIN_COMPOSITOR_HARDWAREREADY=${WPE_COMPOSITOR_HARDWARE_READY} -DWPEFRAMEWORK_PLUGIN_COMPOSITOR_IMPLEMENTATION=${WPE_COMPOSITOR_IMPL} -DWPEFRAMEWORK_PLUGIN_COMPOSITOR_VIRTUALINPUT=ON ${WPE_COMPOSITOR_EXTRAFLAGS},-DWPEFRAMEWORK_PLUGIN_COMPOSITOR=OFF,${WPE_COMPOSITOR_DEP}"
 PACKAGECONFIG[deviceinfo]     = "-DWPEFRAMEWORK_PLUGIN_DEVICEINFO=ON,-DWPEFRAMEWORK_PLUGIN_DEVICEINFO=OFF,"
@@ -88,6 +97,7 @@ PACKAGECONFIG[opencdmi]       = "-DWPEFRAMEWORK_PLUGIN_OPENCDMI=ON \
 PACKAGECONFIG[opencdmi_ck]    = "-DPLUGIN_OPENCDMI_CLEARKEY=ON,,wpeframework-ocdm-clearkey"
 PACKAGECONFIG[opencdmi_pr]    = "-DPLUGIN_OPENCDMI_PLAYREADY=ON,,wpeframework-ocdm-playready"
 PACKAGECONFIG[opencdmi_prnx]  = "-DPLUGIN_OPENCDMI_PLAYREADY_NEXUS=ON,,wpeframework-ocdm-playready-nexus"
+PACKAGECONFIG[opencdmi_prnx_svp]  = "-DWPEFRAMEWORK_CDMI_BCM_NEXUS_SVP=ON,,wpeframework-ocdm-nexus-svp"
 PACKAGECONFIG[opencdmi_vgrdm] = "-DPLUGIN_OPENCDMI_PLAYREADY_VGDRM=ON,,"
 PACKAGECONFIG[opencdmi_wv]    = "-DPLUGIN_OPENCDMI_WIDEVINE=ON,,wpeframework-ocdm-widevine"
 PACKAGECONFIG[remote]         = "-DWPEFRAMEWORK_PLUGIN_REMOTECONTROL=ON \

--- a/recipes-wpe/wpeframework/wpeframework_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework_git.bb
@@ -25,13 +25,20 @@ inherit cmake pkgconfig systemd update-rc.d
 WPEFRAMEWORK_PERSISTENT_PATH = "/home/root"
 WPEFRAMEWORK_SYSTEM_PREFIX = "OE"
 
-PACKAGECONFIG ?= "opencdm virtualinput websource webkitbrowser"
+PACKAGECONFIG ?= " \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opencdm', 'opencdm', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'playready_nexus_svp', 'opencdmi_prnx_svp', '', d)} \
+    virtualinput websource webkitbrowser \
+    "
 
 PACKAGECONFIG[cyclicinspector]  = "-DWPEFRAMEWORK_TEST_CYCLICINSPECTOR=ON,-DWPEFRAMEWORK_TEST_CYCLICINSPECTOR=OFF,"
 PACKAGECONFIG[opencdm]          = "-DWPEFRAMEWORK_CDMI=ON,-DWPEFRAMEWORK_CDMI=OFF,"
 PACKAGECONFIG[provisionproxy]   = "-DWPEFRAMEWORK_PROVISIONPROXY=ON,-DWPEFRAMEWORK_PROVISIONPROXY=OFF,libprovision"
 PACKAGECONFIG[testloader]       = "-DWPEFRAMEWORK_TEST_LOADER=ON,-DWPEFRAMEWORK_TEST_LOADER=OFF,"
 PACKAGECONFIG[virtualinput]     = "-DWPEFRAMEWORK_VIRTUALINPUT=ON,-DWPEFRAMEWORK_VIRTUALINPUT=OFF,"
+
+# BRCM specific OCDM flag (required for ocdm.pc generation)
+PACKAGECONFIG[opencdmi_prnx_svp]  = "-DWPEFRAMEWORK_CDMI_BCM_NEXUS_SVP=ON,,"
 
 # FIXME
 # The WPEFramework also needs limited Plugin info in order to determine what to put in the "resumes" configuration
@@ -51,11 +58,12 @@ PACKAGECONFIG[webkitbrowser]   = "-DWPEFRAMEWORK_PLUGIN_WEBKITBROWSER=ON,,"
 # Only enable certain events if wpeframework is in distro features
 WPEFRAMEWORK_DIST_EVENTS ?= "${@bb.utils.contains('DISTRO_FEATURES', 'wpeframework', 'Network', '', d)}"
 
-WPEFRAMEWORK_EXTERN_EVENTS ?= "Location Time Internet \
+WPEFRAMEWORK_EXTERN_EVENTS ?= " \
     ${@bb.utils.contains('PACKAGECONFIG', 'opencdm', 'Decryption', '', d)} \
-    ${WPEFRAMEWORK_DIST_EVENTS} \
     ${@bb.utils.contains('PACKAGECONFIG', 'provisionproxy', 'Provisioning', '', d)} \
     ${@bb.utils.contains('PACKAGECONFIG', 'websource', 'WebSource', '', d)} \
+    ${WPEFRAMEWORK_DIST_EVENTS} \
+    Location Time Internet \
 "
 
 EXTRA_OECMAKE += " \


### PR DESCRIPTION
…d DRMs through DISTRO_FEATURES.

Configuring OpenCDM and related CMDI's with the right DRM modules is spread over 2 or more packages. This made it confusing for someone to setup and configure. To streamline the configuration this commit introduces the following features that can be enabled:
opencdm - Enables the main OpenCDM server
playready - Enables PlayReady CDMI modules
widevine - Enables Widevine CDMI modules

For SOC or solution specific CDMI modules, such as Nexus please use:
playread_nexus, playready_nexus_svp and playready_vg respectively

Note: This will require to have the DRM solution in another layer, meta-wpe does not provide PlayReady, Widevine, etc. As these are licensed components.

Signed-off-by: wouterlucas <wouter@wouterlucas.com>