### PR TITLE
#493 gstreamer-plugins-base: fix egls build

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0001-meson-add-window-system-egl.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0001-meson-add-window-system-egl.patch
@@ -1,0 +1,65 @@
+From: Zdzislaw Krajewski <zdzislaw@krw.sk>
+Date: Mon, 17 Aug 2020
+Subject: https://gitlab.freedesktop.org/gstreamer/gst-plugins-base/-/merge_requests/520
+
+Signed-off-by: Zdzislaw Krajewski <zdzislaw@krw.sk>
+--- a/gst-libs/gst/gl/meson.build
++++ b/gst-libs/gst/gl/meson.build
+@@ -231,6 +231,7 @@ if gl_winsys.contains('auto')
+   need_win_wayland = 'auto'
+   need_win_win32 = 'auto'
+   need_win_cocoa = 'auto'
++  need_win_egl = 'auto'
+   need_win_eagl = 'auto'
+   need_win_dispmanx = 'auto'
+   need_win_viv_fb = 'auto'
+@@ -241,6 +242,7 @@ else
+   need_win_wayland = 'no'
+   need_win_win32 = 'no'
+   need_win_cocoa = 'no'
++  need_win_egl = 'no'
+   need_win_eagl = 'no'
+   need_win_dispmanx = 'no'
+   need_win_viv_fb = 'no'
+@@ -255,6 +257,8 @@ else
+       need_win_win32 = 'yes'
+     elif winsys == 'cocoa'
+       need_win_cocoa = 'yes'
++    elif winsys == 'egl'
++      need_win_egl = 'yes'
+     elif winsys == 'eagl'
+       need_win_eagl = 'yes'
+     elif winsys == 'dispmanx'
+@@ -511,6 +515,17 @@ if need_platform_egl != 'no'
+   endif
+ endif
+ 
++# winsys_egl checks
++if need_win_egl == 'yes'
++  if need_platform_egl == 'no'
++    error('Impossible situation requested: Cannot use Winsys egl without EGL support')
++  elif not egl_dep.found()
++    error ('Could not find EGL libraries for Winsys egl')
++  else
++    enabled_gl_winsys += 'egl'
++  endif
++endif
++
+ # wayland checks
+ wayland_client_dep = unneeded_dep
+ wayland_cursor_dep = unneeded_dep
+diff --git a/meson_options.txt b/meson_options.txt
+index 298340950..476b53063 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -12,8 +12,8 @@ option('gl_platform', type : 'array',
+        choices : ['glx', 'egl', 'cgl', 'wgl', 'eagl', 'auto'], value : ['auto'],
+        description : 'A comma separated list of opengl platforms to enable building against')
+ option('gl_winsys', type : 'array',
+-       choices : ['x11', 'wayland', 'win32', 'cocoa', 'dispmanx', 'viv-fb', 'gbm', 'android', 'auto'], value : ['auto'],
+-       description : 'A comma separated list of opengl windows systems to enable building against. Supported values are x11, wayland, win32, cocoa, dispmanx, viv-fb, gbm and android')
++       choices : ['x11', 'wayland', 'win32', 'cocoa', 'dispmanx', 'egl', 'viv-fb', 'gbm', 'android', 'auto'], value : ['auto'],
++       description : 'A comma separated list of opengl windows systems to enable building against. Supported values are x11, wayland, win32, cocoa, dispmanx, egl, viv-fb, gbm and android')
+ option('egl_module_name', type : 'string', value : '',
+        description : 'The file to pass to g_module_open to open the libEGL library (default: libEGL)')
+ option('opengl_module_name', type : 'string', value : '',

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.16.%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.16.%.bbappend
@@ -1,0 +1,7 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+
+SRC_URI += " \
+    file://0001-meson-add-window-system-egl.patch \
+"
+
+OPENGL_WINSYS_append = "${@bb.utils.contains('PACKAGECONFIG', 'egl', ' egl', '', d)}"


### PR DESCRIPTION
Patch formatted from [original commit](https://gitlab.freedesktop.org/gstreamer/gst-plugins-base/-/merge_requests/520/diffs?commit_id=7b00e5de9998aa5b997a288d2d298f852427fe6a) didn't apply automatically, so that I created it manually.  

With those changes `gstreamer1.0-plugins-base` builds properly.  
Tested on `poky` and `yoe`.