### PR TITLE
wpebackend-fdo: Fix packaging dev-so QA issue and fix Warrior compatibilty

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,7 +9,7 @@ BBFILE_COLLECTIONS += "wpe-layer"
 BBFILE_PATTERN_wpe-layer := "^${LAYERDIR}/"
 BBFILE_PRIORITY_wpe-layer = "20"
 
-LAYERSERIES_COMPAT_wpe-layer = "sumo thud"
+LAYERSERIES_COMPAT_wpe-layer = "sumo thud warrior"
 
 LAYERDEPENDS_wpe-layer = "core \
                           openembedded-layer \

--- a/recipes-wpe/wpebackend-fdo/wpebackend-fdo_git.bb
+++ b/recipes-wpe/wpebackend-fdo/wpebackend-fdo_git.bb
@@ -18,3 +18,5 @@ S = "${WORKDIR}/git"
 
 FILES_SOLIBSDEV = ""
 FILES_${PN} += "${libdir}/libWPEBackend-fdo-0.1.so"
+
+INSANE_SKIP_${PN} = "dev-so"


### PR DESCRIPTION
Fixes
do_package_qa: QA Issue: non -dev/-dbg/nativesdk- package contains symlink .so: wpebackend-fdo path '/work/core2-64-yoe-linux-musl/wpebackend-fdo/1.0.0+gitAUTOINC+5a4b58c7d6-r0/packages-split/wpebackend-fdo/usr/lib/libWPEBackend-fdo-0.1.so' [dev-so]

Signed-off-by: Khem Raj <raj.khem@gmail.com>