### PR TITLE
switch wpe stuffs to point HEAD revision when required

### DIFF
--- a/recipes-wpe/wpebackend-rdk/wpebackend-rdk_0.1.bb
+++ b/recipes-wpe/wpebackend-rdk/wpebackend-rdk_0.1.bb
@@ -8,7 +8,7 @@ DEPENDS += "libwpe glib-2.0"
 
 SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEBackend-rdk.git;protocol=http;branch=master \
           "
-SRCREV = "a855d3f61cd94f8b3f16e5e4de6e587363f54ca8"
+SRCREV = "${@bb.utils.contains('DISTRO_FEATURES', 'wpe_src_tip', '${AUTOREV}', 'a855d3f61cd94f8b3f16e5e4de6e587363f54ca8', d)}"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-wpe/wpeframework/include/compositor.inc
+++ b/recipes-wpe/wpeframework/include/compositor.inc
@@ -2,6 +2,7 @@
 
 # Compositor settings, if Wayland is in the distro set the implementation to Wayland with Westeros dependency
 WPE_COMPOSITOR_IMPL 		?= "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'Wayland', 'RPI', d)}"
+WPE_COMPOSITOR_SUB_IMPL         ?= "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'Westeros', '', d)}"
 WPE_COMPOSITOR_DEP 			?= "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'westeros', 'userland', d)}"
 WPE_COMPOSITOR_EXTRAFLAGS 	?= ""
 WPE_COMPOSITOR_HW_READY 	?= "0"

--- a/recipes-wpe/wpeframework/wpeframework-ocdm-clearkey_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-ocdm-clearkey_git.bb
@@ -7,6 +7,6 @@ require include/wpeframework-plugins.inc
 SRC_URI = "git://git@github.com/WebPlatformForEmbedded/OCDM-Clearkey.git;protocol=https;branch=master \
            file://0001-OpenSSL-align-implementation-with-latest-OpenSSL-1.1.patch \
            "
-SRCREV = "b02f00b12ce216bc5c26782b8174210ff3b5339d"
+SRCREV = "${@bb.utils.contains('DISTRO_FEATURES', 'wpe_src_tip', '${AUTOREV}', 'b02f00b12ce216bc5c26782b8174210ff3b5339d', d)}"
 
 FILES_${PN} = "${datadir}/WPEFramework/OCDM/*.drm"

--- a/recipes-wpe/wpeframework/wpeframework-ocdm-playready_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-ocdm-playready_git.bb
@@ -10,6 +10,6 @@ require include/wpeframework-plugins.inc
 DEPENDS += " playready"
 
 SRC_URI = "git://git@github.com/WebPlatformForEmbedded/OCDM-Playready.git;protocol=https;branch=master"
-SRCREV = "023a064e3e87de8a9934394fd835f57f37bbcb10"
+SRCREV = "${@bb.utils.contains('DISTRO_FEATURES', 'wpe_src_tip', '${AUTOREV}', '023a064e3e87de8a9934394fd835f57f37bbcb10', d)}"
 
 FILES_${PN} = "${datadir}/WPEFramework/OCDM/*.drm"

--- a/recipes-wpe/wpeframework/wpeframework-plugins_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-plugins_git.bb
@@ -14,7 +14,7 @@ SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEFrameworkPlugins.git;proto
            file://0001-wpeframework-plugins-Linking-InjectedBundle-cpp-file.patch \
            "
 
-SRCREV = "f5cc1a0218e6fe64eb6a2f99b42f5ee2dd635675"
+SRCREV = "${@bb.utils.contains('DISTRO_FEATURES', 'wpe_src_tip', '${AUTOREV}', 'f5cc1a0218e6fe64eb6a2f99b42f5ee2dd635675', d)}"
 
 # ----------------------------------------------------------------------------
 

--- a/recipes-wpe/wpeframework/wpeframework_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework_git.bb
@@ -20,7 +20,7 @@ SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEFramework.git \
            file://wpeframework.service.in \
            file://0001-Thread.cpp-Include-limits.h-for-PTHREAD_STACK_MIN-de.patch \
            "
-SRCREV = "e770ecf4ba1f7e9293c5c0eac7fe4b660025c389"
+SRCREV = "${@bb.utils.contains('DISTRO_FEATURES', 'wpe_src_tip', '${AUTOREV}', 'e770ecf4ba1f7e9293c5c0eac7fe4b660025c389', d)}"
 
 inherit cmake pkgconfig systemd update-rc.d
 
@@ -95,6 +95,7 @@ EXTRA_OECMAKE += " \
     -DPERSISTENT_PATH=${WPEFRAMEWORK_PERSISTENT_PATH} \
     -DSYSTEM_PREFIX=${WPEFRAMEWORK_SYSTEM_PREFIX} \
     -DPLUGIN_COMPOSITOR_IMPLEMENTATION=${WPE_COMPOSITOR_IMPL} \
+    -DPLUGIN_COMPOSITOR_SUB_IMPLEMENTATION=${WPE_COMPOSITOR_SUB_IMPL} \
     -DPYTHON_EXECUTABLE=${STAGING_BINDIR_NATIVE}/python-native/python \
 "
 

--- a/recipes-wpe/wpewebkit/wpewebkit_2.22.bb
+++ b/recipes-wpe/wpewebkit/wpewebkit_2.22.bb
@@ -3,7 +3,7 @@ require wpewebkit.inc
 PV = "2.22+git${SRCPV}"
 PR = "r0"
 
-SRCREV ?= "2c1e49c291a3a67c25b4a508c59a5c3e52c89421"
+SRCREV ?= "${@bb.utils.contains('DISTRO_FEATURES', 'wpe_src_tip', '${AUTOREV}', '2c1e49c291a3a67c25b4a508c59a5c3e52c89421', d)}"
 SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEWebKit.git;branch=wpe-2.22 \
            file://0001-Fix-build-with-musl.patch \
            file://0002-Define-MESA_EGL_NO_X11_HEADERS-when-not-using-GLX.patch \


### PR DESCRIPTION
   - wpeframework, plugins, webkit and OCDMi repos pointed
to HEAD revision when 'wpe_src_tip' mentioned in DISTRO_FEATURES.
This helps to validate a new change which is to be upstreamed and
to identify if any errors on top of the latest code

Signed-off-by: Moorthy Baskar <moorthy.baskaravenkatraman-sambamoorthy@linaro.org>