### PR TITLE
Thunder: fix debug version build issue in RPI

### DIFF
--- a/recipes-wpe/wpeframework/wpeframework_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework_git.bb
@@ -121,6 +121,10 @@ EXTRA_OECMAKE += " \
     -DEXCEPTIONS_ENABLE=${WPEFRAMEWORK_EXCEPTIONS_ENABLE} \
 "
 
+SELECTED_OPTIMIZATION_append = "\
+    ${@bb.utils.contains('PACKAGECONFIG', 'debugoptimized', " -O0 " , '', d)} \
+"
+
 do_install_append() {
     if ${@bb.utils.contains("DISTRO_FEATURES", "systemd", "true", "false", d)}
     then


### PR DESCRIPTION
RPI build always used -Os optimisation level, this causing issue for Thunder debug build. So disabling optimisation level with 0 for debug build