### PR TITLE
wpeframework-plugins: cleanup webkit plugins

### DIFF
--- a/recipes-wpe/wpeframework/include/webkitbrowser.inc
+++ b/recipes-wpe/wpeframework/include/webkitbrowser.inc
@@ -1,5 +1,5 @@
 # Provides the WPE WebKitBrowser plugin settings for WPEFramwork
-# Also extends WPE instances in the form of UX and a YouTube specific instance
+# Also extends WPE instances in the form of UX and a Apps specific instance
 
 WEBKITBROWSER_AUTOSTART ?= "true"
 WEBKITBROWSER_MEDIADISKCACHE ?= "false"
@@ -18,6 +18,7 @@ WEBKITBROWSER_THREADEDPAINTING_rpi ?= "2"
 
 # ----------------------------------------------------------------------------
 
+PACKAGECONFIG[apps]           = "-DPLUGIN_WEBKITBROWSER_APPS=ON,-DPLUGIN_WEBKITBROWSER_APPS=OFF,"
 PACKAGECONFIG[ux]             = "-DPLUGIN_WEBKITBROWSER_UX=ON,-DPLUGIN_WEBKITBROWSER_UX=OFF,"
 PACKAGECONFIG[webkitbrowser]  = "-DPLUGIN_WEBKITBROWSER=ON \
    -DPLUGIN_WEBKITBROWSER_AUTOSTART="${WEBKITBROWSER_AUTOSTART}" \
@@ -32,6 +33,5 @@ PACKAGECONFIG[webkitbrowser]  = "-DPLUGIN_WEBKITBROWSER=ON \
    -DPLUGIN_WEBKITBROWSER_TRANSPARENT="${WEBKITBROWSER_TRANSPARENT}" \
    -DPLUGIN_WEBKITBROWSER_THREADEDPAINTING="${WEBKITBROWSER_THREADEDPAINTING}" \
    ,-DPLUGIN_WEBKITBROWSER=OFF,wpewebkit"
-PACKAGECONFIG[youtube]        = "-DPLUGIN_WEBKITBROWSER_YOUTUBE=ON, -DPLUGIN_WEBKITBROWSER_YOUTUBE=OFF,,"
 
 # ----------------------------------------------------------------------------

--- a/recipes-wpe/wpeframework/wpeframework-plugins_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-plugins_git.bb
@@ -50,7 +50,7 @@ PACKAGECONFIG ?= " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'thunder',              'network', '', d)} \
     ${@bb.utils.contains('MACHINE_FEATURES', 'wifi',                'network wifi', '', d)} \
     ${@bb.utils.contains('STREAMER_DISTRO_PACKAGE_AVAILABLE', 'True', 'streamer', '', d)} \
-    deviceinfo dhcpserver dictionary ioconnector locationsync monitor remote remote-devinput systemcommands timesync tracing ux virtualinput webkitbrowser webserver youtube \
+    apps deviceinfo dhcpserver dictionary ioconnector locationsync monitor remote remote-devinput systemcommands timesync tracing ux virtualinput webkitbrowser webserver \
 "
 
 PACKAGECONFIG_append_rpi = " cobalt"


### PR DESCRIPTION
Removing YouTube, as that is superceded with Cobalt
Adding Apps, as an extra app instance