### PR TITLE
Userland: link libbrcmEGL with wayland libraries while wayland support enabled case

### DIFF
--- a/recipes-graphics/userland/files/0020-brcmEGL-wayland-support.patch
+++ b/recipes-graphics/userland/files/0020-brcmEGL-wayland-support.patch
@@ -1,0 +1,13 @@
+diff --git a/interface/khronos/CMakeLists.txt b/interface/khronos/CMakeLists.txt
+index 9ad615b..03a8d20 100644
+--- a/interface/khronos/CMakeLists.txt
++++ b/interface/khronos/CMakeLists.txt
+@@ -87,7 +87,7 @@ add_library(brcmGLESv2 ${SHARED} ${GLES_SOURCE})
+ add_library(brcmOpenVG ${SHARED} ${VG_SOURCE})
+ add_library(brcmWFC ${SHARED} ${WFC_SOURCE})
+ 
+-target_link_libraries(brcmEGL khrn_client vchiq_arm vcos bcm_host ${VCSM_LIBS} -lm)
++target_link_libraries(brcmEGL khrn_client vchiq_arm vcos bcm_host ${VCSM_LIBS} -lm ${WAYLAND_SERVER_LIBRARIES} ${WAYLAND_CLIENT_LIBRARIES})
+ target_link_libraries(brcmGLESv2 brcmEGL khrn_client vcos)
+ target_link_libraries(brcmWFC brcmEGL)
+ target_link_libraries(brcmOpenVG brcmEGL)

--- a/recipes-graphics/userland/userland_%.bbappend
+++ b/recipes-graphics/userland/userland_%.bbappend
@@ -1,5 +1,8 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-SRC_URI += "file://0015-EGL-glplatform.h-define-EGL_CAST.patch"
+SRC_URI += " \
+    file://0015-EGL-glplatform.h-define-EGL_CAST.patch \
+    file://0020-brcmEGL-wayland-support.patch \
+"
 
 RPROVIDES_${PN} += " libegl"


### PR DESCRIPTION
In wayland package enabled case, brcmEGL lib use wayland call so this library has to be linked with wayland libraries to avoid undefined symbol issue