### PR TITLE
layer.conf: enable compositor distro for vc4graphics

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -52,7 +52,4 @@ LICENSE_FLAGS_WHITELIST += "commercial_faad2"
 # Enable early start of Thunder
 DISTRO_FEATURES_append = " compositor thunder"
 
-# Compositor does not support vc4graphics yet
-DISTRO_FEATURES_remove = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', 'compositor', '', d)}"
-
 KERNEL_MODULE_AUTOLOAD += "${@bb.utils.contains("MACHINE_FEATURES", "bluetooth", "ecb", "", d)}"


### PR DESCRIPTION
Now westeros is working with vc4graphics wayland enable so, okay to have compositor plugin / package config

Signed-off-by: Moorthy Baskar <moorthy.bs@ltts.com>