### PR TITLE
add missing LICENSE tag

### DIFF
--- a/recipes-core/packagegroups/packagegroup-wpe-boot.bb
+++ b/recipes-core/packagegroups/packagegroup-wpe-boot.bb
@@ -3,7 +3,7 @@
 
 SUMMARY = "Minimal boot requirements for WPE"
 DESCRIPTION = "The minimal set of packages required to boot the system for WPE"
-
+LICENSE = "MIT"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 inherit packagegroup


### PR DESCRIPTION
Fixes:
ERROR: onemw/meta-wpe/recipes-core/packagegroups/packagegroup-wpe-boot.bb: This recipe does not have the LICENSE field set (packagegroup-wpe-boot)      | ETA:  00:00:21
ERROR: Failed to parse recipe: onemw/onemw/oe-builds/svp-1/onemw/meta-wpe/recipes-core/packagegroups/packagegroup-wpe-boot.bb