### PR TITLE
westeros-soc-drm: CFLAGS as per the new drm code

### DIFF
--- a/recipes-graphics/westeros/westeros-soc-drm.bb
+++ b/recipes-graphics/westeros/westeros-soc-drm.bb
@@ -13,7 +13,8 @@ DEPENDS = "wayland virtual/egl glib-2.0 libdrm"
 PROVIDES = "westeros-soc"
 RPROVIDES_${PN} = "westeros-soc"
 
-CFLAGS_append = " -I${STAGING_INCDIR}/libdrm"
+CFLAGS_append = " -I${STAGING_INCDIR}/libdrm -DWESTEROS_GL_NO_PLANES"
+CFLAGS_remove_rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '-DWESTEROS_GL_NO_PLANES', '', d)}"
 
 SECURITY_CFLAGS_remove = "-fpie"
 SECURITY_CFLAGS_remove = "-pie"


### PR DESCRIPTION
  - westeros-gl drm added v4l2 support for rpi with
a macro enabled with old code.
Ref. https://github.com/rdkcmf/westeros/commit/9f597624c850923bfa51d3a74b33f17ad79b2ecf

Signed-off-by: Moorthy Baskar <moorthy.baskaravenkatraman-sambamoorthy@linaro.org>