### PR TITLE
Removed NE10 library dependency for libopus.

### DIFF
--- a/recipes-multimedia/libopus/libopus%.bbappend
+++ b/recipes-multimedia/libopus/libopus%.bbappend
@@ -1,0 +1,2 @@
+DEPENDS_remove = "ne10"
+


### PR DESCRIPTION
It adds .bbappend file for meta-openembedded/meta-oe/recipes-multimedia/libopus recipe.
NE10 provides optimized routines for math / signal processing for ARM CPUs.
However it produces audio noise when OPUS audio codec is used with YouTube video in Cobalt browser.
NE10 library is not used in buildroot.
This change is verified for RPI and Amlogic platform.