### PR TITLE
Master updates

### DIFF
--- a/recipes-devtools/python-jsonref/python-jsonref.inc
+++ b/recipes-devtools/python-jsonref/python-jsonref.inc
@@ -1,0 +1,11 @@
+SUMMARY = "jsonref is a library for automatic dereferencing of JSON Reference objects for Python"
+HOMEPAGE = "https://github.com/gazpachoking/jsonref"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=a34264f25338d41744dca1abfe4eb18f"
+
+SRC_URI[md5sum] = "42b518b9ccd6852d1d709749bc96cb70"
+SRC_URI[sha256sum] = "f3c45b121cf6257eafabdc3a8008763aed1cd7da06dbabc59a9e4d2a5e4e6697"
+
+inherit pypi setuptools
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/python-jsonref/python-jsonref_0.2.bb
+++ b/recipes-devtools/python-jsonref/python-jsonref_0.2.bb
@@ -1,0 +1,1 @@
+require python-jsonref.inc

--- a/recipes-wpe/wpebackend-rdk/wpebackend-rdk_0.1.bb
+++ b/recipes-wpe/wpebackend-rdk/wpebackend-rdk_0.1.bb
@@ -18,12 +18,14 @@ RPROVIDES_${PN} += "virtual/wpebackend"
 inherit cmake pkgconfig
 
 # Default back end selections. Please override in your machine config using WPE_BACKEND=<> to meet your machine required
-WPE_BACKEND ?= "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'westeros', 'rpi', d)}"
-WPE_BACKEND_rpi ?= "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', 'wpeframework','', d)}"
+WPE_BACKEND ?= "wpeframework"
 
 WPE_BACKEND_x86 = "intelce"
 WPE_BACKEND ?= "${@bb.utils.contains('PREFERRED_PROVIDER_virtual/egl', 'broadcom-refsw', 'nexus', '', d)}"
 WPE_BACKEND ?= "rpi"
+
+# Add westeros dependency in case Wayland is part of distro (else will default to EGLFS)
+WPEFRAMEWORK_DEPS ?= "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'westeros', '', d)}"
 
 PACKAGECONFIG ?= "${WPE_BACKEND} virtualinput"
 
@@ -39,7 +41,7 @@ PACKAGECONFIG[wayland]          = "-DUSE_BACKEND_WAYLAND=ON,,wayland libxkbcommo
 PACKAGECONFIG[wayland-egl]      = "-DUSE_BACKEND_WAYLAND_EGL=ON,,wayland libxkbcommon"
 PACKAGECONFIG[westeros]         = "-DUSE_BACKEND_WESTEROS=ON,,wayland westeros libxkbcommon"
 PACKAGECONFIG[bcm-weston]       = "-DUSE_BACKEND_BCM_NEXUS_WAYLAND=ON,,wayland wayland-egl-bnxs libxkbcommon"
-PACKAGECONFIG[wpeframework]     = "-DUSE_BACKEND_WPEFRAMEWORK=ON,,wayland westeros wpeframework wpeframework-plugins libxkbcommon xkeyboard-config"
+PACKAGECONFIG[wpeframework]     = "-DUSE_BACKEND_WPEFRAMEWORK=ON -DUSE_KEY_INPUT_HANDLING_LINUX_INPUT=OFF -DUSE_INPUT_LIBINPUT=OFF,,wpeframework wpeframework-plugins libxkbcommon xkeyboard-config ${WPEFRAMEWORK_DEPS}"
 
 # MESA
 PACKAGECONFIG[westeros-mesa]    = "-DUSE_BACKEND_WESTEROS_MESA=ON,,"

--- a/recipes-wpe/wpeframework/include/compositor.inc
+++ b/recipes-wpe/wpeframework/include/compositor.inc
@@ -1,19 +1,38 @@
 # Compositor plugin provides an interface to manage windows on the embedded device. Either through Wayland, dispmanx or Nexus
 
 # Compositor settings, if Wayland is in the distro set the implementation to Wayland with Westeros dependency
-WPE_COMPOSITOR ?= "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'compositor', '', d)}"
-WPE_COMPOSITOR_IMPL ?= "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'Wayland', 'None', d)}"
-WPE_COMPOSITOR_DEP ?= "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'westeros', '', d)}"
-WPE_COMPOSITOR_EXTRAFLAGS ?= ""
-WPE_COMPOSITOR_HARDWARE_READY ?= "0"
+WPE_COMPOSITOR_IMPL 		?= "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'Wayland', 'RPI', d)}"
+WPE_COMPOSITOR_DEP 			?= "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'westeros', '', d)}"
+WPE_COMPOSITOR_EXTRAFLAGS 	?= ""
+WPE_COMPOSITOR_HW_READY 	?= "0"
+
+# Additional flags
+WPE_COMPOSITOR_AUTOSTART 	?= "true"
+WPE_COMPOSITOR_OUTOFPROCESS ?= "true"
+WPE_COMPOSITOR_RESOLUTION	?= "720p"
+WPE_COMPOSITOR_MEMORY_GFX	?= ""
+WPE_COMPOSITOR_IRMODE		?= "16"
+WPE_COMPOSITOR_SVP			?= "None"
+
+# ----------------------------------------------------------------------------
+
+WPE_COMPOSITOR_EXTRAFLAGS = ' \
+-DPLUGIN_COMPOSITOR_AUTOSTART=${WPE_COMPOSITOR_AUTOSTART} \
+-DPLUGIN_COMPOSITOR_OUTOFPROCESS=${WPE_COMPOSITOR_OUTOFPROCESS} \
+-DPLUGIN_COMPOSITOR_RESOLUTION=${WPE_COMPOSITOR_RESOLUTION} \
+-DPLUGIN_COMPOSITOR_MEMORY_GFX=${WPE_COMPOSITOR_MEMORY_GFX} \
+-DPLUGIN_COMPOSITOR_IRMODE=${WPE_COMPOSITOR_IRMODE} \
+-DPLUGIN_COMPOSITOR_VIRTUALINPUT=ON \
+-DPLUGIN_COMPOSITOR_SVP="${WPE_COMPOSITOR_SVP}" \
+'
 
 # ----------------------------------------------------------------------------
 
 PACKAGECONFIG[compositor]     = " \
     -DPLUGIN_COMPOSITOR=ON \
-    -DPLUGIN_COMPOSITOR_HARDWAREREADY=${WPE_COMPOSITOR_HARDWARE_READY} \
+    -DPLUGIN_COMPOSITOR_HARDWAREREADY=${WPE_COMPOSITOR_HW_READY} \
     -DPLUGIN_COMPOSITOR_IMPLEMENTATION=${WPE_COMPOSITOR_IMPL} \
-    -DPLUGIN_COMPOSITOR_VIRTUALINPUT=ON ${WPE_COMPOSITOR_EXTRAFLAGS} \
+    ${WPE_COMPOSITOR_EXTRAFLAGS} \
     ,-DPLUGIN_COMPOSITOR=OFF,${WPE_COMPOSITOR_DEP}"
 
 # ----------------------------------------------------------------------------

--- a/recipes-wpe/wpeframework/wpeframework-plugins_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-plugins_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "WPE Framework common plugins"
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=e338ae07876cc28375de01750cc8a162"
 PR = "r1"
 
 require include/wpeframework-plugins.inc
@@ -11,7 +11,7 @@ SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEFrameworkPlugins.git;proto
            file://osmc-devinput-remote.json \
            "
 
-SRCREV = "7ece0856af9c0055f7a8a4f36f22284e453a3cfc"
+SRCREV = "2c32139e3d659a7ac51d8896d04136a7825dc36b"
 
 # ----------------------------------------------------------------------------
 
@@ -46,7 +46,7 @@ PACKAGECONFIG ?= " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'widevine',             'opencdmi_wv', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wpeframework',         'network', '', d)} \
     ${@bb.utils.contains('MACHINE_FEATURES', 'wifi',                'network wifi', '', d)} \
-    deviceinfo dictionary locationsync monitor remote remote-devinput timesync tracing ux virtualinput webkitbrowser webserver youtube ${WPE_COMPOSITOR} \
+    compositor deviceinfo dictionary locationsync monitor remote remote-devinput timesync tracing ux virtualinput webkitbrowser webserver youtube \
 "
 
 PACKAGECONFIG[bluetooth]      = "-DPLUGIN_BLUETOOTH=ON -DPLUGIN_BLUETOOTH_AUTOSTART=false,-DPLUGIN_BLUETOOTH=OFF,,dbus-glib bluez5"

--- a/recipes-wpe/wpeframework/wpeframework/0001-Thread.cpp-Include-limits.h-for-PTHREAD_STACK_MIN-de.patch
+++ b/recipes-wpe/wpeframework/wpeframework/0001-Thread.cpp-Include-limits.h-for-PTHREAD_STACK_MIN-de.patch
@@ -1,22 +1,20 @@
-From bc3b7b1e50f4354ea17e1658760303bfdaf11ad3 Mon Sep 17 00:00:00 2001
+From e1eb0b823b3804de6c14c3bba34ed3870cf4441d Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Mon, 11 Sep 2017 08:49:49 -0700
 Subject: [PATCH] Thread.cpp: Include limits.h for PTHREAD_STACK_MIN definition
 
 Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
 ---
  Source/core/Thread.cpp | 1 +
  1 file changed, 1 insertion(+)
 
 diff --git a/Source/core/Thread.cpp b/Source/core/Thread.cpp
-index f3e1b0b..8fe5d94 100644
+index f905b36..ca92944 100644
 --- a/Source/core/Thread.cpp
 +++ b/Source/core/Thread.cpp
 @@ -1,3 +1,4 @@
 +#include <limits.h>
  #include "Thread.h"
  #include "Proxy.h"
- #include "Trace.h"
--- 
-2.14.1
-
+ #include "Serialization.h"

--- a/recipes-wpe/wpeframework/wpeframework_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework_git.bb
@@ -2,12 +2,14 @@ SUMMARY = "Web Platform for Embedded Framework"
 HOMEPAGE = "https://github.com/WebPlatformForEmbedded"
 SECTION = "wpe"
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=1fe8768cbb5fd322f7d50656133549de"
 PR = "r0"
 
 require include/wpeframework.inc
+require include/compositor.inc
 
-DEPENDS = "zlib"
+
+DEPENDS = "zlib python-jsonref-native virtual/egl ${WPE_COMPOSITOR_DEP}"
 DEPENDS_append_libc-musl = " libexecinfo"
 
 PV = "3.0+git${SRCPV}"
@@ -17,7 +19,7 @@ SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEFramework.git \
            file://wpeframework.service.in \
            file://0001-Thread.cpp-Include-limits.h-for-PTHREAD_STACK_MIN-de.patch \
            "
-SRCREV = "6f3b75efe9af35e84675a0c2cb420173abb8d584"
+SRCREV = "367ca8bb390d960a6ba980b751db6b93fbb6b245"
 
 inherit cmake pkgconfig systemd update-rc.d
 
@@ -32,8 +34,9 @@ PACKAGECONFIG ?= " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'provisionproxy', 'provisionproxy', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opencdm', 'opencdm opencdm_gst', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'playready_nexus_svp', 'opencdmi_prnx_svp', '', d)} \
-    virtualinput websource webkitbrowser \
+    compositorclient virtualinput websource webkitbrowser \
     "
+
 # Buildtype
 # Maybe we need to couple this to a Yocto feature
 PACKAGECONFIG[debug]          = "-DBUILD_TYPE=Debug,,"
@@ -42,6 +45,7 @@ PACKAGECONFIG[releasesymbols] = "-DBUILD_TYPE=ReleaseSymbols,,"
 PACKAGECONFIG[release]        = "-DBUILD_TYPE=Release,,"
 PACKAGECONFIG[production]     = "-DBUILD_TYPE=Production,,"
 
+PACKAGECONFIG[compositorclient] = "-DCOMPOSITORCLIENT=ON,-DCOMPOSITORCLIENT=OFF"
 PACKAGECONFIG[cyclicinspector]  = "-DTEST_CYCLICINSPECTOR=ON,-DTEST_CYCLICINSPECTOR=OFF,"
 PACKAGECONFIG[provisionproxy]   = "-DPROVISIONPROXY=ON,-DPROVISIONPROXY=OFF,libprovision"
 PACKAGECONFIG[testloader]       = "-DTEST_LOADER=ON,-DTEST_LOADER=OFF,"
@@ -88,6 +92,8 @@ EXTRA_OECMAKE += " \
     -DTREE_REFERENCE=${SRCREV} \
     -DPERSISTENT_PATH=${WPEFRAMEWORK_PERSISTENT_PATH} \
     -DSYSTEM_PREFIX=${WPEFRAMEWORK_SYSTEM_PREFIX} \
+    -DPLUGIN_COMPOSITOR_IMPLEMENTATION=${WPE_COMPOSITOR_IMPL} \
+    -DPYTHON_EXECUTABLE=${STAGING_BINDIR_NATIVE}/python-native/python \
 "
 
 do_install_append() {

--- a/recipes-wpe/wpewebkit/wpewebkit_2.22.bb
+++ b/recipes-wpe/wpewebkit/wpewebkit_2.22.bb
@@ -3,7 +3,7 @@ require wpewebkit.inc
 PV = "2.22+git${SRCPV}"
 PR = "r0"
 
-SRCREV ?= "d5fd6f782aeb0faf2bccd72ac0de596b4f9f4c1b"
+SRCREV ?= "179ca0f6fb6d5c04b940f81d954b2f5b377fd561"
 SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEWebKit.git;branch=wpe-2.22"
 
 DEPENDS += "libgcrypt"

--- a/recipes-wpe/wpewebkit/wpewebkit_20170728.bb
+++ b/recipes-wpe/wpewebkit/wpewebkit_20170728.bb
@@ -5,7 +5,7 @@ DEFAULT_PREFERENCE = "-1"
 PV = "20170728+git${SRCPV}"
 PR = "r2"
 
-SRCREV ?= "f6a0308bead63cca4b47d2db561200e96c691437"
+SRCREV ?= "f9402295bed27deb780d38e33c20e397eccb009a"
 SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEWebKit.git;protocol=git;branch=wpe-20170728"
 SRC_URI += "file://0001-Fix-build-with-musl.patch"
 SRC_URI += "file://0002-Define-MESA_EGL_NO_X11_HEADERS-when-not-using-GLX.patch"


### PR DESCRIPTION
- Bump webkit 2.22 and 20170728
- Fix wpeframework compositor flags and proxystub generator
- Add python-jsonref (needs to go upstream)
- Set wpeframework as default backend for wpebackend-rdk