### PR TITLE
remove patch for version as its already part of the code for dunfell migration

### DIFF
--- a/recipes-support/libsoup/libsoup-2.4_2.58.1.bbappend
+++ b/recipes-support/libsoup/libsoup-2.4_2.58.1.bbappend
@@ -1,0 +1,1 @@
+SRC_URI_remove_dunfell = "file://0001-soup-cookie-jar-add-API-to-set-a-limit-of-cookies-in.patch"


### PR DESCRIPTION
Reason for change: remove patch for version as its already part of the code
Test Procedure: Build and verify.
Risks: Low.

Signed-off-by: rkhan467 <Riyaz.l@ltts.com>