### PR TITLE
Adds packageconfig option to enable and disable DIALServer

### DIFF
--- a/recipes-wpe/wpeframework/wpeframework-plugins_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-plugins_git.bb
@@ -103,6 +103,7 @@ WPE_WIFICONTROL_DEP          ?= ""
 WPE_WIFICONTROL_DEP_rpi      ?= "linux-firmware-bcm43430"
 PACKAGECONFIG[wifi]           = "-DPLUGIN_WIFICONTROL=ON,-DPLUGIN_WIFICONTROL=OFF,,wpa-supplicant ${WPE_WIFICONTROL_DEP}"
 PACKAGECONFIG[wifi_rdkhal]    = "-DPLUGIN_USE_RDK_HAL_WIFI=ON,-DPLUGIN_USE_RDK_HAL_WIFI=OFF,,wifi-hal"
+PACKAGECONFIG[dialserver]     = "-DPLUGIN_DIALSERVER=ON,-DPLUGIN_DIALSERVER=OFF,,"
 
 # ----------------------------------------------------------------------------
 


### PR DESCRIPTION
This commit is for adding PACKAGECONFIG option to enable and disable
DIALServer. This change has been added since, there was no PACKAGECONFIG
available for the DIALServer and this seems to be the nicer way to
enable a feature.