### PR TITLE
Fix build errors when using sstate cache

### DIFF
--- a/recipes-extended/libcobalt/libcobalt_git.bb
+++ b/recipes-extended/libcobalt/libcobalt_git.bb
@@ -63,24 +63,6 @@ do_install() {
     install -d ${D}/usr/share
     cp -prf ${S}/src/out/${COBALT_PLATFORM_NAME}_${COBALT_BUILD_TYPE}/content ${D}/usr/share/
 
-    if [ -d "${WORKDIR}/sysroot-destdir/${includedir}/third_party" ]
-    then
-        rm -rf ${WORKDIR}/sysroot-destdir/${includedir}/third_party
-    fi
-    if [ -d "${STAGING_DIR_TARGET}/${includedir}/third_party" ]
-    then
-        rm -rf ${STAGING_DIR_TARGET}/${includedir}/third_party
-    fi
-
-    if [ -d "${WORKDIR}/sysroot-destdir/${includedir}/starboard" ]
-    then
-        rm -rf ${WORKDIR}/sysroot-destdir/${includedir}/starboard
-    fi
-    if [ -d "${STAGING_DIR_TARGET}/${includedir}/starboard" ]
-    then
-        rm -rf ${STAGING_DIR_TARGET}/${includedir}/starboard
-    fi
-
     install -d ${D}/${includedir}/third_party/starboard/wpe/${COBALT_PLATFORM}/${COBALT_ARCH}
     cp -prf ${S}/src/third_party/starboard/wpe/${COBALT_PLATFORM}/${COBALT_ARCH}/*.h ${D}/${includedir}/third_party/starboard/wpe/${COBALT_PLATFORM}/${COBALT_ARCH}/
     install -d ${D}/${includedir}/third_party/starboard/wpe/shared
@@ -89,6 +71,8 @@ do_install() {
     install -d ${D}/${includedir}/starboard
     cp -prf ${S}/src/starboard/*.h ${D}/${includedir}/starboard/
 }
+
+SSTATE_DUPWHITELIST = "/"
 
 COBALT_PACKAGE = " \
     ${libdir}/libcobalt.so \

--- a/recipes-extended/libcobalt/libcobalt_git.bb
+++ b/recipes-extended/libcobalt/libcobalt_git.bb
@@ -71,10 +71,23 @@ do_install() {
     then
         rm -rf ${STAGING_DIR_TARGET}/${includedir}/third_party
     fi
+
+    if [ -d "${WORKDIR}/sysroot-destdir/${includedir}/starboard" ]
+    then
+        rm -rf ${WORKDIR}/sysroot-destdir/${includedir}/starboard
+    fi
+    if [ -d "${STAGING_DIR_TARGET}/${includedir}/starboard" ]
+    then
+        rm -rf ${STAGING_DIR_TARGET}/${includedir}/starboard
+    fi
+
     install -d ${D}/${includedir}/third_party/starboard/wpe/${COBALT_PLATFORM}/${COBALT_ARCH}
     cp -prf ${S}/src/third_party/starboard/wpe/${COBALT_PLATFORM}/${COBALT_ARCH}/*.h ${D}/${includedir}/third_party/starboard/wpe/${COBALT_PLATFORM}/${COBALT_ARCH}/
     install -d ${D}/${includedir}/third_party/starboard/wpe/shared
     cp -prf ${S}/src/third_party/starboard/wpe/shared/*.h ${D}/${includedir}/third_party/starboard/wpe/shared/
+
+    install -d ${D}/${includedir}/starboard
+    cp -prf ${S}/src/starboard/*.h ${D}/${includedir}/starboard/
 }
 
 COBALT_PACKAGE = " \


### PR DESCRIPTION
This fixes the build error:
| build-raspberrypi-rdk-hybrid-thunder/tmp/work/cortexa7t2hf-neon-vfpv4-rdk-linux-gnueabi/wpeframework-plugins/3.0+gitrAUTOINC+e0b75be2b6-r1/git/Cobalt/CobaltImplementation.cpp:5:30: fatal error: starboard/export.h: No such file or directory
|  #include starboard/export.h
|                               ^
| compilation terminated.
| make[2]: *** [Cobalt/CMakeFiles/WPEFrameworkCobalt.dir/CobaltImplementation.cpp.o] Error 1

Signed-off-by: Simon Chung <simon.c.chung@accenture.com>