### PR TITLE
gstreamer1.0: Refresh 0002-Small-robustness-fixes.patch

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0/0002-Small-robustness-fixes.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0/0002-Small-robustness-fixes.patch
@@ -8,11 +8,9 @@ Subject: [PATCH 2/3] Small robustness fixes
  libs/gst/base/gstadapter.c | 5 ++++-
  2 files changed, 5 insertions(+), 1 deletion(-)
 
-diff --git a/gst/gststructure.c b/gst/gststructure.c
-index 8596c2b..60339b6 100644
 --- a/gst/gststructure.c
 +++ b/gst/gststructure.c
-@@ -375,6 +375,7 @@ gst_structure_free (GstStructure * structure)
+@@ -375,6 +375,7 @@ gst_structure_free (GstStructure * struc
    guint i, len;
  
    g_return_if_fail (structure != NULL);
@@ -20,11 +18,9 @@ index 8596c2b..60339b6 100644
    g_return_if_fail (GST_STRUCTURE_REFCOUNT (structure) == NULL);
  
    len = GST_STRUCTURE_FIELDS (structure)->len;
-diff --git a/libs/gst/base/gstadapter.c b/libs/gst/base/gstadapter.c
-index e3dff28..fbdfb89 100644
 --- a/libs/gst/base/gstadapter.c
 +++ b/libs/gst/base/gstadapter.c
-@@ -225,7 +225,10 @@ gst_adapter_finalize (GObject * object)
+@@ -227,7 +227,10 @@ gst_adapter_finalize (GObject * object)
  {
    GstAdapter *adapter = GST_ADAPTER (object);
  
@@ -34,8 +30,5 @@ index e3dff28..fbdfb89 100644
 +    adapter->assembled_size = NULL;
 +  }
  
-   GST_CALL_PARENT (G_OBJECT_CLASS, finalize, (object));
- }
--- 
-1.8.3.2
-
+   gst_queue_array_free (adapter->bufqueue);
+ 


### PR DESCRIPTION
Makes devtool happy

WARNING: gstreamer1.0-1.16.0-r0 do_patch: Fuzz detected:
Applying patch 0002-Small-robustness-fixes.patch
patching file gst/gststructure.c
patching file libs/gst/base/gstadapter.c
Hunk #1 succeeded at 227 with fuzz 2 (offset 2 lines).
The context lines in the patches can be updated with devtool:

Signed-off-by: Khem Raj <raj.khem@gmail.com>