### PR TITLE
Do not remove debug information.

### DIFF
--- a/recipes-wpe/libwpe/libwpe_0.2.bb
+++ b/recipes-wpe/libwpe/libwpe_0.2.bb
@@ -14,8 +14,6 @@ SRCREV = "4be4c7df5734d125148367a90da477c8d40d9eaf"
 
 S = "${WORKDIR}/git"
 
-FULL_OPTIMIZATION_remove = "-g"
-
 inherit cmake
 
 CXXFLAGS += " \


### PR DESCRIPTION
Debug information should not be removed as it prevents from
getting meaningful callstacks.

Note: Yocto handles debug information by itself appropriately
(e.g. stripping it in a final image if instructed to do so).

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>