### PR TITLE
Bump to latest and add PluginLauncher

### DIFF
--- a/recipes-wpe/wpeframework/wpeframework-ocdm-widevine_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-ocdm-widevine_git.bb
@@ -8,6 +8,6 @@ DEPENDS += " widevine"
 
 SRC_URI = "git://git@github.com/WebPlatformForEmbedded/OCDM-Widevine.git;protocol=https;branch=master"
 
-SRCREV = "15222ce093962317a8c4798e4682d27ae01ad57a"
+SRCREV = "1a4b9812df227fe9fac83b04585e33d4bb11d2d1"
 
 FILES_${PN} = "${datadir}/WPEFramework/OCDM/*.drm"

--- a/recipes-wpe/wpeframework/wpeframework-plugin-launcher_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-plugin-launcher_git.bb
@@ -1,0 +1,8 @@
+SUMMARY = "WPE Framework Launcher Plugin. Plugin to launch external linux applications and scripts"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
+
+SRC_URI = "git://git@github.com/WebPlatformForEmbedded/WPEPluginLauncher.git"
+SRCREV = "94e4d81cfdc4ac2e169ae95955e19ee8e98f2ea7"
+
+require wpeframework-plugins.inc

--- a/recipes-wpe/wpeframework/wpeframework-plugins_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-plugins_git.bb
@@ -9,10 +9,9 @@ SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEFrameworkPlugins.git;proto
            file://index.html \
            file://osmc-devinput-remote.json \
            file://0003-RemoteControl-fix-refsw-include-path.patch \
-           file://0002-Compositor-Support-for-splitted-refsw-and-nxclient-i.patch \
            "
 
-SRCREV = "8be4e6393e2a9c6650d136e9dc7f51b99482b0ed"
+SRCREV = "c19e216f6987b9d2aa988717012f82655470d098"
 
 WEBKITBROWSER_AUTOSTART ?= "true"
 WEBKITBROWSER_MEDIADISKCACHE ?= "false"

--- a/recipes-wpe/wpeframework/wpeframework.inc
+++ b/recipes-wpe/wpeframework/wpeframework.inc
@@ -12,3 +12,5 @@ S = "${WORKDIR}/git"
 inherit cmake pkgconfig
 
 TOOLCHAIN = "gcc"
+
+EXTRA_OECMAKE += "-DCMAKE_SYSROOT=${STAGING_DIR_HOST}"

--- a/recipes-wpe/wpeframework/wpeframework_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework_git.bb
@@ -17,7 +17,7 @@ SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEFramework.git \
            file://wpeframework.service.in \
            file://0001-Thread.cpp-Include-limits.h-for-PTHREAD_STACK_MIN-de.patch \
 "
-SRCREV = "cb4484d3e39d97be3088c38e3db58e195c94d47e"
+SRCREV = "06eb8d30113e2619008ff6ae74d9b5ab40867bb1"
 
 inherit cmake pkgconfig systemd update-rc.d
 


### PR DESCRIPTION
Upstream had a lot of CMAKE refactors, these bump include that with the CMAKE_SYSROOT var in wpeframework.inc. 

Also adds the new WPEFramework Plugin Launcher to launch external services.