### PR TITLE
westeros-soc-drm: Add -DDRM_NO_NATIVE_FENCE for rpi/vc4 to disable

### DIFF
--- a/recipes-graphics/westeros/westeros-soc-drm.bb
+++ b/recipes-graphics/westeros/westeros-soc-drm.bb
@@ -16,7 +16,7 @@ RPROVIDES_${PN} = "westeros-soc"
 CFLAGS_append = " -I${STAGING_INCDIR}/libdrm -DWESTEROS_GL_NO_PLANES"
 CFLAGS_remove_rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '-DWESTEROS_GL_NO_PLANES', '', d)}"
 
-CFLAGS_append_rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', ' -DDRM_USE_NATIVE_FENCE', '', d)}"
+CFLAGS_append_rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', ' -DDRM_NO_NATIVE_FENCE', '', d)}"
 
 SECURITY_CFLAGS_remove = "-fpie"
 SECURITY_CFLAGS_remove = "-pie"


### PR DESCRIPTION
		  some API's of mesa which are not supposed to be available.

Signed-off-by: Khan3033 <Riyaz.l@ltts.com>