### PR TITLE
Set Arp ignore rules to avoid arp replay for all other interfaces

### DIFF
--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -1,9 +1,9 @@
 # Network and Timesync are handled through Thunder/WPEFramework
 PACKAGECONFIG_remove = "${@bb.utils.contains('DISTRO_FEATURES', 'thunder', 'networkd timedated timesyncd resolved', '', d)}"
 
-do_install_append() {
+do_setup_arp_configs() {
     if [ "${@bb.utils.contains('DISTRO_FEATURES', 'thunder', 'true', '', d)}" ]; then
-        cat >> ${S}/sysctl.d/50-default.conf <<EOF
+        cat >> ${D}${libdir}/sysctl.d/50-default.conf <<EOF
 
 # arp settings
 net.ipv4.conf.default.arp_ignore = 1
@@ -12,3 +12,5 @@ net.ipv4.conf.all.arp_ignore = 1
 EOF
     fi
 }
+
+addtask do_setup_arp_configs after do_install before do_package

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -1,2 +1,14 @@
 # Network and Timesync are handled through Thunder/WPEFramework
 PACKAGECONFIG_remove = "${@bb.utils.contains('DISTRO_FEATURES', 'thunder', 'networkd timedated timesyncd resolved', '', d)}"
+
+do_install_append() {
+    if [ "${@bb.utils.contains('DISTRO_FEATURES', 'thunder', 'true', '', d)}" ]; then
+        cat >> ${S}/sysctl.d/50-default.conf <<EOF
+
+# arp settings
+net.ipv4.conf.default.arp_ignore = 1
+net.ipv4.conf.all.arp_ignore = 1
+
+EOF
+    fi
+}


### PR DESCRIPTION
https://jira.rdkcentral.com/jira/browse/HP40A-326: Based on this issue, found that in some router case, it is sending ARP request to device for the validation of IPs. So in that case os stack is responding on this with details. But if both eth0 and wlan0 are up, then it will share the same details with both interface with its own MAC address. This making conflict with router, and it will issue new IP. So adding using arp_ignore = 1 to avoid this situation and respond only for its own request.