### PR TITLE
Updated SRC_URI for Thunder, ThunderUI and ThunderNanoServices

### DIFF
--- a/recipes-wpe/wpeframework/wpeframework-plugins_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-plugins_git.bb
@@ -5,7 +5,7 @@ PR = "r1"
 
 require include/wpeframework-plugins.inc
 
-SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEFrameworkPlugins.git;protocol=git;branch=master \
+SRC_URI = "git://github.com/rdkcentral/ThunderNanoServices.git;protocol=git;branch=master \
            file://0001-WebKitBrowser-Add-Time-to-dependencies.patch \
            file://index.html \
            file://osmc-devinput-remote.json \

--- a/recipes-wpe/wpeframework/wpeframework-tools-native_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-tools-native_git.bb
@@ -1,12 +1,12 @@
 SUMMARY = "Host/Native tooling for the Web Platform for Embedded Framework"
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=79069d74da393ab7ff3d1f5990c48aad"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=f1dffbfd5c2eb52e0302eb6296cc3711"
 
 PR = "r0"
 PV = "3.0+git${SRCPV}"
 S = "${WORKDIR}/git"
 
-SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEFramework.git;protocol=git;branch=master \
+SRC_URI = "git://github.com/rdkcentral/Thunder.git;protocol=git;branch=master \
           "
 SRC_URI[md5sum] = "42b518b9ccd6852d1d709749bc96cb70"
 SRC_URI[sha256sum] = "f3c45b121cf6257eafabdc3a8008763aed1cd7da06dbabc59a9e4d2a5e4e6697"

--- a/recipes-wpe/wpeframework/wpeframework-ui_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-ui_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=c2b3f2a8aff73c673037a89bee1ee396"
 
 require include/wpeframework-plugins.inc
 
-SRC_URI = "git://github.com/WebPlatformForEmbedded/ThunderUI.git"
+SRC_URI = "git://github.com/rdkcentral/ThunderUI.git"
 SRCREV = "a6f21d4fb8f33f819075820eb40f19a368b460ee"
 
 do_configure[noexec] = "1"

--- a/recipes-wpe/wpeframework/wpeframework_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework_git.bb
@@ -2,7 +2,7 @@ SUMMARY = "Web Platform for Embedded Framework"
 HOMEPAGE = "https://github.com/WebPlatformForEmbedded"
 SECTION = "wpe"
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=79069d74da393ab7ff3d1f5990c48aad"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=f1dffbfd5c2eb52e0302eb6296cc3711"
 PR = "r0"
 
 require include/wpeframework.inc
@@ -15,7 +15,7 @@ DEPENDS += "${@bb.utils.contains('PACKAGECONFIG', 'testapp', 'gtest', '', d)}"
 
 PV = "3.0+git${SRCPV}"
 
-SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEFramework.git \
+SRC_URI = "git://github.com/rdkcentral/Thunder.git \
            file://wpeframework-init \
            file://wpeframework.service.in \
            "


### PR DESCRIPTION
Points to rdkcentral layer instead of WebPlatformForEmbedded layer for Thunder, ThunderUI and ThunderNanoservice components.

Signed-off-by: KrishnakumarPathivuraj <krishnakumar.pathivuraj@ltts.com>