### PR TITLE
Cobalt: fix to work in broadcom platform

### DIFF
--- a/recipes-extended/libcobalt/libcobalt_git.bb
+++ b/recipes-extended/libcobalt/libcobalt_git.bb
@@ -7,8 +7,7 @@ PR = "r0"
 PACKAGES = "${PN}"
 DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad ninja-native bison-native wpeframework"
 
-SRC_URI = "git://git@github.com/Metrological/Cobalt.git;protocol=https;rev=c0e5376052e4c99e9e99866198e78fcff61d42f3 \
-           git://chromium.googlesource.com/chromium/tools/depot_tools.git;protocol=https;rev=44ea3ffa40fe375a8ae2e0f89968c335d08c8a8a;destsuffix=depot_tools;name=depot_tools \
+SRC_URI = "git://git@github.com/Metrological/Cobalt.git;protocol=https;rev=a6f2a67ee2ec181a2263d1c1996dce23ac02e1c6  \
 "
 S = "${WORKDIR}/git"
 
@@ -35,7 +34,7 @@ RDEPENDS_${PN} += "gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-g
 COBALT_BUILD_TYPE = "qa"
 
 do_configure() {
-    export PATH=$PATH:${S}/../depot_tools
+    export PATH=$PATH:${S}/depot_tools
     export COBALT_EXECUTABLE_TYPE=shared_library
     export COBALT_HAS_OCDM="${@bb.utils.contains('DISTRO_FEATURES', 'opencdm', 1, 0, d)}"
 
@@ -47,7 +46,7 @@ do_configure() {
 }
 
 do_compile() {
-    export PATH=$PATH:${S}/../depot_tools
+    export PATH=$PATH:${S}/depot_tools
     ${STAGING_BINDIR_NATIVE}/ninja -C ${S}/src/out/${COBALT_PLATFORM_NAME}_${COBALT_BUILD_TYPE} cobalt_deploy
 }
 

--- a/recipes-graphics/wayland-egl-bnxs/files/wayland-egl-bnxs-nxjoin.patch
+++ b/recipes-graphics/wayland-egl-bnxs/files/wayland-egl-bnxs-nxjoin.patch
@@ -1,0 +1,77 @@
+diff --git a/wayland-egl.cpp b/wayland-egl.cpp
+index 6ceee3b..3d4c744 100644
+--- a/wayland-egl.cpp
++++ b/wayland-egl.cpp
+@@ -149,6 +149,9 @@ static void winRegistryHandleGlobalRemove(void *data,
+ bnxsPixmap *createBNXSPixmap( WayEGLDisplay *wayEGLDisplay, struct wl_client *client, struct wl_bnxs_buffer *bnxsBuffer );
+ void destroyBNXSPixmap( WayEGLDisplay *wayEGLDisplay, bnxsPixmap *bpx );
+ 
++static NEXUS_Error eglJoin();
++bool eglJoinStatus = false;
++
+ static bool checkZeroCopy()
+ {
+    bool useZeroCopy= false;
+@@ -887,6 +890,29 @@ exit:
+    return s;   
+ }
+ 
++NEXUS_Error eglJoin()
++{
++    NEXUS_Error rc = NEXUS_SUCCESS;
++    if (!eglJoinStatus)
++    {
++        NxClient_JoinSettings joinSettings;
++
++        NxClient_GetDefaultJoinSettings( &joinSettings );
++        snprintf( joinSettings.name, NXCLIENT_MAX_NAME, "wayland-egl%x", getpid());
++
++        rc= NxClient_Join( &joinSettings );
++        if ( rc )
++        {
++            printf("wayland-egl: eglJoin: error: NxClient_Join failed\n");
++        }
++        else
++        {
++            printf("wayland-egl: eglJoin: NxClient_Join ok as %s\n", joinSettings.name );
++        }
++    }
++    return rc;
++}
++
+ EGLAPI EGLDisplay EGLAPIENTRY eglGetDisplay(EGLNativeDisplayType displayId)
+ {
+    EGLDisplay eglDisplay= 0;
+@@ -895,18 +921,12 @@ EGLAPI EGLDisplay EGLAPIENTRY eglGetDisplay(EGLNativeDisplayType displayId)
+    if ( !gNxplHandle )
+    {
+       NEXUS_Error rc;
+-      NxClient_JoinSettings joinSettings;
+-
+-      NxClient_GetDefaultJoinSettings( &joinSettings );
+-      snprintf( joinSettings.name, NXCLIENT_MAX_NAME, "wayland-egl%x", getpid());
+-
+-      rc= NxClient_Join( &joinSettings );
++      rc= eglJoin();
+       if ( rc )
+       {
+          printf("wayland-egl: eglGetDisplay: error: NxClient_Join failed\n");
+          goto exit;
+       }
+-      printf("wayland-egl: eglGetDisplay: NxClient_Join ok as %s\n", joinSettings.name );
+ 
+       NXPL_RegisterNexusDisplayPlatform( &gNxplHandle, 0 );
+       if ( !gNxplHandle )
+@@ -1123,7 +1143,11 @@ struct wl_egl_window *wl_egl_window_create(struct wl_surface *surface, int width
+    NXPL_NativeWindowInfo windowInfo;
+    WEGLNativeWindowListener windowListener;
+    struct wl_display *wldisp;
+-   
++
++   if (eglJoin() != NEXUS_SUCCESS)
++   {
++       goto exit;
++   }
+    wldisp= getWLDisplayFromProxy(surface);
+    if ( wldisp )
+    {

--- a/recipes-graphics/wayland-egl-bnxs/files/wayland-egl-bnxs-nxjoin.patch
+++ b/recipes-graphics/wayland-egl-bnxs/files/wayland-egl-bnxs-nxjoin.patch
@@ -1,5 +1,5 @@
 diff --git a/wayland-egl.cpp b/wayland-egl.cpp
-index 6ceee3b..3d4c744 100644
+index 6ceee3b..25e9545 100644
 --- a/wayland-egl.cpp
 +++ b/wayland-egl.cpp
 @@ -149,6 +149,9 @@ static void winRegistryHandleGlobalRemove(void *data,
@@ -12,7 +12,7 @@ index 6ceee3b..3d4c744 100644
  static bool checkZeroCopy()
  {
     bool useZeroCopy= false;
-@@ -887,6 +890,29 @@ exit:
+@@ -887,6 +890,30 @@ exit:
     return s;   
  }
  
@@ -34,6 +34,7 @@ index 6ceee3b..3d4c744 100644
 +        else
 +        {
 +            printf("wayland-egl: eglJoin: NxClient_Join ok as %s\n", joinSettings.name );
++            NxClient_UnregisterAcknowledgeStandby(NxClient_RegisterAcknowledgeStandby());
 +        }
 +    }
 +    return rc;
@@ -42,7 +43,7 @@ index 6ceee3b..3d4c744 100644
  EGLAPI EGLDisplay EGLAPIENTRY eglGetDisplay(EGLNativeDisplayType displayId)
  {
     EGLDisplay eglDisplay= 0;
-@@ -895,18 +921,12 @@ EGLAPI EGLDisplay EGLAPIENTRY eglGetDisplay(EGLNativeDisplayType displayId)
+@@ -895,18 +922,12 @@ EGLAPI EGLDisplay EGLAPIENTRY eglGetDisplay(EGLNativeDisplayType displayId)
     if ( !gNxplHandle )
     {
        NEXUS_Error rc;
@@ -62,7 +63,7 @@ index 6ceee3b..3d4c744 100644
  
        NXPL_RegisterNexusDisplayPlatform( &gNxplHandle, 0 );
        if ( !gNxplHandle )
-@@ -1123,7 +1143,11 @@ struct wl_egl_window *wl_egl_window_create(struct wl_surface *surface, int width
+@@ -1123,7 +1144,11 @@ struct wl_egl_window *wl_egl_window_create(struct wl_surface *surface, int width
     NXPL_NativeWindowInfo windowInfo;
     WEGLNativeWindowListener windowListener;
     struct wl_display *wldisp;

--- a/recipes-graphics/wayland-egl-bnxs/wayland-egl-bnxs_git.bbappend
+++ b/recipes-graphics/wayland-egl-bnxs/wayland-egl-bnxs_git.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI += "file://wayland-egl-bnxs-nxjoin.patch"

--- a/recipes-wpe/wpeframework/include/cobalt.inc
+++ b/recipes-wpe/wpeframework/include/cobalt.inc
@@ -6,11 +6,16 @@ WPE_COBALT_STARBOARD_CONFIGURATION_INCLUDE_brcm ?= "third_party/starboard/wpe/br
 WPE_COBALT_AUTOSTART        ?= "false"
 WPE_COBALT_OUTOFPROCESS     ?= "true"
 
+WPE_COBALT_RESOLUTION       ?= ""
+WPE_COBALT_RESOLUTION_rpi   ?= "720p"
+WPE_COBALT_RESOLUTION_brcm  ?= "1080p"
+
 # ----------------------------------------------------------------------------
 WPE_COBALT_EXTRAFLAGS = ' \
     -DPLUGIN_COBALT_AUTOSTART=${WPE_COBALT_AUTOSTART} \
     -DPLUGIN_COBALT_OUTOFPROCESS=${WPE_COBALT_OUTOFPROCESS} \
     -DWPEFRAMEWORK_PLUGIN_COBALT_STARBOARD_CONFIGURATION_INCLUDE=${WPE_COBALT_STARBOARD_CONFIGURATION_INCLUDE} \
+    -DPLUGIN_COBALT_RESOLUTION=${WPE_COBALT_RESOLUTION} \
 '
 # ----------------------------------------------------------------------------
 

--- a/recipes-wpe/wpeframework/include/cobalt.inc
+++ b/recipes-wpe/wpeframework/include/cobalt.inc
@@ -7,7 +7,7 @@ WPE_COBALT_AUTOSTART        ?= "false"
 WPE_COBALT_OUTOFPROCESS     ?= "true"
 
 WPE_COBALT_RESOLUTION       ?= "720p"
-WPE_COBALT_RESOLUTION_rpi   ?= "${@base_conditional('MODE_64', 'aarch64', '1080p', '720p', d)}"
+WPE_COBALT_RESOLUTION_rpi   ?= "720p"
 WPE_COBALT_RESOLUTION_brcm  ?= "1080p"
 
 # ----------------------------------------------------------------------------

--- a/recipes-wpe/wpeframework/include/cobalt.inc
+++ b/recipes-wpe/wpeframework/include/cobalt.inc
@@ -6,8 +6,8 @@ WPE_COBALT_STARBOARD_CONFIGURATION_INCLUDE_brcm ?= "third_party/starboard/wpe/br
 WPE_COBALT_AUTOSTART        ?= "false"
 WPE_COBALT_OUTOFPROCESS     ?= "true"
 
-WPE_COBALT_RESOLUTION       ?= ""
-WPE_COBALT_RESOLUTION_rpi   ?= "720p"
+WPE_COBALT_RESOLUTION       ?= "720p"
+WPE_COBALT_RESOLUTION_rpi   ?= "${@base_conditional('MODE_64', 'aarch64', '1080p', '720p', d)}"
 WPE_COBALT_RESOLUTION_brcm  ?= "1080p"
 
 # ----------------------------------------------------------------------------

--- a/recipes-wpe/wpeframework/wpeframework-plugins/0007-Cobalt-resolution-param-configurable.patch
+++ b/recipes-wpe/wpeframework/wpeframework-plugins/0007-Cobalt-resolution-param-configurable.patch
@@ -1,0 +1,38 @@
+diff --git a/Cobalt/CMakeLists.txt b/Cobalt/CMakeLists.txt
+index ad459c2..ba2d1b2 100644
+--- a/Cobalt/CMakeLists.txt
++++ b/Cobalt/CMakeLists.txt
+@@ -61,5 +61,18 @@ install(TARGETS ${MODULE_NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/${STORAGE
+ 
+ set(PLUGIN_COBALT_AUTOSTART false CACHE STRING "Automatically start Cobalt plugin")
+ set(PLUGIN_COBALT_OUTOFPROCESS false CACHE STRING "Controls if the plugin should run in its own process")
++set(PLUGIN_COBALT_RESOLUTION "720p" CACHE STRING "Browser resolution")
++
++# resolution handling
++if(PLUGIN_COBALT_RESOLUTION EQUAL "720p")
++    set(PLUGIN_COBALT_HEIGHT "720")
++    set(PLUGIN_COBALT_WIDTH "1280")
++elseif(PLUGIN_COBALT_RESOLUTION EQUAL "1080p")
++    set(PLUGIN_COBALT_HEIGHT "1080")
++    set(PLUGIN_COBALT_WIDTH "1920")
++elseif(PLUGIN_COBALT_RESOLUTION EQUAL "2160p")
++    set(PLUGIN_COBALT_HEIGHT "2160")
++    set(PLUGIN_COBALT_WIDTH "3840")
++endif()
+ 
+ write_config(${PLUGIN_NAME})
+diff --git a/Cobalt/Cobalt.config b/Cobalt/Cobalt.config
+index 17f042f..2b47424 100644
+--- a/Cobalt/Cobalt.config
++++ b/Cobalt/Cobalt.config
+@@ -8,8 +8,8 @@ ans(rootobject)
+ 
+ map()
+     kv(url "https://www.youtube.com/tv")
+-    kv(height 720)
+-    kv(width 1280)
++    kv(height ${PLUGIN_COBALT_HEIGHT})
++    kv(width ${PLUGIN_COBALT_WIDTH})
+     if(PLUGIN_COBALT_CLIENTIDENTIFIER)
+         kv(clientidentifier ${PLUGIN_COBALT_CLIENTIDENTIFIER})
+     endif()

--- a/recipes-wpe/wpeframework/wpeframework-plugins_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-plugins_git.bb
@@ -14,6 +14,7 @@ SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEFrameworkPlugins.git;proto
            file://0004-NEXUS-SERVER-EXTERNAL-header-path-search-included.patch \
            file://0005-FileTransfer-test-plugin-selection-flag.patch \
            file://0006-Streamer-crash-fix.patch \
+           file://0007-Cobalt-resolution-param-configurable.patch \
            "
 SRCREV = "e0b75be2b60ca44f3ed2e0f13fff7ef27ab8d073"
 


### PR DESCRIPTION
Cobalt is crashing, if wl_egl_window_create is invoked first, since it is not registered with NXClient. So added changes to register with NxClient using NxClient_Join