### PR TITLE
wpeframework: hack decouple opencdm_gst

### DIFF
--- a/recipes-wpe/wpeframework/wpeframework_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework_git.bb
@@ -42,6 +42,10 @@ PACKAGECONFIG ?= " \
 # add compositor client if Wayland is present
 PACKAGECONFIG_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'compositor', 'compositorclient', '', d)}"
 
+# remove opencdm_gst
+# FIXME: rework the distro features / machine features for DRM
+PACKAGECONFIG_remove = "${@bb.utils.contains('DISTRO_FEATURES', 'playready_nexus_svp', 'opencdm_gst', '', d)}"
+
 # Buildtype
 # Maybe we need to couple this to a Yocto feature
 PACKAGECONFIG[debug]          = "-DBUILD_TYPE=Debug,,"


### PR DESCRIPTION
The distro features are a mess and should be reworked. They blend in machine features and distro features and we should re-organise them properly based on Broadcom's availability of SVP. 

This is a temp hack to decouple opencdm_gst if playready_nexus_svp is enabled.