### PR TITLE
wpeframework-ocdm-widevine: bump to latest

### DIFF
--- a/recipes-wpe/wpeframework/wpeframework-ocdm-widevine_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-ocdm-widevine_git.bb
@@ -7,6 +7,6 @@ require include/wpeframework-plugins.inc
 DEPENDS += " widevine"
 
 SRC_URI = "git://git@github.com/WebPlatformForEmbedded/OCDM-Widevine.git;protocol=https;branch=master"
-SRCREV = "ac3a765bdf96027fcb4ff67b0ca69858eb5dd665"
+SRCREV = "18d4e0f203c727b4fc20301f3370a24d0cf8e463"
 
 FILES_${PN} = "${datadir}/WPEFramework/OCDM/*.drm"


### PR DESCRIPTION
to fix the breakage due to wpeframework CDM interface updates