### PR TITLE
Changes to compile for morty branches

### DIFF
--- a/classes/bluetooth.bbclass
+++ b/classes/bluetooth.bbclass
@@ -1,0 +1,14 @@
+# Avoid code duplication in bluetooth-dependent recipes.
+
+# Define a variable that expands to the recipe (package) providing core
+# bluetooth support on the platform:
+# "" if bluetooth is not in DISTRO_FEATURES
+# else "bluez5" if bluez5 is in DISTRO_FEATURES
+# else "bluez4"
+
+# Use this with:
+#  inherit bluetooth
+#  PACKAGECONFIG ??= "${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', '${BLUEZ}', '', d)}
+#  PACKAGECONFIG[bluez4] = "--enable-bluez4,--disable-bluez4,bluez4"
+
+BLUEZ ?= "${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', bb.utils.contains('DISTRO_FEATURES', 'bluez5', 'bluez5', 'bluez4', d), '', d)}"

--- a/classes/features_check.bbclass
+++ b/classes/features_check.bbclass
@@ -1,0 +1,37 @@
+# Allow checking of required and conflicting DISTRO_FEATURES
+#
+# ANY_OF_DISTRO_FEATURES:   ensure at least one item on this list is included
+#                           in DISTRO_FEATURES.
+# REQUIRED_DISTRO_FEATURES: ensure every item on this list is included
+#                           in DISTRO_FEATURES.
+# CONFLICT_DISTRO_FEATURES: ensure no item in this list is included in
+#                           DISTRO_FEATURES.
+#
+# Copyright 2013 (C) O.S. Systems Software LTDA.
+
+python () {
+    # Assume at least one var is set.
+    distro_features = (d.getVar('DISTRO_FEATURES', True) or "").split()
+
+    any_of_distro_features = d.getVar('ANY_OF_DISTRO_FEATURES', True)
+    if any_of_distro_features:
+        any_of_distro_features = any_of_distro_features.split()
+        if set.isdisjoint(set(any_of_distro_features),set(distro_features)):
+            raise bb.parse.SkipPackage("one of '%s' needs to be in DISTRO_FEATURES" % any_of_distro_features)
+
+    required_distro_features = d.getVar('REQUIRED_DISTRO_FEATURES', True)
+    if required_distro_features:
+        required_distro_features = required_distro_features.split()
+        for f in required_distro_features:
+            if f in distro_features:
+                continue
+            else:
+                raise bb.parse.SkipPackage("missing required distro feature '%s' (not in DISTRO_FEATURES)" % f)
+
+    conflict_distro_features = d.getVar('CONFLICT_DISTRO_FEATURES', True)
+    if conflict_distro_features:
+        conflict_distro_features = conflict_distro_features.split()
+        for f in conflict_distro_features:
+            if f in distro_features:
+                raise bb.parse.SkipPackage("conflicting distro feature '%s' (in DISTRO_FEATURES)" % f)
+}

--- a/conf/distro/include/thunder_generic.conf
+++ b/conf/distro/include/thunder_generic.conf
@@ -4,3 +4,15 @@ DISTRO_FEATURES_append = " compositor"
 DISTRO_FEATURES_append = " thunder"
 WPE_THUNDER_BUILDTYPE = "thunder_release"
 DISTRO_FEATURES_append = " ${WPE_THUNDER_BUILDTYPE}"
+DISTROOVERRIDES .= ":${DISTRO_CODENAME}"
+
+PREFERRED_VERSION_wpewebkit = "2.22%"
+PREFERRED_VERSION_libwpe = "1.0.0%"
+PREFERRED_VERSION_wpebackend-rdk = "git%"
+PREFERRED_VERSION_icu = "65.%"
+PREFERRED_PROVIDER_virtual/wpebackend = "wpebackend-rdk"
+
+# Select packages based on distro name selection
+require thunder_generic_dunfell.conf
+require thunder_generic_morty.conf
+

--- a/conf/distro/include/thunder_generic_dunfell.conf
+++ b/conf/distro/include/thunder_generic_dunfell.conf
@@ -1,0 +1,15 @@
+PREFERRED_VERSION_cmake_dunfell = "3.16.%"
+PREFERRED_VERSION_cmake-native_dunfell = "3.16.%"
+PREFERRED_VERSION_gstreamer1.0_dunfell = "1.16.%"
+PREFERRED_VERSION_gstreamer1.0-libav_dunfell = "1.16.%"
+PREFERRED_VERSION_gstreamer1.0-plugins-bad_dunfell = "1.16.%"
+PREFERRED_VERSION_gstreamer1.0-plugins-base_dunfell = "1.16.%"
+PREFERRED_VERSION_gstreamer1.0-plugins-good_dunfell = "1.16.%"
+PREFERRED_VERSION_gstreamer1.0-plugins-ugly_dunfell = "1.16.%"
+PREFERRED_VERSION_libepoxy_dunfell = "1.5.4"
+PREFERRED_VERSION_libsoup_dunfell = "2.4_2.68.4"
+
+BBMASK_append_dunfell = " meta-wpe/recipes-core/glibc/glibc-locale_2.24.bbappend"
+BBMASK_append_dunfell = " meta-wpe/recipes-support/libsoup/libsoup-2.4_2.58.1.bbappend"
+BBMASK_append_dunfell = " meta-wpe-restricted/recipes-connectivity/openssl/openssl10_1.0.%.bbappend"
+

--- a/conf/distro/include/thunder_generic_morty.conf
+++ b/conf/distro/include/thunder_generic_morty.conf
@@ -1,0 +1,18 @@
+PREFERRED_VERSION_cmake_morty = "3.7.%"
+PREFERRED_VERSION_cmake-native_morty = "3.7.%"
+PREFERRED_VERSION_gstreamer1.0_morty = "1.10.4"
+PREFERRED_VERSION_gstreamer1.0-libav_morty = "1.10.4"
+PREFERRED_VERSION_gstreamer1.0-plugins-bad_morty = "1.10.4"
+PREFERRED_VERSION_gstreamer1.0-plugins-base_morty = "1.10.4"
+PREFERRED_VERSION_gstreamer1.0-plugins-good_morty = "1.10.4"
+PREFERRED_VERSION_gstreamer1.0-plugins-ugly_morty = "1.10.4"
+
+DISTRO_FEATURES_append_morty = " ${DISTRO_FEATURES_LIBC}"
+
+BBMASK_append_morty = " meta-wpe-restricted/recipes-connectivity/openssl/openssl10_1.0.%.bbappend"
+BBMASK_append_morty = " meta-wpe/recipes-graphics/mesa"
+BBMASK_append_morty = " meta-wpe/recipes-graphics/cairo/cairo_1.16.0.bbappend"
+BBMASK_append_morty = " meta-wpe/recipes-graphics/drm"
+BBMASK_append_morty = " meta-wpe/recipes-support/libsoup/libsoup-2.4_2.58.1.bbappend"
+BBMASK_append_morty = " meta-wpe/recipes-multimedia/gstreamer/gstreamer1.0_1.16.%.bbappend|meta-wpe/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.16.%.bbappend meta-wpe/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.16%.bbappend meta-wpe/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.16.%.bbappend meta-wpe/recipes-multimedia/gstreamer/gstreamer1.0_1.16.%.bbappend meta-wpe/recipes-multimedia/gstreamer/gstreamer1.0-omx_1.16.%.bbappend"
+

--- a/dynamic-layers/brcm/recipes-bsp/broadcom-refsw/broadcom-refsw_%.bbappend
+++ b/dynamic-layers/brcm/recipes-bsp/broadcom-refsw/broadcom-refsw_%.bbappend
@@ -3,7 +3,7 @@
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-SRC_URI_append = "\
+SRC_URI_append = " \
     file://egl.pc \
     file://glesv2.pc \
 "

--- a/dynamic-layers/brcm/recipes-bsp/broadcom-refsw/broadcom-refsw_%.bbappend
+++ b/dynamic-layers/brcm/recipes-bsp/broadcom-refsw/broadcom-refsw_%.bbappend
@@ -3,7 +3,7 @@
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-SRC_URI += " \
+SRC_URI_append = "\
     file://egl.pc \
     file://glesv2.pc \
 "

--- a/recipes-connectivity/bluez5/bluez5_%.bbappend
+++ b/recipes-connectivity/bluez5/bluez5_%.bbappend
@@ -1,4 +1,4 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
-SRC_URI += "file://0001-Install-also-lib-mgmt.h.patch"
+SRC_URI_append = " file://0001-Install-also-lib-mgmt.h.patch"
 

--- a/recipes-core/glibc/glibc-locale_2.24.bbappend
+++ b/recipes-core/glibc/glibc-locale_2.24.bbappend
@@ -1,0 +1,9 @@
+FILES_kernel-base += "/usr/share/i18n/charmaps/*"
+FILES_kernel-base += "/usr/share/i18n/locales/*"
+FILES_kernel-base += "/usr/lib/gconv/*"
+FILES_kernel-base += "/usr/share/i18n*"
+
+FILES_${PN} += "/usr/share/i18n/charmaps/*"
+FILES_${PN} += "/usr/share/i18n/locales/*"
+FILES_${PN} += "/usr/lib/gconv/*"
+FILES_${PN} += "/usr/share/i18n*"

--- a/recipes-devtools/cmake/cmake-native_3.7.2.bb
+++ b/recipes-devtools/cmake/cmake-native_3.7.2.bb
@@ -1,0 +1,37 @@
+require cmake.inc
+inherit native
+
+DEPENDS += "bzip2-replacement-native expat-native xz-native zlib-native curl-native"
+
+SRC_URI += "\
+    file://cmlibarchive-disable-ext2fs.patch \
+"
+
+B = "${WORKDIR}/build"
+do_configure[cleandirs] = "${B}"
+
+# Disable ccmake since we don't depend on ncurses
+CMAKE_EXTRACONF = "\
+    -DCMAKE_LIBRARY_PATH=${STAGING_LIBDIR_NATIVE} \
+    -DBUILD_CursesDialog=0 \
+    -DCMAKE_USE_SYSTEM_LIBRARIES=1 \
+    -DCMAKE_USE_SYSTEM_LIBRARY_JSONCPP=0 \
+    -DCMAKE_USE_SYSTEM_LIBRARY_LIBARCHIVE=0 \
+    -DCMAKE_USE_SYSTEM_LIBRARY_LIBUV=0 \
+    -DENABLE_ACL=0 -DHAVE_ACL_LIBACL_H=0 \
+    -DHAVE_SYS_ACL_H=0 \
+"
+
+do_configure () {
+	${S}/configure --verbose --prefix=${prefix} -- ${CMAKE_EXTRACONF}
+}
+
+do_compile() {
+	oe_runmake
+}
+
+do_install() {
+	oe_runmake 'DESTDIR=${D}' install
+}
+
+do_compile[progress] = "percent"

--- a/recipes-devtools/cmake/cmake-native_3.7.2.bb
+++ b/recipes-devtools/cmake/cmake-native_3.7.2.bb
@@ -1,9 +1,9 @@
 require cmake.inc
 inherit native
 
-DEPENDS += "bzip2-replacement-native expat-native xz-native zlib-native curl-native"
+DEPENDS_append = " bzip2-replacement-native expat-native xz-native zlib-native curl-native"
 
-SRC_URI += "\
+SRC_URI_append = "\
     file://cmlibarchive-disable-ext2fs.patch \
 "
 

--- a/recipes-devtools/cmake/cmake-native_3.7.2.bb
+++ b/recipes-devtools/cmake/cmake-native_3.7.2.bb
@@ -3,17 +3,16 @@ inherit native
 
 DEPENDS_append = " bzip2-replacement-native expat-native xz-native zlib-native curl-native"
 
-SRC_URI_append = "\
+SRC_URI_append = " \
     file://cmlibarchive-disable-ext2fs.patch \
 "
 
 B = "${WORKDIR}/build"
 do_configure[cleandirs] = "${B}"
+PACKAGECONFIG[ncurser] = "-DBUILD_CursesDialog=1,-DBUILD_CursesDialog=0,ncurses-native"
 
-# Disable ccmake since we don't depend on ncurses
 CMAKE_EXTRACONF = "\
     -DCMAKE_LIBRARY_PATH=${STAGING_LIBDIR_NATIVE} \
-    -DBUILD_CursesDialog=0 \
     -DCMAKE_USE_SYSTEM_LIBRARIES=1 \
     -DCMAKE_USE_SYSTEM_LIBRARY_JSONCPP=0 \
     -DCMAKE_USE_SYSTEM_LIBRARY_LIBARCHIVE=0 \

--- a/recipes-devtools/cmake/cmake-native_3.7.2.bb
+++ b/recipes-devtools/cmake/cmake-native_3.7.2.bb
@@ -35,3 +35,5 @@ do_install() {
 }
 
 do_compile[progress] = "percent"
+DEFAULT_PREFERENCE = "-1"
+

--- a/recipes-devtools/cmake/cmake-native_3.7.2.bb
+++ b/recipes-devtools/cmake/cmake-native_3.7.2.bb
@@ -22,15 +22,15 @@ CMAKE_EXTRACONF = "\
 "
 
 do_configure () {
-	${S}/configure --verbose --prefix=${prefix} -- ${CMAKE_EXTRACONF}
+    ${S}/configure --verbose --prefix=${prefix} -- ${CMAKE_EXTRACONF}
 }
 
 do_compile() {
-	oe_runmake
+    oe_runmake
 }
 
 do_install() {
-	oe_runmake 'DESTDIR=${D}' install
+    oe_runmake 'DESTDIR=${D}' install
 }
 
 do_compile[progress] = "percent"

--- a/recipes-devtools/cmake/cmake.inc
+++ b/recipes-devtools/cmake/cmake.inc
@@ -3,9 +3,9 @@
 
 SUMMARY = "Cross-platform, open-source make system"
 DESCRIPTION = "CMake is used to control the software compilation process \
-using simple platform and compiler independent configuration files. CMake \
-generates native makefiles and workspaces that can be used in the compiler \
-environment of your choice."
+    using simple platform and compiler independent configuration files. CMake \
+    generates native makefiles and workspaces that can be used in the compiler \
+    environment of your choice."
 HOMEPAGE = "http://www.cmake.org/"
 BUGTRACKER = "http://public.kitware.com/Bug/my_view_page.php"
 SECTION = "console/utils"

--- a/recipes-devtools/cmake/cmake.inc
+++ b/recipes-devtools/cmake/cmake.inc
@@ -2,21 +2,28 @@
 # Released under the MIT license (see packages/COPYING)
 
 SUMMARY = "Cross-platform, open-source make system"
+DESCRIPTION = "CMake is used to control the software compilation process \
+using simple platform and compiler independent configuration files. CMake \
+generates native makefiles and workspaces that can be used in the compiler \
+environment of your choice."
 HOMEPAGE = "http://www.cmake.org/"
 BUGTRACKER = "http://public.kitware.com/Bug/my_view_page.php"
 SECTION = "console/utils"
 LICENSE = "BSD"
-LIC_FILES_CHKSUM = "file://Copyright.txt;md5=7a64bc564202bf7401d9a8ef33c9564d \
-                    file://Source/cmake.h;beginline=1;endline=3;md5=4494dee184212fc89c469c3acd555a14"
+LIC_FILES_CHKSUM = "\
+    file://Copyright.txt;md5=7a64bc564202bf7401d9a8ef33c9564d \
+    file://Source/cmake.h;beginline=1;endline=3;md5=4494dee184212fc89c469c3acd555a14 \
+"
 
 CMAKE_MAJOR_VERSION = "${@'.'.join(d.getVar('PV', True).split('.')[0:2])}"
 
-SRC_URI = "https://cmake.org/files/v${CMAKE_MAJOR_VERSION}/cmake-${PV}.tar.gz \
-           file://support-oe-qt4-tools-names.patch \
-           file://qt4-fail-silent.patch \
-           file://avoid-gcc-warnings-with-Wstrict-prototypes.patch \
-           file://0001-KWIML-tests-Remove-format-security-from-flags.patch \
-           "
+SRC_URI = "\
+    https://cmake.org/files/v${CMAKE_MAJOR_VERSION}/cmake-${PV}.tar.gz \
+    file://support-oe-qt4-tools-names.patch \
+    file://qt4-fail-silent.patch \
+    file://avoid-gcc-warnings-with-Wstrict-prototypes.patch \
+    file://0001-KWIML-tests-Remove-format-security-from-flags.patch \
+"
 
 SRC_URI[md5sum] = "79bd7e65cd81ea3aa2619484ad6ff25a"
 SRC_URI[sha256sum] = "dc1246c4e6d168ea4d6e042cfba577c1acd65feea27e56f5ff37df920c30cae0"
@@ -37,11 +44,11 @@ UPSTREAM_CHECK_REGEX = "cmake-(?P<pver>\d+(\.\d+)+)\.tar"
 #|   but this file does not exist.  Possible reasons include:
 
 do_configure_prepend() {
-	sed -i 's/^find_package(Qt5Core QUIET)$/#find_package(Qt5Core QUIET)/g' ${S}/Tests/RunCMake/CMakeLists.txt
-	sed -i 's/^  find_package(Qt5Core REQUIRED)/#  find_package(Qt5Core REQUIRED)/g' ${S}/Tests/Qt4And5Automoc/CMakeLists.txt
-	sed -i 's/^  find_package(Qt5Widgets QUIET NO_MODULE)/#  find_package(Qt5Widgets QUIET NO_MODULE)/g' ${S}/Tests/CMakeLists.txt
-	sed -i 's/^find_package(Qt5Widgets QUIET)/#find_package(Qt5Widgets QUIET)/g' ${S}/Source/QtDialog/CMakeLists.txt
-	sed -i 's/^  find_package(Qt5Widgets REQUIRED)/#  find_package(Qt5Widgets REQUIRED)/g' ${S}/Tests/QtAutoUicInterface/CMakeLists.txt
-	sed -i 's/^  find_package(Qt5Widgets REQUIRED)/#  find_package(Qt5Widgets REQUIRED)/g' ${S}/Tests/QtAutogen/CMakeLists.txt
-	sed -i 's/^  find_package(Qt5Core REQUIRED)/#  find_package(Qt5Core REQUIRED)/g' ${S}/Tests/QtAutogen/autorcc_depends/CMakeLists.txt
+    sed -i 's/^find_package(Qt5Core QUIET)$/#find_package(Qt5Core QUIET)/g' ${S}/Tests/RunCMake/CMakeLists.txt
+    sed -i 's/^  find_package(Qt5Core REQUIRED)/#  find_package(Qt5Core REQUIRED)/g' ${S}/Tests/Qt4And5Automoc/CMakeLists.txt
+    sed -i 's/^  find_package(Qt5Widgets QUIET NO_MODULE)/#  find_package(Qt5Widgets QUIET NO_MODULE)/g' ${S}/Tests/CMakeLists.txt
+    sed -i 's/^find_package(Qt5Widgets QUIET)/#find_package(Qt5Widgets QUIET)/g' ${S}/Source/QtDialog/CMakeLists.txt
+    sed -i 's/^  find_package(Qt5Widgets REQUIRED)/#  find_package(Qt5Widgets REQUIRED)/g' ${S}/Tests/QtAutoUicInterface/CMakeLists.txt
+    sed -i 's/^  find_package(Qt5Widgets REQUIRED)/#  find_package(Qt5Widgets REQUIRED)/g' ${S}/Tests/QtAutogen/CMakeLists.txt
+    sed -i 's/^  find_package(Qt5Core REQUIRED)/#  find_package(Qt5Core REQUIRED)/g' ${S}/Tests/QtAutogen/autorcc_depends/CMakeLists.txt
 }

--- a/recipes-devtools/cmake/cmake.inc
+++ b/recipes-devtools/cmake/cmake.inc
@@ -1,0 +1,47 @@
+# Copyright (C) 2005, Koninklijke Philips Electronics NV.  All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+SUMMARY = "Cross-platform, open-source make system"
+HOMEPAGE = "http://www.cmake.org/"
+BUGTRACKER = "http://public.kitware.com/Bug/my_view_page.php"
+SECTION = "console/utils"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://Copyright.txt;md5=7a64bc564202bf7401d9a8ef33c9564d \
+                    file://Source/cmake.h;beginline=1;endline=3;md5=4494dee184212fc89c469c3acd555a14"
+
+CMAKE_MAJOR_VERSION = "${@'.'.join(d.getVar('PV', True).split('.')[0:2])}"
+
+SRC_URI = "https://cmake.org/files/v${CMAKE_MAJOR_VERSION}/cmake-${PV}.tar.gz \
+           file://support-oe-qt4-tools-names.patch \
+           file://qt4-fail-silent.patch \
+           file://avoid-gcc-warnings-with-Wstrict-prototypes.patch \
+           file://0001-KWIML-tests-Remove-format-security-from-flags.patch \
+           "
+
+SRC_URI[md5sum] = "79bd7e65cd81ea3aa2619484ad6ff25a"
+SRC_URI[sha256sum] = "dc1246c4e6d168ea4d6e042cfba577c1acd65feea27e56f5ff37df920c30cae0"
+
+UPSTREAM_CHECK_REGEX = "cmake-(?P<pver>\d+(\.\d+)+)\.tar"
+
+# Ugly hack to work around undefined OE_QMAKE_PATH_EXTERNAL_HOST_BINS variable
+# and possibly missing qmake binary (qtbase-native can be removed from sysroot
+# e.g. in order to upgrade it, even when there is target qtbase)
+
+# Fixes errors like this in cmake(-native).do_configure:
+#| -- Performing Test run_pic_test - Success
+#| CMake Error at tmp-eglibc/sysroots/qemuarm/usr/lib/cmake/Qt5Core/Qt5CoreConfig.cmake:27 (message):
+#|   The imported target "Qt5::Core" references the file
+#|
+#|      "/qmake"
+#|
+#|   but this file does not exist.  Possible reasons include:
+
+do_configure_prepend() {
+	sed -i 's/^find_package(Qt5Core QUIET)$/#find_package(Qt5Core QUIET)/g' ${S}/Tests/RunCMake/CMakeLists.txt
+	sed -i 's/^  find_package(Qt5Core REQUIRED)/#  find_package(Qt5Core REQUIRED)/g' ${S}/Tests/Qt4And5Automoc/CMakeLists.txt
+	sed -i 's/^  find_package(Qt5Widgets QUIET NO_MODULE)/#  find_package(Qt5Widgets QUIET NO_MODULE)/g' ${S}/Tests/CMakeLists.txt
+	sed -i 's/^find_package(Qt5Widgets QUIET)/#find_package(Qt5Widgets QUIET)/g' ${S}/Source/QtDialog/CMakeLists.txt
+	sed -i 's/^  find_package(Qt5Widgets REQUIRED)/#  find_package(Qt5Widgets REQUIRED)/g' ${S}/Tests/QtAutoUicInterface/CMakeLists.txt
+	sed -i 's/^  find_package(Qt5Widgets REQUIRED)/#  find_package(Qt5Widgets REQUIRED)/g' ${S}/Tests/QtAutogen/CMakeLists.txt
+	sed -i 's/^  find_package(Qt5Core REQUIRED)/#  find_package(Qt5Core REQUIRED)/g' ${S}/Tests/QtAutogen/autorcc_depends/CMakeLists.txt
+}

--- a/recipes-devtools/cmake/cmake/0001-KWIML-tests-Remove-format-security-from-flags.patch
+++ b/recipes-devtools/cmake/cmake/0001-KWIML-tests-Remove-format-security-from-flags.patch
@@ -1,0 +1,33 @@
+From 0941395b146804abcd87004589ff6e7a2953412d Mon Sep 17 00:00:00 2001
+From: Jussi Kukkonen <jussi.kukkonen@intel.com>
+Date: Thu, 16 Mar 2017 14:39:04 +0200
+Subject: [PATCH] KWIML tests: Remove format-security from flags
+
+For the tests where "format" is removed from flags, "format-security"
+should be removed as well. Otherwise building cmake with
+"-Wformat -Wformat-security" fails:
+
+| cc1: error: -Wformat-security ignored without -Wformat [-Werror=format-security]
+
+Upstream-Status: Backport [part of commit f77420cfc9]
+Signed-off-by: Jussi Kukkonen <jussi.kukkonen@intel.com>
+---
+ Utilities/KWIML/test/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Utilities/KWIML/test/CMakeLists.txt b/Utilities/KWIML/test/CMakeLists.txt
+index 4f6f37b..1bf93bb 100644
+--- a/Utilities/KWIML/test/CMakeLists.txt
++++ b/Utilities/KWIML/test/CMakeLists.txt
+@@ -10,7 +10,7 @@ endif()
+ # Suppress printf/scanf format warnings; we test if the sizes match.
+ foreach(lang C CXX)
+   if(KWIML_LANGUAGE_${lang} AND CMAKE_${lang}_COMPILER_ID STREQUAL "GNU")
+-    set(CMAKE_${lang}_FLAGS "${CMAKE_${lang}_FLAGS} -Wno-format")
++    set(CMAKE_${lang}_FLAGS "${CMAKE_${lang}_FLAGS} -Wno-format -Wno-format-security")
+   endif()
+ endforeach()
+ 
+-- 
+2.1.4
+

--- a/recipes-devtools/cmake/cmake/OEToolchainConfig.cmake
+++ b/recipes-devtools/cmake/cmake/OEToolchainConfig.cmake
@@ -1,0 +1,22 @@
+set( CMAKE_SYSTEM_NAME Linux )
+set( CMAKE_C_FLAGS $ENV{CFLAGS} CACHE STRING "" FORCE )
+set( CMAKE_CXX_FLAGS $ENV{CXXFLAGS}  CACHE STRING "" FORCE )
+set( CMAKE ASM_FLAGS ${CMAKE_C_FLAGS} CACHE STRING "" FORCE )
+set( CMAKE_LDFLAGS_FLAGS ${CMAKE_CXX_FLAGS} CACHE STRING "" FORCE )
+
+set( CMAKE_FIND_ROOT_PATH $ENV{OECORE_TARGET_SYSROOT} $ENV{OECORE_NATIVE_SYSROOT} )
+set( CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER )
+set( CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY )
+set( CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY )
+set( CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY )
+
+# Set CMAKE_SYSTEM_PROCESSOR from the sysroot name (assuming processor-distro-os).
+if ($ENV{SDKTARGETSYSROOT} MATCHES "/sysroots/([a-zA-Z0-9_-]+)-.+-.+")
+  set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_MATCH_1})
+endif()
+
+# Include the toolchain configuration subscripts
+file( GLOB toolchain_config_files "${CMAKE_TOOLCHAIN_FILE}.d/*.cmake" )
+foreach(config ${toolchain_config_files})
+    include(${config})
+endforeach()

--- a/recipes-devtools/cmake/cmake/avoid-gcc-warnings-with-Wstrict-prototypes.patch
+++ b/recipes-devtools/cmake/cmake/avoid-gcc-warnings-with-Wstrict-prototypes.patch
@@ -1,0 +1,42 @@
+From 4bc17345c01ea467099e28c7df30c23ace9e7811 Mon Sep 17 00:00:00 2001
+From: Andre McCurdy <armccurdy@gmail.com>
+Date: Fri, 14 Oct 2016 16:26:58 -0700
+Subject: [PATCH] CheckFunctionExists.c: avoid gcc warnings with
+ -Wstrict-prototypes
+
+Avoid warnings (and therefore build failures etc) if a user happens
+to add -Wstrict-prototypes to CFLAGS.
+
+ | $ gcc --version
+ | gcc (Ubuntu 4.8.4-2ubuntu1~14.04.3) 4.8.4
+ |
+ | $ gcc -Wstrict-prototypes -Werror -DCHECK_FUNCTION_EXISTS=pthread_create -o foo.o -c Modules/CheckFunctionExists.c
+ | Modules/CheckFunctionExists.c:7:3: error: function declaration isn't a prototype [-Werror=strict-prototypes]
+ |    CHECK_FUNCTION_EXISTS();
+ |    ^
+ | cc1: all warnings being treated as errors
+ |
+
+Upstream-Status: Pending
+
+Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
+---
+ Modules/CheckFunctionExists.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Modules/CheckFunctionExists.c b/Modules/CheckFunctionExists.c
+index 2304000..224e340 100644
+--- a/Modules/CheckFunctionExists.c
++++ b/Modules/CheckFunctionExists.c
+@@ -4,7 +4,7 @@
+ extern "C"
+ #endif
+   char
+-  CHECK_FUNCTION_EXISTS();
++  CHECK_FUNCTION_EXISTS(void);
+ #ifdef __CLASSIC_C__
+ int main()
+ {
+-- 
+1.9.1
+

--- a/recipes-devtools/cmake/cmake/cmlibarchive-disable-ext2fs.patch
+++ b/recipes-devtools/cmake/cmake/cmlibarchive-disable-ext2fs.patch
@@ -1,0 +1,26 @@
+Disable use of ext2fs/ext2_fs.h by cmake's internal libarchive copy
+
+We don't want to add a dependency on e2fsprogs-native for cmake-native,
+and we don't use CPack so just disable this functionality.
+
+Upstream-Status: Inappropriate [config]
+
+Signed-off-by: Paul Eggleton <paul.eggleton@linux.intel.com>
+
+--- a/Utilities/cmlibarchive/CMakeLists.txt
++++ b/Utilities/cmlibarchive/CMakeLists.txt
+@@ -237,12 +237,8 @@ LA_CHECK_INCLUDE_FILE("copyfile.h" HAVE_COPYFILE_H)
+ LA_CHECK_INCLUDE_FILE("direct.h" HAVE_DIRECT_H)
+ LA_CHECK_INCLUDE_FILE("dlfcn.h" HAVE_DLFCN_H)
+ LA_CHECK_INCLUDE_FILE("errno.h" HAVE_ERRNO_H)
+-LA_CHECK_INCLUDE_FILE("ext2fs/ext2_fs.h" HAVE_EXT2FS_EXT2_FS_H)
+-
+-CHECK_C_SOURCE_COMPILES("#include <sys/ioctl.h>
+-#include <ext2fs/ext2_fs.h>
+-int main(void) { return EXT2_IOC_GETFLAGS; }" HAVE_WORKING_EXT2_IOC_GETFLAGS)
+-
++SET(HAVE_EXT2FS_EXT2_FS_H 0)
++SET(HAVE_WORKING_EXT2_IOC_GETFLAGS 0)
+ LA_CHECK_INCLUDE_FILE("fcntl.h" HAVE_FCNTL_H)
+ LA_CHECK_INCLUDE_FILE("grp.h" HAVE_GRP_H)
+ LA_CHECK_INCLUDE_FILE("inttypes.h" HAVE_INTTYPES_H)

--- a/recipes-devtools/cmake/cmake/environment.d-cmake.sh
+++ b/recipes-devtools/cmake/cmake/environment.d-cmake.sh
@@ -1,0 +1,1 @@
+alias cmake="cmake -DCMAKE_TOOLCHAIN_FILE=$OECORE_NATIVE_SYSROOT/usr/share/cmake/OEToolchainConfig.cmake"

--- a/recipes-devtools/cmake/cmake/qt4-fail-silent.patch
+++ b/recipes-devtools/cmake/cmake/qt4-fail-silent.patch
@@ -1,0 +1,77 @@
+Fail silently if system Qt installation is broken
+
+Fixes a regression in behaviour from 2.8.10 to 2.8.11 resulting in the
+following error if the system Qt installation is broken:
+
+CMake Error at Modules/FindQt4.cmake:1028 (set_property):
+  set_property could not find TARGET Qt4::QtCore.  Perhaps it has not yet
+  been created.
+Call Stack (most recent call first):
+  Tests/RunCMake/CMakeLists.txt:79 (find_package)
+
+Upstream-Status: Pending
+
+Signed-off-by: Paul Eggleton <paul.eggleton@linux.intel.com>
+
+The patch was slightly adapted in order to match cmake 3.2.2:
+Another set_property was introduced which had to be included
+within the if(QT_QTCORE_FOUND) statement.
+
+Signed-off-by: Moritz Blume <moritz.blume@bmw-carit.de>
+---
+ Modules/FindQt4.cmake | 39 ++++++++++++++++++++-------------------
+ 1 file changed, 20 insertions(+), 19 deletions(-)
+
+diff --git a/Modules/FindQt4.cmake b/Modules/FindQt4.cmake
+index 6704769..9048e35 100644
+--- a/Modules/FindQt4.cmake
++++ b/Modules/FindQt4.cmake
+@@ -1000,25 +1000,26 @@ if (QT_QMAKE_EXECUTABLE AND
+     endif()
+   endmacro()
+ 
+-
+-  # Set QT_xyz_LIBRARY variable and add
+-  # library include path to QT_INCLUDES
+-  _QT4_ADJUST_LIB_VARS(QtCore)
+-  set_property(TARGET Qt4::QtCore APPEND PROPERTY
+-    INTERFACE_INCLUDE_DIRECTORIES
+-      "${QT_MKSPECS_DIR}/default"
+-      ${QT_INCLUDE_DIR}
+-  )
+-  set_property(TARGET Qt4::QtCore APPEND PROPERTY
+-    INTERFACE_COMPILE_DEFINITIONS
+-      $<$<NOT:$<CONFIG:Debug>>:QT_NO_DEBUG>
+-  )
+-  set_property(TARGET Qt4::QtCore PROPERTY
+-    INTERFACE_QT_MAJOR_VERSION 4
+-  )
+-  set_property(TARGET Qt4::QtCore APPEND PROPERTY
+-    COMPATIBLE_INTERFACE_STRING QT_MAJOR_VERSION
+-  )
++  if(QT_QTCORE_FOUND)
++    # Set QT_xyz_LIBRARY variable and add
++    # library include path to QT_INCLUDES
++    _QT4_ADJUST_LIB_VARS(QtCore)
++    set_property(TARGET Qt4::QtCore APPEND PROPERTY
++      INTERFACE_INCLUDE_DIRECTORIES
++        "${QT_MKSPECS_DIR}/default"
++        ${QT_INCLUDE_DIR}
++    )
++    set_property(TARGET Qt4::QtCore APPEND PROPERTY
++      INTERFACE_COMPILE_DEFINITIONS
++        $<$<NOT:$<CONFIG:Debug>>:QT_NO_DEBUG>
++    )
++    set_property(TARGET Qt4::QtCore PROPERTY
++      INTERFACE_QT_MAJOR_VERSION 4
++    )
++    set_property(TARGET Qt4::QtCore APPEND PROPERTY
++      COMPATIBLE_INTERFACE_STRING QT_MAJOR_VERSION
++    )
++  endif()
+ 
+   foreach(QT_MODULE ${QT_MODULES})
+     _QT4_ADJUST_LIB_VARS(${QT_MODULE})
+-- 
+1.9.1
+

--- a/recipes-devtools/cmake/cmake/support-oe-qt4-tools-names.patch
+++ b/recipes-devtools/cmake/cmake/support-oe-qt4-tools-names.patch
@@ -1,0 +1,54 @@
+cmake: support OpenEmbedded Qt4 tool binary names
+
+The FindQt4 module looks for Qt4 binaries to be able to gather the
+paths used for compilation and also to be using during other processes
+(translation update, translation binary generating and like) however
+OpenEmbedded has renamed those to allow old QMake to be used in
+parallel with the current one. This patch adds support for the
+OpenEmbedded specific binary names.
+
+Upstream-Status: Inappropriate [embedded specific]
+
+Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>
+
+The patch was slightly adapted in order to match cmake 3.2.2:
+Instead of find_program, _find_qt4_program is now used.
+
+Signed-off-by: Moritz Blume <moritz.blume@bmw-carit.de>
+---
+ Modules/FindQt4.cmake | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/Modules/FindQt4.cmake b/Modules/FindQt4.cmake
+index 11091b5..6704769 100644
+--- a/Modules/FindQt4.cmake
++++ b/Modules/FindQt4.cmake
+@@ -522,7 +522,7 @@ endfunction()
+ 
+ set(QT4_INSTALLED_VERSION_TOO_OLD FALSE)
+ 
+-set(_QT4_QMAKE_NAMES qmake qmake4 qmake-qt4 qmake-mac)
++set(_QT4_QMAKE_NAMES qmake qmake2 qmake4 qmake-qt4 qmake-mac)
+ _qt4_find_qmake("${_QT4_QMAKE_NAMES}" QT_QMAKE_EXECUTABLE QTVERSION)
+ 
+ if (QT_QMAKE_EXECUTABLE AND
+@@ -1148,12 +1148,12 @@ if (QT_QMAKE_EXECUTABLE AND
+   _find_qt4_program(QT_MOC_EXECUTABLE Qt4::moc moc-qt4 moc4 moc)
+   _find_qt4_program(QT_UIC_EXECUTABLE Qt4::uic uic-qt4 uic4 uic)
+   _find_qt4_program(QT_UIC3_EXECUTABLE Qt4::uic3 uic3)
+-  _find_qt4_program(QT_RCC_EXECUTABLE Qt4::rcc rcc)
+-  _find_qt4_program(QT_DBUSCPP2XML_EXECUTABLE Qt4::qdbuscpp2xml qdbuscpp2xml)
+-  _find_qt4_program(QT_DBUSXML2CPP_EXECUTABLE Qt4::qdbusxml2cpp qdbusxml2cpp)
++  _find_qt4_program(QT_RCC_EXECUTABLE Qt4::rcc rcc4 rcc)
++  _find_qt4_program(QT_DBUSCPP2XML_EXECUTABLE Qt4::qdbuscpp2xml qdbuscpp2xml4 qdbuscpp2xml)
++  _find_qt4_program(QT_DBUSXML2CPP_EXECUTABLE Qt4::qdbusxml2cpp qdbusxml2cpp4 qdbusxml2cpp)
+   _find_qt4_program(QT_LUPDATE_EXECUTABLE Qt4::lupdate lupdate-qt4 lupdate4 lupdate)
+   _find_qt4_program(QT_LRELEASE_EXECUTABLE Qt4::lrelease lrelease-qt4 lrelease4 lrelease)
+-  _find_qt4_program(QT_QCOLLECTIONGENERATOR_EXECUTABLE Qt4::qcollectiongenerator qcollectiongenerator-qt4 qcollectiongenerator)
++  _find_qt4_program(QT_QCOLLECTIONGENERATOR_EXECUTABLE Qt4::qcollectiongenerator qcollectiongenerator-qt4 qcollectiongenerator qcollectiongenerator4)
+   _find_qt4_program(QT_DESIGNER_EXECUTABLE Qt4::designer designer-qt4 designer4 designer)
+   _find_qt4_program(QT_LINGUIST_EXECUTABLE Qt4::linguist linguist-qt4 linguist4 linguist)
+ 
+-- 
+1.9.1
+

--- a/recipes-devtools/cmake/cmake_3.7.2.bb
+++ b/recipes-devtools/cmake/cmake_3.7.2.bb
@@ -23,7 +23,7 @@ python () {
     d.setVar("docdir_stripped", docdir_stripped)
 }
 
-EXTRA_OECMAKE=" \
+EXTRA_OECMAKE = "\
     -DCMAKE_DOC_DIR=${docdir_stripped}/cmake-${CMAKE_MAJOR_VERSION} \
     -DCMAKE_USE_SYSTEM_LIBRARIES=1 \
     -DCMAKE_USE_SYSTEM_LIBRARY_JSONCPP=0 \

--- a/recipes-devtools/cmake/cmake_3.7.2.bb
+++ b/recipes-devtools/cmake/cmake_3.7.2.bb
@@ -2,7 +2,7 @@ require cmake.inc
 
 inherit cmake
 
-DEPENDS += "curl expat zlib libarchive xz ncurses bzip2"
+DEPENDS_append = " curl expat zlib libarchive xz ncurses bzip2"
 
 SRC_URI_append_class-nativesdk = " \
     file://OEToolchainConfig.cmake \

--- a/recipes-devtools/cmake/cmake_3.7.2.bb
+++ b/recipes-devtools/cmake/cmake_3.7.2.bb
@@ -47,3 +47,6 @@ FILES_${PN} += "${datadir}/cmake-${CMAKE_MAJOR_VERSION}"
 FILES_${PN}-doc += "${docdir}/cmake-${CMAKE_MAJOR_VERSION}"
 
 BBCLASSEXTEND = "nativesdk"
+
+DEFAULT_PREFERENCE = "-1"
+

--- a/recipes-devtools/cmake/cmake_3.7.2.bb
+++ b/recipes-devtools/cmake/cmake_3.7.2.bb
@@ -1,0 +1,49 @@
+require cmake.inc
+
+inherit cmake
+
+DEPENDS += "curl expat zlib libarchive xz ncurses bzip2"
+
+SRC_URI_append_class-nativesdk = " \
+    file://OEToolchainConfig.cmake \
+    file://environment.d-cmake.sh"
+
+# Strip ${prefix} from ${docdir}, set result into docdir_stripped
+python () {
+    prefix=d.getVar("prefix", True)
+    docdir=d.getVar("docdir", True)
+
+    if not docdir.startswith(prefix):
+        bb.fatal('docdir must contain prefix as its prefix')
+
+    docdir_stripped = docdir[len(prefix):]
+    if len(docdir_stripped) > 0 and docdir_stripped[0] == '/':
+        docdir_stripped = docdir_stripped[1:]
+
+    d.setVar("docdir_stripped", docdir_stripped)
+}
+
+EXTRA_OECMAKE=" \
+    -DCMAKE_DOC_DIR=${docdir_stripped}/cmake-${CMAKE_MAJOR_VERSION} \
+    -DCMAKE_USE_SYSTEM_LIBRARIES=1 \
+    -DCMAKE_USE_SYSTEM_LIBRARY_JSONCPP=0 \
+    -DCMAKE_USE_SYSTEM_LIBRARY_LIBUV=0 \
+    -DKWSYS_CHAR_IS_SIGNED=1 \
+    -DBUILD_CursesDialog=0 \
+    -DKWSYS_LFS_WORKS=1 \
+"
+
+do_install_append_class-nativesdk() {
+    mkdir -p ${D}${datadir}/cmake
+    install -m 644 ${WORKDIR}/OEToolchainConfig.cmake ${D}${datadir}/cmake/
+
+    mkdir -p ${D}${SDKPATHNATIVE}/environment-setup.d
+    install -m 644 ${WORKDIR}/environment.d-cmake.sh ${D}${SDKPATHNATIVE}/environment-setup.d/cmake.sh
+}
+
+FILES_${PN}_append_class-nativesdk = " ${SDKPATHNATIVE}"
+
+FILES_${PN} += "${datadir}/cmake-${CMAKE_MAJOR_VERSION}"
+FILES_${PN}-doc += "${docdir}/cmake-${CMAKE_MAJOR_VERSION}"
+
+BBCLASSEXTEND = "nativesdk"

--- a/recipes-devtools/opkg/opkg/001-provisioning_hook.patch
+++ b/recipes-devtools/opkg/opkg/001-provisioning_hook.patch
@@ -1,5 +1,5 @@
 diff --git a/configure.ac b/configure.ac
-index 52e1025..7888b38 100644
+index e090a10..2d4b625 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -10,6 +10,7 @@ AC_CONFIG_HEADERS(config.h)
@@ -10,7 +10,7 @@ index 52e1025..7888b38 100644
  
  # Disable C++/Fortran checks
  define([AC_LIBTOOL_LANG_CXX_CONFIG], [:])
-@@ -74,6 +75,18 @@ if test "x$want_curl" = "xyes"; then
+@@ -116,6 +117,18 @@ if test "x$want_curl" = "xyes"; then
  fi
  AM_CONDITIONAL(HAVE_CURL, test "x$want_curl" = "xyes")
  
@@ -30,10 +30,10 @@ index 52e1025..7888b38 100644
  AC_ARG_ENABLE(sha256,
                AC_HELP_STRING([--enable-sha256], [Enable sha256sum check
 diff --git a/libopkg/Makefile.am b/libopkg/Makefile.am
-index 3e62c24..c714bf6 100644
+index 2e2fb05..c50254b 100644
 --- a/libopkg/Makefile.am
 +++ b/libopkg/Makefile.am
-@@ -38,6 +38,11 @@ if HAVE_OPENSSL
+@@ -40,6 +40,11 @@ if HAVE_OPENSSL
  opkg_sources += opkg_openssl.c
  opkg_headers += opkg_openssl.h
  endif
@@ -45,7 +45,7 @@ index 3e62c24..c714bf6 100644
  if HAVE_GPGME
  opkg_sources += opkg_gpg.c
  opkg_headers += opkg_gpg.h
-@@ -67,7 +72,7 @@ libopkg_include_HEADERS = $(opkg_headers)
+@@ -68,7 +73,7 @@ libopkg_include_HEADERS = $(opkg_headers)
  endif
  
  libopkg_la_LIBADD = $(LIBARCHIVE_LIBS) \
@@ -55,12 +55,12 @@ index 3e62c24..c714bf6 100644
  
  libopkg_la_LDFLAGS = -version-info 1:0:0
 diff --git a/libopkg/opkg_install.c b/libopkg/opkg_install.c
-index 975d9c6..d3843bb 100644
+index c1e7e04..c99a976 100644
 --- a/libopkg/opkg_install.c
 +++ b/libopkg/opkg_install.c
-@@ -926,6 +926,17 @@ int opkg_install_pkg(pkg_t * pkg, int from_upgrade)
-             return -1;
-         }
+@@ -921,6 +921,17 @@ int opkg_install_pkg(pkg_t * pkg)
+         if (err)
+             return err;
      }
 +#ifdef HAVE_PROVISION
 +    /* Weird. opkg_download_pkg() calls pkg_verify() which checks the signature but it seems it's not always called
@@ -74,11 +74,11 @@ index 975d9c6..d3843bb 100644
 +    }
 +#endif
  
-     if (opkg_config->download_only) {
- #ifndef HAVE_SOLVER
+     if (opkg_config->noaction)
+         return 0;
 diff --git a/libopkg/opkg_provision.cpp b/libopkg/opkg_provision.cpp
 new file mode 100644
-index 0000000..3baac7b
+index 0000000..d952606
 --- /dev/null
 +++ b/libopkg/opkg_provision.cpp
 @@ -0,0 +1,257 @@
@@ -375,10 +375,10 @@ index 0000000..89940be
 +#endif
 +#endif
 diff --git a/libopkg/opkg_verify.c b/libopkg/opkg_verify.c
-index a71591d..9f9ea29 100644
+index 2c36841..da3c546 100644
 --- a/libopkg/opkg_verify.c
 +++ b/libopkg/opkg_verify.c
-@@ -53,6 +53,20 @@ int opkg_verify_openssl_signature(const char *file, const char *sigfile)
+@@ -55,6 +55,20 @@ int opkg_verify_openssl_signature(const char *file, const char *sigfile)
  }
  #endif
  
@@ -399,7 +399,7 @@ index a71591d..9f9ea29 100644
  int opkg_verify_md5sum(const char *file, const char *md5sum)
  {
      int r;
-@@ -104,6 +118,8 @@ int opkg_verify_signature(const char *file, const char *sigfile)
+@@ -106,6 +120,8 @@ int opkg_verify_signature(const char *file, const char *sigfile)
          return opkg_verify_gpg_signature(file, sigfile);
      else if (strcmp(opkg_config->signature_type, "openssl") == 0)
          return opkg_verify_openssl_signature(file, sigfile);
@@ -409,10 +409,10 @@ index a71591d..9f9ea29 100644
      opkg_msg(ERROR, "signature_type option '%s' not understood.\n",
               opkg_config->signature_type);
 diff --git a/libopkg/pkg.c b/libopkg/pkg.c
-index b142b99..bfc061c 100644
+index bd679db..97d6efc 100644
 --- a/libopkg/pkg.c
 +++ b/libopkg/pkg.c
-@@ -262,6 +262,19 @@ int pkg_init_from_file(pkg_t * pkg, const char *filename)
+@@ -271,6 +271,19 @@ int pkg_init_from_file(pkg_t * pkg, const char *filename)
  
      pkg->local_filename = xstrdup(filename);
  
@@ -432,7 +432,7 @@ index b142b99..bfc061c 100644
      tmp = xstrdup(filename);
      sprintf_alloc(&control_path, "%s/%s.control.XXXXXX", opkg_config->tmp_dir,
                    basename(tmp));
-@@ -1417,11 +1430,13 @@ int pkg_verify(pkg_t * pkg)
+@@ -1562,11 +1575,13 @@ int pkg_verify(pkg_t * pkg)
      }
  
      if (opkg_config->check_pkg_signature) {

--- a/recipes-devtools/opkg/opkg/002-package_name_code_path_crash_fix.patch
+++ b/recipes-devtools/opkg/opkg/002-package_name_code_path_crash_fix.patch
@@ -1,8 +1,8 @@
 diff --git a/libopkg/opkg.c b/libopkg/opkg.c
-index c296362..12da529 100644
+index 05de83d..1706e22 100644
 --- a/libopkg/opkg.c
 +++ b/libopkg/opkg.c
-@@ -209,7 +209,10 @@ int opkg_install_package(const char *package_url,
+@@ -207,7 +207,10 @@ int opkg_install_package(const char *package_url,
      /* Pre-process the package name to handle remote URLs and paths to
       * ipk/opk files.
       */
@@ -15,12 +15,12 @@ index c296362..12da529 100644
      /* ... */
      pkg_info_preinstall_check();
 diff --git a/libopkg/opkg_download.c b/libopkg/opkg_download.c
-index a37b10d..039452c 100644
+index 5c74f66..8c66ecd 100644
 --- a/libopkg/opkg_download.c
 +++ b/libopkg/opkg_download.c
-@@ -415,6 +415,9 @@ int opkg_prepare_url_for_install(const char *url, char **namep)
- {
-     int r;
+@@ -425,6 +425,9 @@ int opkg_prepare_url_for_install(const char *url, char **namep)
+     abstract_pkg_vec_t *apkgs = NULL;
+     abstract_pkg_t *ab_pkg = NULL;
  
 +    if (namep)
 +        *namep = NULL;
@@ -28,8 +28,8 @@ index a37b10d..039452c 100644
      /* First heuristic: Maybe it's a remote URL. */
      if (url_has_remote_protocol(url)) {
          char *cache_location;
-@@ -453,6 +456,13 @@ int opkg_prepare_url_for_install(const char *url, char **namep)
-             return opkg_prepare_file_for_install(pkg->local_filename, namep);
+@@ -498,6 +501,13 @@ int opkg_prepare_url_for_install(const char *url, char **namep)
+             }
          }
  
 +     /*
@@ -40,5 +40,5 @@ index a37b10d..039452c 100644
 +            *namep = url;
 +
          /* Nothing special to do. */
-         return 0;
+         goto CLEANUP;
      }

--- a/recipes-devtools/opkg/opkg/003-fix_crash_when_opkg_does_reinit.patch
+++ b/recipes-devtools/opkg/opkg/003-fix_crash_when_opkg_does_reinit.patch
@@ -1,8 +1,8 @@
 diff --git a/libopkg/opkg.c b/libopkg/opkg.c
-index 581b343..89d7e21 100644
+index 1706e22..c940c53 100644
 --- a/libopkg/opkg.c
 +++ b/libopkg/opkg.c
-@@ -128,6 +128,12 @@ int opkg_new()
+@@ -130,6 +130,12 @@ int opkg_new()
      int r;
      saved_conf = *opkg_config;
  

--- a/recipes-extended/libcobalt/libcobalt_git.bb
+++ b/recipes-extended/libcobalt/libcobalt_git.bb
@@ -8,8 +8,8 @@ PACKAGES = "${PN}"
 inherit pythonnative
 DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad python-native ninja-native bison-native wpeframework-clientlibraries"
 
-SRC_URI = "\
-    git://git@github.com/Metrological/Cobalt.git;protocol=https;branch=master \
+SRC_URI = "git://git@github.com/Metrological/Cobalt.git;protocol=https;branch=master"
+SRC_URI_append_dunfell = "\
     file://0001-changes-for-gcc-8.patch \
     file://0002-changes-for-gcc-9.patch \
 "

--- a/recipes-extended/libcobalt/libcobalt_git.bb
+++ b/recipes-extended/libcobalt/libcobalt_git.bb
@@ -8,11 +8,17 @@ PACKAGES = "${PN}"
 inherit pythonnative
 DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad python-native ninja-native bison-native wpeframework-clientlibraries"
 
-SRC_URI = "git://git@github.com/Metrological/Cobalt.git;protocol=https;branch=master"
-SRC_URI_append = "${@oe.utils.ifelse(d.getVar('DISTRO_CODENAME', True) == 'dunfell', '${GCC8_9_COMPILE_FIX_PATCHES}', '')}"
-GCC8_9_COMPILE_FIX_PATCHES = "\
-    file://0001-changes-for-gcc-8.patch \
+GCC_MAJOR_VERSION = "${@oe.utils.trim_version("${GCCVERSION}", 1)}"
+GCC_8_PATCH = "file://0001-changes-for-gcc-8.patch"
+GCC_9_PATCH = "\
+    ${GCC_8_PATCH} \
     file://0002-changes-for-gcc-9.patch \
+"
+
+SRC_URI = "git://git@github.com/Metrological/Cobalt.git;protocol=https;branch=master"
+SRC_URI_append = "\
+    ${@bb.utils.contains('GCC_MAJOR_VERSION', '8', '${GCC_8_PATCH}', '', d)} \
+    ${@bb.utils.contains('GCC_MAJOR_VERSION', '9', '${GCC_9_PATCH}', '', d)} \
 "
 SRCREV ??= "06acca6a6d5224bb61bbf6092b4d8d6ba3f5970b"
 
@@ -25,7 +31,7 @@ COBALT_PLATFORM ??= ""
 COBALT_PLATFORM_NAME ??= ""
 
 COBALT_DEPENDENCIES ??= ""
-DEPENDS += "${COBALT_DEPENDENCIES}"
+DEPENDS_append = " ${COBALT_DEPENDENCIES}"
 
 RDEPENDS_${PN} += "gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad wpeframework ${COBALT_DEPENDENCIES}"
 

--- a/recipes-extended/libcobalt/libcobalt_git.bb
+++ b/recipes-extended/libcobalt/libcobalt_git.bb
@@ -1,3 +1,7 @@
+DESCRIPTION = " Cobalt is a lightweight application container \
+(i.e. an application runtime, like a JVM or the Flash Player) \
+that is compatible with a subset of the W3C HTML5 specifications"
+
 LICENSE = "BSD-3-Clause & BSD-2-Clause & Apache-2.0 & MIT & ISC & OpenSSL & CC0-1.0 & LGPL-2.0 & LGPL-2.1 & PD & Zlib & MPL-2.0"
 LIC_FILES_CHKSUM = "\
     file://src/LICENSE;md5=0fca02217a5d49a14dfe2d11837bb34d \
@@ -9,16 +13,16 @@ inherit pythonnative
 DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad python-native ninja-native bison-native wpeframework-clientlibraries"
 
 GCC_MAJOR_VERSION = "${@oe.utils.trim_version("${GCCVERSION}", 1)}"
-GCC_8_PATCH = "file://0001-changes-for-gcc-8.patch"
-GCC_9_PATCH = "\
-    ${GCC_8_PATCH} \
+GCC_8_PATCHLIST = "file://0001-changes-for-gcc-8.patch"
+GCC_9_PATCHLIST = "\
+    ${GCC_8_PATCHLIST} \
     file://0002-changes-for-gcc-9.patch \
 "
 
 SRC_URI = "git://git@github.com/Metrological/Cobalt.git;protocol=https;branch=master"
-SRC_URI_append = "\
-    ${@bb.utils.contains('GCC_MAJOR_VERSION', '8', '${GCC_8_PATCH}', '', d)} \
-    ${@bb.utils.contains('GCC_MAJOR_VERSION', '9', '${GCC_9_PATCH}', '', d)} \
+SRC_URI_append = " \
+    ${@bb.utils.contains('GCC_MAJOR_VERSION', '8', '${GCC_8_PATCHLIST}', '', d)} \
+    ${@bb.utils.contains('GCC_MAJOR_VERSION', '9', '${GCC_9_PATCHLIST}', '', d)} \
 "
 SRCREV ??= "06acca6a6d5224bb61bbf6092b4d8d6ba3f5970b"
 

--- a/recipes-extended/libcobalt/libcobalt_git.bb
+++ b/recipes-extended/libcobalt/libcobalt_git.bb
@@ -9,7 +9,8 @@ inherit pythonnative
 DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad python-native ninja-native bison-native wpeframework-clientlibraries"
 
 SRC_URI = "git://git@github.com/Metrological/Cobalt.git;protocol=https;branch=master"
-SRC_URI_append_dunfell = "\
+SRC_URI_append = "${@oe.utils.ifelse(d.getVar('DISTRO_CODENAME', True) == 'dunfell', '${GCC8_9_COMPILE_FIX_PATCHES}', '')}"
+GCC8_9_COMPILE_FIX_PATCHES = "\
     file://0001-changes-for-gcc-8.patch \
     file://0002-changes-for-gcc-9.patch \
 "

--- a/recipes-graphics/cairo/cairo_%.bbappend
+++ b/recipes-graphics/cairo/cairo_%.bbappend
@@ -3,7 +3,8 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 PACKAGECONFIG_append_class-target = " egl"
 PACKAGECONFIG_append_class-target = " ${@bb.utils.contains('DISTRO_FEATURES', 'x11', '', 'glesv2', d)}"
 
-SRC_URI += "file://0006-add-egl-device-create.patch"
-#SRC_URI += "file://0008-add-noaa-compositor.patch"
-SRC_URI += "file://0009-error-check-just-in-debug.patch"
+SRC_URI_append = "\
+    file://0006-add-egl-device-create.patch \
+    file://0009-error-check-just-in-debug.patch \
+"
 

--- a/recipes-graphics/cairo/cairo_%.bbappend
+++ b/recipes-graphics/cairo/cairo_%.bbappend
@@ -3,7 +3,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 PACKAGECONFIG_append_class-target = " egl"
 PACKAGECONFIG_append_class-target = " ${@bb.utils.contains('DISTRO_FEATURES', 'x11', '', 'glesv2', d)}"
 
-SRC_URI_append = "\
+SRC_URI_append = " \
     file://0006-add-egl-device-create.patch \
     file://0009-error-check-just-in-debug.patch \
 "

--- a/recipes-graphics/cairo/cairo_1.16.0.bbappend
+++ b/recipes-graphics/cairo/cairo_1.16.0.bbappend
@@ -1,4 +1,4 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
-SRC_URI += "file://0001-add-noaa-compositor-for-v1.16.patch"
+SRC_URI_append = " file://0001-add-noaa-compositor-for-v1.16.patch"
 

--- a/recipes-graphics/drm/libdrm_2.4.%.bbappend
+++ b/recipes-graphics/drm/libdrm_2.4.%.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
-SRC_URI_append = "\
+SRC_URI_append = " \
     file://0004-meson.build-enable-static-build.patch \
     file://0005-tests-meson.build-disable-nouveau-tests-for-static-b.patch \
 "

--- a/recipes-graphics/drm/libdrm_2.4.%.bbappend
+++ b/recipes-graphics/drm/libdrm_2.4.%.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
-SRC_URI += "\
+SRC_URI_append = "\
     file://0004-meson.build-enable-static-build.patch \
     file://0005-tests-meson.build-disable-nouveau-tests-for-static-b.patch \
 "

--- a/recipes-graphics/libepoxy/libepoxy_%.bbappend
+++ b/recipes-graphics/libepoxy/libepoxy_%.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
-SRC_URI_append = " ${@oe.utils.ifelse(d.getVar('DISTRO_CODENAME', True) == 'dunfell', 'file://0001-Make-graphic-libs-configurable.patch', '')}"
+SRC_URI_append_dunfell = " file://0001-Make-graphic-libs-configurable.patch"
 
 GLX_LIB_NAME    ?= "${@bb.utils.contains('PREFERRED_PROVIDER_virtual/libgl',    'broadcom-refsw', 'libv3ddriver.so', '/usr/lib/libGL.so.1', d)}"
 EGL_LIB_NAME    ?= "${@bb.utils.contains('PREFERRED_PROVIDER_virtual/egl',      'broadcom-refsw', 'libv3ddriver.so', '/usr/lib/libEGL.so.1', d)}"

--- a/recipes-graphics/libepoxy/libepoxy_%.bbappend
+++ b/recipes-graphics/libepoxy/libepoxy_%.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
-SRC_URI_append_dunfell = "file://0001-Make-graphic-libs-configurable.patch"
+SRC_URI_append = " ${@oe.utils.ifelse(d.getVar('DISTRO_CODENAME', True) == 'dunfell', 'file://0001-Make-graphic-libs-configurable.patch', '')}"
 
 GLX_LIB_NAME    ?= "${@bb.utils.contains('PREFERRED_PROVIDER_virtual/libgl',    'broadcom-refsw', 'libv3ddriver.so', '/usr/lib/libGL.so.1', d)}"
 EGL_LIB_NAME    ?= "${@bb.utils.contains('PREFERRED_PROVIDER_virtual/egl',      'broadcom-refsw', 'libv3ddriver.so', '/usr/lib/libEGL.so.1', d)}"

--- a/recipes-graphics/libepoxy/libepoxy_%.bbappend
+++ b/recipes-graphics/libepoxy/libepoxy_%.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
-SRC_URI += "file://0001-Make-graphic-libs-configurable.patch"
+SRC_URI_append_dunfell = "file://0001-Make-graphic-libs-configurable.patch"
 
 GLX_LIB_NAME    ?= "${@bb.utils.contains('PREFERRED_PROVIDER_virtual/libgl',    'broadcom-refsw', 'libv3ddriver.so', '/usr/lib/libGL.so.1', d)}"
 EGL_LIB_NAME    ?= "${@bb.utils.contains('PREFERRED_PROVIDER_virtual/egl',      'broadcom-refsw', 'libv3ddriver.so', '/usr/lib/libEGL.so.1', d)}"

--- a/recipes-graphics/libepoxy/libepoxy_1.4.0.bb
+++ b/recipes-graphics/libepoxy/libepoxy_1.4.0.bb
@@ -1,4 +1,8 @@
 SUMMARY = "OpenGL function pointer management library"
+DESCRIPTION = "Epoxy is a library for handling OpenGL function pointer management \
+It hides the complexity of dlopen(), dlsym(), glXGetProcAddress(), eglGetProcAddress(), etc. \
+from the app developer, with very little knowledge needed on their part. \
+They get to read GL specs and write code using undecorated function names like glCompileShader()"
 HOMEPAGE = "https://github.com/anholt/libepoxy/"
 SECTION = "libs"
 
@@ -14,7 +18,7 @@ inherit autotools pkgconfig features_check
 
 REQUIRED_DISTRO_FEATURES = "opengl"
 
-DEPENDS = "util-macros virtual/egl"
+DEPENDS_append = " util-macros virtual/egl"
 
 PACKAGECONFIG[x11] = "--enable-glx, --disable-glx, virtual/libx11"
 PACKAGECONFIG ??= "${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'x11', '', d)}"

--- a/recipes-graphics/libepoxy/libepoxy_1.4.0.bb
+++ b/recipes-graphics/libepoxy/libepoxy_1.4.0.bb
@@ -1,0 +1,20 @@
+SUMMARY = "OpenGL function pointer management library"
+HOMEPAGE = "https://github.com/anholt/libepoxy/"
+SECTION = "libs"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://COPYING;md5=58ef4c80d401e07bd9ee8b6b58cf464b"
+
+SRC_URI = "https://github.com/anholt/${BPN}/releases/download/v1.4/${BP}.tar.xz"
+SRC_URI[md5sum] = "d8d8cbf2beb64975d424fcc5167a2a38"
+SRC_URI[sha256sum] = "25a906b14a921bc2b488cfeaa21a00486fe92630e4a9dd346e4ecabeae52ab41"
+UPSTREAM_CHECK_URI = "https://github.com/anholt/libepoxy/releases"
+
+inherit autotools pkgconfig distro_features_check
+
+REQUIRED_DISTRO_FEATURES = "opengl"
+
+DEPENDS = "util-macros virtual/egl"
+
+PACKAGECONFIG[x11] = "--enable-glx, --disable-glx, virtual/libx11"
+PACKAGECONFIG ??= "${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'x11', '', d)}"

--- a/recipes-graphics/libepoxy/libepoxy_1.4.0.bb
+++ b/recipes-graphics/libepoxy/libepoxy_1.4.0.bb
@@ -1,8 +1,8 @@
 SUMMARY = "OpenGL function pointer management library"
 DESCRIPTION = "Epoxy is a library for handling OpenGL function pointer management \
-It hides the complexity of dlopen(), dlsym(), glXGetProcAddress(), eglGetProcAddress(), etc. \
-from the app developer, with very little knowledge needed on their part. \
-They get to read GL specs and write code using undecorated function names like glCompileShader()"
+    It hides the complexity of dlopen(), dlsym(), glXGetProcAddress(), eglGetProcAddress(), etc. \
+    from the app developer, with very little knowledge needed on their part. \
+    They get to read GL specs and write code using undecorated function names like glCompileShader()"
 HOMEPAGE = "https://github.com/anholt/libepoxy/"
 SECTION = "libs"
 

--- a/recipes-graphics/libepoxy/libepoxy_1.4.0.bb
+++ b/recipes-graphics/libepoxy/libepoxy_1.4.0.bb
@@ -10,7 +10,7 @@ SRC_URI[md5sum] = "d8d8cbf2beb64975d424fcc5167a2a38"
 SRC_URI[sha256sum] = "25a906b14a921bc2b488cfeaa21a00486fe92630e4a9dd346e4ecabeae52ab41"
 UPSTREAM_CHECK_URI = "https://github.com/anholt/libepoxy/releases"
 
-inherit autotools pkgconfig distro_features_check
+inherit autotools pkgconfig features_check
 
 REQUIRED_DISTRO_FEATURES = "opengl"
 

--- a/recipes-graphics/mesa/mesa_21%.bbappend
+++ b/recipes-graphics/mesa/mesa_21%.bbappend
@@ -1,4 +1,4 @@
-SRC_URI_append = "\
+SRC_URI_append = " \
     file://0003-vc4-add-meson-option-to-disable-optional-neon-suppor.patch \
     file://0004-src-util-rand_xor-Include-stddef.h-to-fix-build-erro.patch \
 "

--- a/recipes-graphics/mesa/mesa_21%.bbappend
+++ b/recipes-graphics/mesa/mesa_21%.bbappend
@@ -1,4 +1,4 @@
-SRC_URI += "\
+SRC_URI_append = "\
     file://0003-vc4-add-meson-option-to-disable-optional-neon-suppor.patch \
     file://0004-src-util-rand_xor-Include-stddef.h-to-fix-build-erro.patch \
 "

--- a/recipes-graphics/openjpeg/openjpeg/0002-Do-not-ask-cmake-to-export-binaries-they-don-t-make-.patch
+++ b/recipes-graphics/openjpeg/openjpeg/0002-Do-not-ask-cmake-to-export-binaries-they-don-t-make-.patch
@@ -1,0 +1,31 @@
+From 4681de07e21f17aa28710d3a51fabe7da60463f9 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Andreas=20M=C3=BCller?= <schnitzeltony@gmail.com>
+Date: Fri, 28 Sep 2018 00:38:50 +0200
+Subject: [PATCH] Do not ask cmake to export binaries - they don't make it
+ dependants sysroots
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Upstream-Status: Inappropriate [OE-Specific]
+
+Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>
+---
+ src/bin/jp2/CMakeLists.txt | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/src/bin/jp2/CMakeLists.txt b/src/bin/jp2/CMakeLists.txt
+index 4324c36d..2c11fe02 100644
+--- a/src/bin/jp2/CMakeLists.txt
++++ b/src/bin/jp2/CMakeLists.txt
+@@ -66,7 +66,6 @@ foreach(exe opj_decompress opj_compress opj_dump)
+   endif()
+   # Install exe
+   install(TARGETS ${exe}
+-    EXPORT OpenJPEGTargets
+     DESTINATION ${OPENJPEG_INSTALL_BIN_DIR} COMPONENT Applications
+   )
+   if(OPJ_USE_DSYMUTIL)
+-- 
+2.14.4
+

--- a/recipes-graphics/openjpeg/openjpeg/CVE-2020-6851.patch
+++ b/recipes-graphics/openjpeg/openjpeg/CVE-2020-6851.patch
@@ -1,0 +1,32 @@
+From 024b8407392cb0b82b04b58ed256094ed5799e04 Mon Sep 17 00:00:00 2001
+From: Even Rouault <even.rouault@spatialys.com>
+Date: Sat, 11 Jan 2020 01:51:19 +0100
+Subject: [PATCH] opj_j2k_update_image_dimensions(): reject images whose
+ coordinates are beyond INT_MAX (fixes #1228)
+
+---
+ src/lib/openjp2/j2k.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/src/lib/openjp2/j2k.c b/src/lib/openjp2/j2k.c
+index 14f6ff41..922550eb 100644
+--- a/src/lib/openjp2/j2k.c
++++ b/src/lib/openjp2/j2k.c
+@@ -9236,6 +9236,14 @@ static OPJ_BOOL opj_j2k_update_image_dim
+     l_img_comp = p_image->comps;
+     for (it_comp = 0; it_comp < p_image->numcomps; ++it_comp) {
+         OPJ_INT32 l_h, l_w;
++        if (p_image->x0 > (OPJ_UINT32)INT_MAX ||
++                p_image->y0 > (OPJ_UINT32)INT_MAX ||
++                p_image->x1 > (OPJ_UINT32)INT_MAX ||
++                p_image->y1 > (OPJ_UINT32)INT_MAX) {
++            opj_event_msg(p_manager, EVT_ERROR,
++                          "Image coordinates above INT_MAX are not supported\n");
++            return OPJ_FALSE;
++        }
+ 
+         l_img_comp->x0 = (OPJ_UINT32)opj_int_ceildiv((OPJ_INT32)p_image->x0,
+                          (OPJ_INT32)l_img_comp->dx);
+-- 
+2.17.1
+

--- a/recipes-graphics/openjpeg/openjpeg/CVE-2020-8112.patch
+++ b/recipes-graphics/openjpeg/openjpeg/CVE-2020-8112.patch
@@ -1,0 +1,46 @@
+From 05f9b91e60debda0e83977e5e63b2e66486f7074 Mon Sep 17 00:00:00 2001
+From: Even Rouault <even.rouault@spatialys.com>
+Date: Thu, 30 Jan 2020 00:59:57 +0100
+Subject: [PATCH] opj_tcd_init_tile(): avoid integer overflow
+
+That could lead to later assertion failures.
+
+Fixes #1231 / CVE-2020-8112
+---
+ src/lib/openjp2/tcd.c | 20 ++++++++++++++++++--
+ 1 file changed, 18 insertions(+), 2 deletions(-)
+
+diff --git a/src/lib/openjp2/tcd.c b/src/lib/openjp2/tcd.c
+index deecc4df..aa419030 100644
+--- a/src/lib/openjp2/tcd.c
++++ b/src/lib/openjp2/tcd.c
+@@ -905,8 +905,24 @@ static INLINE OPJ_BOOL opj_tcd_init_tile(opj_tcd_t *p_tcd, OPJ_UINT32 p_tile_no,
+             /* p. 64, B.6, ISO/IEC FDIS15444-1 : 2000 (18 august 2000)  */
+             l_tl_prc_x_start = opj_int_floordivpow2(l_res->x0, (OPJ_INT32)l_pdx) << l_pdx;
+             l_tl_prc_y_start = opj_int_floordivpow2(l_res->y0, (OPJ_INT32)l_pdy) << l_pdy;
+-            l_br_prc_x_end = opj_int_ceildivpow2(l_res->x1, (OPJ_INT32)l_pdx) << l_pdx;
+-            l_br_prc_y_end = opj_int_ceildivpow2(l_res->y1, (OPJ_INT32)l_pdy) << l_pdy;
++            {
++                OPJ_UINT32 tmp = ((OPJ_UINT32)opj_int_ceildivpow2(l_res->x1,
++                                  (OPJ_INT32)l_pdx)) << l_pdx;
++                if (tmp > (OPJ_UINT32)INT_MAX) {
++                    opj_event_msg(manager, EVT_ERROR, "Integer overflow\n");
++                    return OPJ_FALSE;
++                }
++                l_br_prc_x_end = (OPJ_INT32)tmp;
++            }
++            {
++                OPJ_UINT32 tmp = ((OPJ_UINT32)opj_int_ceildivpow2(l_res->y1,
++                                  (OPJ_INT32)l_pdy)) << l_pdy;
++                if (tmp > (OPJ_UINT32)INT_MAX) {
++                    opj_event_msg(manager, EVT_ERROR, "Integer overflow\n");
++                    return OPJ_FALSE;
++                }
++                l_br_prc_y_end = (OPJ_INT32)tmp;
++            }
+             /*fprintf(stderr, "\t\t\tprc_x_start=%d, prc_y_start=%d, br_prc_x_end=%d, br_prc_y_end=%d \n", l_tl_prc_x_start, l_tl_prc_y_start, l_br_prc_x_end ,l_br_prc_y_end );*/
+ 
+             l_res->pw = (l_res->x0 == l_res->x1) ? 0U : (OPJ_UINT32)((
+-- 
+2.20.1
+

--- a/recipes-graphics/openjpeg/openjpeg_2.3.1.bb
+++ b/recipes-graphics/openjpeg/openjpeg_2.3.1.bb
@@ -1,0 +1,22 @@
+DESCRIPTION = "OpenJPEG library is an open-source JPEG 2000 codec"
+HOMEPAGE = "http://www.openjpeg.org"
+LICENSE = "BSD-2-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=c648878b4840d7babaade1303e7f108c"
+
+DEPENDS = "libpng tiff lcms zlib"
+
+SRC_URI = " \
+    git://github.com/uclouvain/openjpeg.git \
+    file://0002-Do-not-ask-cmake-to-export-binaries-they-don-t-make-.patch \
+    file://CVE-2020-6851.patch \
+    file://CVE-2020-8112.patch \
+"
+SRCREV = "57096325457f96d8cd07bd3af04fe81d7a2ba788"
+S = "${WORKDIR}/git"
+
+inherit cmake
+
+# for multilib
+EXTRA_OECMAKE += "-DOPENJPEG_INSTALL_LIB_DIR=${@d.getVar('baselib', True).replace('/', '')}"
+
+FILES_${PN} += "${libdir}/openjpeg*"

--- a/recipes-graphics/openjpeg/openjpeg_2.3.1.bb
+++ b/recipes-graphics/openjpeg/openjpeg_2.3.1.bb
@@ -3,9 +3,9 @@ HOMEPAGE = "http://www.openjpeg.org"
 LICENSE = "BSD-2-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=c648878b4840d7babaade1303e7f108c"
 
-DEPENDS = "libpng tiff lcms zlib"
+DEPENDS_append = " libpng tiff lcms zlib"
 
-SRC_URI = " \
+SRC_URI = "\
     git://github.com/uclouvain/openjpeg.git \
     file://0002-Do-not-ask-cmake-to-export-binaries-they-don-t-make-.patch \
     file://CVE-2020-6851.patch \

--- a/recipes-graphics/openjpeg/openjpeg_2.3.1.bb
+++ b/recipes-graphics/openjpeg/openjpeg_2.3.1.bb
@@ -1,4 +1,7 @@
-DESCRIPTION = "OpenJPEG library is an open-source JPEG 2000 codec"
+SUMMARY = "OpenJPEG library"
+DESCRIPTION = "OpenJPEG library is an open-source JPEG 2000 codec written in C language.\
+    It has been developed in order to promote the use of JPEG 2000, a still-image compression\
+    standard from the Joint Photographic Experts Group (JPEG)."
 HOMEPAGE = "http://www.openjpeg.org"
 LICENSE = "BSD-2-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=c648878b4840d7babaade1303e7f108c"

--- a/recipes-graphics/westeros/westeros-simplebuffer.bb
+++ b/recipes-graphics/westeros/westeros-simplebuffer.bb
@@ -5,7 +5,7 @@ SUMMARY = "This receipe compiles the westeros compositor simplebuffer component"
 S = "${WORKDIR}/git"
 LICENSE_LOCATION = "${S}/LICENSE"
 
-DEPENDS += "virtual/libgl wayland-native wayland glib-2.0"
+DEPENDS_append = " virtual/libgl wayland-native wayland glib-2.0"
 
 inherit autotools pkgconfig
 

--- a/recipes-graphics/westeros/westeros-simpleshell.bb
+++ b/recipes-graphics/westeros/westeros-simpleshell.bb
@@ -5,7 +5,7 @@ SUMMARY = "This receipe compiles the westeros compositor simple-shelk component"
 S = "${WORKDIR}/git"
 LICENSE_LOCATION = "${S}/LICENSE"
 
-DEPENDS += "wayland wayland-native glib-2.0"
+DEPENDS_append = " wayland wayland-native glib-2.0"
 
 inherit autotools pkgconfig
 

--- a/recipes-graphics/westeros/westeros-sink.bb
+++ b/recipes-graphics/westeros/westeros-sink.bb
@@ -4,13 +4,11 @@ SUMMARY = "This receipe compiles the westeros compositor gstreamer sink element"
 
 S = "${WORKDIR}/git"
 
-SRC_URI += "\
-    file://0004-Dispatch-custom-queue-instead-flushing-display.patch \
-"
+SRC_URI_append = " file://0004-Dispatch-custom-queue-instead-flushing-display.patch"
 
 inherit autotools pkgconfig
 
-DEPENDS += "wayland-native wayland westeros-simpleshell westeros-simplebuffer westeros"
+DEPENDS_append = " wayland-native wayland westeros-simpleshell westeros-simplebuffer westeros"
 
 do_compile_prepend() {
     oe_runmake -C ${S}/protocol

--- a/recipes-graphics/westeros/westeros.bb
+++ b/recipes-graphics/westeros/westeros.bb
@@ -2,7 +2,7 @@ require westeros.inc
 
 SUMMARY = "This receipe compiles the westeros compositor component"
 
-SRC_URI_append = "\
+SRC_URI_append = " \
     file://0001-Use-intptr_t-to-avoid-precision-errors-on-aarch64.patch \
     file://0002-Add_VCX_flags_support.patch \
     file://0003-Set-default-resolution-to-1080.patch \
@@ -28,7 +28,7 @@ S = "${WORKDIR}/git"
 
 WESTEROS_BACKEND ??= "westeros-soc-drm"
 
-DEPENDS_append = "\
+DEPENDS_append = " \
     westeros-simplebuffer \
     westeros-simpleshell \
     ${WESTEROS_BACKEND} \

--- a/recipes-graphics/westeros/westeros.bb
+++ b/recipes-graphics/westeros/westeros.bb
@@ -2,7 +2,7 @@ require westeros.inc
 
 SUMMARY = "This receipe compiles the westeros compositor component"
 
-SRC_URI += "\
+SRC_URI_append = "\
     file://0001-Use-intptr_t-to-avoid-precision-errors-on-aarch64.patch \
     file://0002-Add_VCX_flags_support.patch \
     file://0003-Set-default-resolution-to-1080.patch \
@@ -26,9 +26,9 @@ PACKAGECONFIG[modules] = "--enable-modules=yes"
 
 S = "${WORKDIR}/git"
 
-WESTEROS_BACKEND ?= "westeros-soc-drm"
+WESTEROS_BACKEND ??= "westeros-soc-drm"
 
-DEPENDS += "\
+DEPENDS_append = "\
     westeros-simplebuffer \
     westeros-simpleshell \
     ${WESTEROS_BACKEND} \

--- a/recipes-graphics/westeros/westeros.bb
+++ b/recipes-graphics/westeros/westeros.bb
@@ -1,6 +1,9 @@
-require westeros.inc
-
 SUMMARY = "This receipe compiles the westeros compositor component"
+DESCRIPTION = "Wayland Compositor: Westeros is a light-weight Wayland compositor library.\
+    It uses the Wayland protocols, and is designed to be compatible with applications built\
+    to use Wayland compositors."
+
+require westeros.inc
 
 SRC_URI_append = " \
     file://0001-Use-intptr_t-to-avoid-precision-errors-on-aarch64.patch \

--- a/recipes-graphics/westeros/westeros.inc
+++ b/recipes-graphics/westeros/westeros.inc
@@ -4,20 +4,21 @@ PV = "1.0+git${SRCPV}"
 
 SRC_URI = "${WESTEROS_URI}"
 SRCREV = "${WESTEROS_SRCREV}"
-WESTEROS_URI ?= "git://github.com/rdkcmf/westeros"
-WESTEROS_SRCREV ?= "fbd296bd25c7c9b122519569bcb5eb71ebebde14"
-LICENSE_LOCATION ?= "${S}/LICENSE"
+WESTEROS_URI ??= "git://github.com/rdkcmf/westeros"
+WESTEROS_SRCREV ??= "fbd296bd25c7c9b122519569bcb5eb71ebebde14"
+LICENSE_LOCATION ??= "${S}/LICENSE"
 LIC_FILES_CHKSUM = "file://${LICENSE_LOCATION};md5=77cf8957a4ffe1f1ae0d474a3d95a3ed"
 
 export SCANNER_TOOL = "wayland-scanner"
 
 acpaths = "-I cfg"
 
-DEPENDS += "wayland-native \
-            gstreamer1.0 \
-            wayland \
-            libxkbcommon \
-           "
+DEPENDS_append = "\
+    wayland-native \
+    gstreamer1.0 \
+    wayland \
+    libxkbcommon \
+"
 # depends on virtual/egl and wayland
 REQUIRED_DISTRO_FEATURES = "opengl wayland"
 

--- a/recipes-graphics/westeros/westeros.inc
+++ b/recipes-graphics/westeros/westeros.inc
@@ -13,7 +13,7 @@ export SCANNER_TOOL = "wayland-scanner"
 
 acpaths = "-I cfg"
 
-DEPENDS_append = "\
+DEPENDS_append = " \
     wayland-native \
     gstreamer1.0 \
     wayland \

--- a/recipes-multimedia/gstreamer/files/0001-introspection.m4-prefix-pkgconfig-paths-with-PKG_CON.patch
+++ b/recipes-multimedia/gstreamer/files/0001-introspection.m4-prefix-pkgconfig-paths-with-PKG_CON.patch
@@ -1,0 +1,42 @@
+From 90916f96262fa7b27a0a99788c69f9fd6df11000 Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Tue, 24 Nov 2015 16:46:27 +0200
+Subject: [PATCH] introspection.m4: prefix pkgconfig paths with
+ PKG_CONFIG_SYSROOT_DIR
+
+We can't use our tweaked introspection.m4 from gobject-introspection tarball
+because gstreamer also defines INTROSPECTION_INIT in its introspection.m4, which
+is later supplied to g-ir-scanner.
+
+Upstream-Status: Pending [review on oe-core list]
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+---
+ common/m4/introspection.m4 | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/common/m4/introspection.m4 b/common/m4/introspection.m4
+index 162be57..217a6ae 100644
+--- a/common/m4/introspection.m4
++++ b/common/m4/introspection.m4
+@@ -54,14 +54,14 @@ m4_define([_GOBJECT_INTROSPECTION_CHECK_INTERNAL],
+     INTROSPECTION_GIRDIR=
+     INTROSPECTION_TYPELIBDIR=
+     if test "x$found_introspection" = "xyes"; then
+-       INTROSPECTION_SCANNER=`$PKG_CONFIG --variable=g_ir_scanner gobject-introspection-1.0`
+-       INTROSPECTION_COMPILER=`$PKG_CONFIG --variable=g_ir_compiler gobject-introspection-1.0`
+-       INTROSPECTION_GENERATE=`$PKG_CONFIG --variable=g_ir_generate gobject-introspection-1.0`
++       INTROSPECTION_SCANNER=$PKG_CONFIG_SYSROOT_DIR`$PKG_CONFIG --variable=g_ir_scanner gobject-introspection-1.0`
++       INTROSPECTION_COMPILER=$PKG_CONFIG_SYSROOT_DIR`$PKG_CONFIG --variable=g_ir_compiler gobject-introspection-1.0`
++       INTROSPECTION_GENERATE=$PKG_CONFIG_SYSROOT_DIR`$PKG_CONFIG --variable=g_ir_generate gobject-introspection-1.0`
+        INTROSPECTION_GIRDIR=`$PKG_CONFIG --variable=girdir gobject-introspection-1.0`
+        INTROSPECTION_TYPELIBDIR="$($PKG_CONFIG --variable=typelibdir gobject-introspection-1.0)"
+        INTROSPECTION_CFLAGS=`$PKG_CONFIG --cflags gobject-introspection-1.0`
+        INTROSPECTION_LIBS=`$PKG_CONFIG --libs gobject-introspection-1.0`
+-       INTROSPECTION_MAKEFILE=`$PKG_CONFIG --variable=datadir gobject-introspection-1.0`/gobject-introspection-1.0/Makefile.introspection
++       INTROSPECTION_MAKEFILE=$PKG_CONFIG_SYSROOT_DIR`$PKG_CONFIG --variable=datadir gobject-introspection-1.0`/gobject-introspection-1.0/Makefile.introspection
+        INTROSPECTION_INIT="extern void gst_init(gint*,gchar**); gst_init(NULL,NULL);"
+     fi
+     AC_SUBST(INTROSPECTION_SCANNER)
+-- 
+2.6.2
+

--- a/recipes-multimedia/gstreamer/gst-plugins-package.inc
+++ b/recipes-multimedia/gstreamer/gst-plugins-package.inc
@@ -1,0 +1,56 @@
+PACKAGESPLITFUNCS_prepend = " split_gstreamer10_packages "
+PACKAGESPLITFUNCS_append = " set_metapkg_rdepends "
+
+python split_gstreamer10_packages () {
+    gst_libdir = d.expand('${libdir}/gstreamer-${LIBV}')
+    postinst = d.getVar('plugin_postinst', True)
+    glibdir = d.getVar('libdir', True)
+
+    do_split_packages(d, glibdir, '^lib(.*)\.so\.*', 'lib%s', 'gstreamer %s library', extra_depends='', allow_links=True)
+    do_split_packages(d, gst_libdir, 'libgst(.*)\.so$', d.expand('${PN}-%s'), 'GStreamer plugin for %s', postinst=postinst, extra_depends='')
+    do_split_packages(d, glibdir+'/girepository-1.0', 'Gst(.*)-1.0\.typelib$', d.expand('${PN}-%s-typelib'), 'GStreamer typelib file for %s', postinst=postinst, extra_depends='')
+    do_split_packages(d, gst_libdir, 'libgst(.*)\.la$', d.expand('${PN}-%s-dev'), 'GStreamer plugin for %s (development files)', extra_depends='${PN}-dev')
+    do_split_packages(d, gst_libdir, 'libgst(.*)\.a$', d.expand('${PN}-%s-staticdev'), 'GStreamer plugin for %s (static development files)', extra_depends='${PN}-staticdev')
+}
+
+python set_metapkg_rdepends () {
+    import os
+
+    pn = d.getVar('PN', True)
+    metapkg =  pn + '-meta'
+    d.setVar('ALLOW_EMPTY_' + metapkg, "1")
+    d.setVar('FILES_' + metapkg, "")
+    blacklist = [ pn, pn + '-locale', pn + '-dev', pn + '-dbg', pn + '-doc', pn + '-meta' ]
+    metapkg_rdepends = []
+    packages = d.getVar('PACKAGES', True).split()
+    pkgdest = d.getVar('PKGDEST', True)
+    for pkg in packages[1:]:
+        if not pkg in blacklist and not pkg in metapkg_rdepends and not pkg.endswith('-dev') and not pkg.endswith('-dbg') and not pkg.count('locale') and not pkg.count('-staticdev'):
+            # See if the package is empty by looking at the contents of its PKGDEST subdirectory. 
+            # If this subdirectory is empty, then the package is.
+            # Empty packages do not get added to the meta package's RDEPENDS
+            pkgdir = os.path.join(pkgdest, pkg)
+            if os.path.exists(pkgdir):
+                dir_contents = os.listdir(pkgdir) or []
+            else:
+                dir_contents = []
+            is_empty = len(dir_contents) == 0
+            if not is_empty:
+                metapkg_rdepends.append(pkg)
+    d.setVar('RDEPENDS_' + metapkg, ' '.join(metapkg_rdepends))
+    d.setVar('DESCRIPTION_' + metapkg, pn + ' meta package')
+}
+
+# each plugin-dev depends on PN-dev, plugin-staticdev on PN-staticdev
+# so we need them even when empty (like in gst-plugins-good case)
+ALLOW_EMPTY_${PN} = "1"
+ALLOW_EMPTY_${PN}-dev = "1"
+ALLOW_EMPTY_${PN}-staticdev = "1"
+
+PACKAGES += "${PN}-apps ${PN}-meta ${PN}-glib"
+
+FILES_${PN} = ""
+FILES_${PN}-apps = "${bindir}"
+FILES_${PN}-glib = "${datadir}/glib-2.0"
+
+RRECOMMENDS_${PN} += "${PN}-meta"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-1.10.4/0001-typefind-min-1k.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-1.10.4/0001-typefind-min-1k.patch
@@ -1,0 +1,12 @@
+diff -rupN a/plugins/elements/gsttypefindelement.c b/plugins/elements/gsttypefindelement.c
+--- a/plugins/elements/gsttypefindelement.c	2015-03-09 14:23:30.699546672 +0000
++++ b/plugins/elements/gsttypefindelement.c	2015-03-09 14:25:12.575549401 +0000
+@@ -97,7 +97,7 @@ GST_STATIC_PAD_TEMPLATE ("src",
+ 
+ /* Require at least 2kB of data before we attempt typefinding in chain-mode.
+  * 128kB is massive overkill for the maximum, but doesn't do any harm */
+-#define TYPE_FIND_MIN_SIZE   (2*1024)
++#define TYPE_FIND_MIN_SIZE   (1*1024)
+ #define TYPE_FIND_MAX_SIZE (128*1024)
+ 
+ /* TypeFind signals and args */

--- a/recipes-multimedia/gstreamer/gstreamer1.0-1.10.4/0002-small-robustness-fixes.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-1.10.4/0002-small-robustness-fixes.patch
@@ -1,0 +1,26 @@
+diff -ur gstreamer1-1.8.2.orig/libs/gst/base/gstadapter.c gstreamer1-1.8.2/libs/gst/base/gstadapter.c
+--- gstreamer1-1.8.2.orig/libs/gst/base/gstadapter.c    2016-07-20 15:11:37.927290574 +0200
++++ gstreamer1-1.8.2/libs/gst/base/gstadapter.c 2016-07-20 15:12:14.779876077 +0200
+@@ -198,7 +198,10 @@
+ {
+   GstAdapter *adapter = GST_ADAPTER (object);
+ 
+-  g_free (adapter->assembled_data);
++  if (adapter->assembled_size) {
++    g_free (adapter->assembled_data);
++    adapter->assembled_size = NULL;
++  }
+ 
+   GST_CALL_PARENT (G_OBJECT_CLASS, finalize, (object));
+ }
+diff -ur gstreamer1-1.8.2.orig/gst/gststructure.c gstreamer1-1.8.2/gst/gststructure.c
+--- gstreamer1-1.8.2.orig/gst/gststructure.c    2016-07-20 15:11:37.743287650 +0200
++++ gstreamer1-1.8.2/gst/gststructure.c 2016-07-20 16:09:22.750655245 +0200
+@@ -373,6 +373,7 @@
+   guint i, len;
+ 
+   g_return_if_fail (structure != NULL);
++  g_return_if_fail (GST_IS_STRUCTURE (structure));
+   g_return_if_fail (GST_STRUCTURE_REFCOUNT (structure) == NULL);
+ 
+   len = GST_STRUCTURE_FIELDS (structure)->len;

--- a/recipes-multimedia/gstreamer/gstreamer1.0-1.10.4/0003-protection-added-function-to-filter-system-ids.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-1.10.4/0003-protection-added-function-to-filter-system-ids.patch
@@ -1,0 +1,131 @@
+From 3d47e56f985d6f516211aad2d704a49fc6a6425b Mon Sep 17 00:00:00 2001
+From: Xabier Rodriguez Calvar <calvaris@igalia.com>
+Date: Wed, 28 Jun 2017 09:54:56 +0200
+Subject: [PATCH] protection: added function to filter system ids
+
+gst_protection_filter_systems_by_available_decryptors takes an array of
+strings and returns a new array of strings filtered by the avaible
+decryptors for them so the ones you get are the ones that you should be
+able to decrypt.
+
+https://bugzilla.gnome.org/show_bug.cgi?id=770107
+
+[eocanha@igalia.com: applied Tim's review suggestions]
+---
+ docs/gst/gstreamer-sections.txt |  1 +
+ gst/gstprotection.c             | 60 +++++++++++++++++++++++++++++++++++++++++
+ gst/gstprotection.h             |  4 +++
+ win32/common/libgstreamer.def   |  1 +
+ 4 files changed, 66 insertions(+)
+
+diff --git a/docs/gst/gstreamer-sections.txt b/docs/gst/gstreamer-sections.txt
+index 93480cc1b..a32bbf21e 100644
+--- a/docs/gst/gstreamer-sections.txt
++++ b/docs/gst/gstreamer-sections.txt
+@@ -2461,6 +2461,7 @@ GstProtectionMeta
+ gst_buffer_add_protection_meta
+ gst_buffer_get_protection_meta
+ gst_protection_select_system
++gst_protection_filter_systems_by_available_decryptors
+ GST_PROTECTION_SYSTEM_ID_CAPS_FIELD
+ <SUBSECTION Standard>
+ GST_PROTECTION_META_API_TYPE
+diff --git a/gst/gstprotection.c b/gst/gstprotection.c
+index bc9df013a..54f415b9c 100644
+--- a/gst/gstprotection.c
++++ b/gst/gstprotection.c
+@@ -193,6 +193,66 @@ gst_protection_select_system (const gchar ** system_identifiers)
+   return retval;
+ }
+ 
++/**
++ * gst_protection_filter_systems_by_available_decryptors:
++ * @system_identifiers: (transfer none): A null terminated array of strings
++ * that contains the UUID values of each protection system that is to be
++ * checked.
++ *
++ * Iterates the supplied list of UUIDs and checks the GstRegistry for
++ * all the decryptors supporting one of the supplied UUIDs.
++ *
++ * Returns: (transfer full): A null terminated array containing all the
++ * @system_identifiers supported by the set of available decryptors.
++ *
++ * Since: 1.14
++ */
++gchar **
++gst_protection_filter_systems_by_available_decryptors (const gchar **
++    system_identifiers)
++{
++  GList *decryptors, *walk;
++  gchar **retval;
++  guint i = 0, decryptors_number;
++
++  decryptors =
++      gst_element_factory_list_get_elements (GST_ELEMENT_FACTORY_TYPE_DECRYPTOR,
++      GST_RANK_MARGINAL);
++
++  decryptors_number = g_list_length (decryptors);
++
++  if (decryptors_number == 0) {
++    return NULL;
++  }
++
++  retval = g_new (gchar *, decryptors_number + 1);
++
++  GST_TRACE ("found %u decrytors", decryptors_number);
++
++  for (walk = decryptors; walk; walk = g_list_next (walk)) {
++    GstElementFactory *fact = (GstElementFactory *) walk->data;
++    const char *found_sys_id =
++        gst_protection_factory_check (fact, system_identifiers);
++
++    GST_DEBUG ("factory %s is valid for %s", GST_OBJECT_NAME (fact),
++        found_sys_id);
++
++    if (found_sys_id) {
++      retval[i++] = g_strdup (found_sys_id);
++    }
++  }
++  retval[i] = NULL;
++
++  if (retval[0] == NULL) {
++    g_free (retval);
++    retval = NULL;
++  }
++
++  gst_plugin_feature_list_free (decryptors);
++
++  return retval;
++}
++
+ static const gchar *
+ gst_protection_factory_check (GstElementFactory * fact,
+     const gchar ** system_identifiers)
+diff --git a/gst/gstprotection.h b/gst/gstprotection.h
+index 39b83c700..b9bcd3f75 100644
+--- a/gst/gstprotection.h
++++ b/gst/gstprotection.h
+@@ -71,5 +71,9 @@ GstProtectionMeta * gst_buffer_add_protection_meta (GstBuffer * buffer,
+ GST_EXPORT
+ const gchar * gst_protection_select_system (const gchar ** system_identifiers);
+ 
++GST_EXPORT
++gchar ** gst_protection_filter_systems_by_available_decryptors (
++    const gchar ** system_identifiers);
++
+ G_END_DECLS
+ #endif /* __GST_PROTECTION_META_H__ */
+diff --git a/win32/common/libgstreamer.def b/win32/common/libgstreamer.def
+index 510d2151a..9578c4fd5 100644
+--- a/win32/common/libgstreamer.def
++++ b/win32/common/libgstreamer.def
+@@ -1078,6 +1078,7 @@ EXPORTS
+ 	gst_printerrln
+ 	gst_println
+ 	gst_progress_type_get_type
++	gst_protection_filter_systems_by_available_decryptors
+ 	gst_protection_meta_api_get_type
+ 	gst_protection_meta_get_info
+ 	gst_protection_select_system
+-- 
+2.11.0

--- a/recipes-multimedia/gstreamer/gstreamer1.0-1.10.4/0004-protection-Add-a-new-definition-for-unspecified-syst.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-1.10.4/0004-protection-Add-a-new-definition-for-unspecified-syst.patch
@@ -1,0 +1,66 @@
+From 05a3da347b3b8dbaf470793dc3f9ebb23e6fc67f Mon Sep 17 00:00:00 2001
+From: Yacine Bandou <yacine.bandou@softathome.com>
+Date: Mon, 1 Oct 2018 12:11:47 +0200
+Subject: [PATCH 1/2] protection: Add a new definition for unspecified system
+ protection
+
+In some cases the system protection ID is not present in the contents
+or in their metadata.
+This define is used to set the value of the "system_id" field in GstProtectionEvent,
+with this value, the application will use an external information to choose which
+protection system to use.
+
+Example: The matroskademux uses this value in the case of encrypted WebM,
+the application will choose the appropriate protection system based on the information
+received through EME API.
+
+https://bugzilla.gnome.org/show_bug.cgi?id=797231
+---
+ docs/gst/gstreamer-sections.txt |  1 +
+ gst/gstprotection.h             | 18 ++++++++++++++++++
+ 2 files changed, 19 insertions(+)
+
+diff --git a/docs/gst/gstreamer-sections.txt b/docs/gst/gstreamer-sections.txt
+index 492c4d592..ecc6b04e5 100644
+--- a/docs/gst/gstreamer-sections.txt
++++ b/docs/gst/gstreamer-sections.txt
+@@ -2506,6 +2506,7 @@ gst_buffer_get_protection_meta
+ gst_protection_select_system
+ gst_protection_filter_systems_by_available_decryptors
+ GST_PROTECTION_SYSTEM_ID_CAPS_FIELD
++GST_PROTECTION_UNSPECIFIED_SYSTEM_ID
+ <SUBSECTION Standard>
+ GST_PROTECTION_META_API_TYPE
+ GST_PROTECTION_META_INFO
+diff --git a/gst/gstprotection.h b/gst/gstprotection.h
+index a7669eab3..0ed87e427 100644
+--- a/gst/gstprotection.h
++++ b/gst/gstprotection.h
+@@ -34,6 +34,24 @@ G_BEGIN_DECLS
+  */
+ #define GST_PROTECTION_SYSTEM_ID_CAPS_FIELD "protection-system"
+ 
++/**
++ * GST_PROTECTION_UNSPECIFIED_SYSTEM_ID:
++ *
++ * The protection system value of the unspecified UUID.
++ * In some cases the system protection ID is not present in the contents or in their
++ * metadata, as encrypted WebM.
++ * This define is used to set the value of the "system_id" field in GstProtectionEvent,
++ * with this value, the application will use an external information to choose which
++ * protection system to use.
++ *
++ * Example: The matroskademux uses this value in the case of encrypted WebM,
++ * the application will choose the appropriate protection system based on the information
++ * received through EME API.
++ *
++ * Since: 1.16
++ */
++#define GST_PROTECTION_UNSPECIFIED_SYSTEM_ID "unspecified.gstreamer.org"
++
+ typedef struct _GstProtectionMeta GstProtectionMeta;
+ /**
+  * GstProtectionMeta:
+-- 
+2.15.0
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-1.10.4/0005-protection-Fix-the-string-to-define-unspecified-syst.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-1.10.4/0005-protection-Fix-the-string-to-define-unspecified-syst.patch
@@ -1,0 +1,27 @@
+From b89b1802df44829a0c034db5807bc893ad3c7774 Mon Sep 17 00:00:00 2001
+From: Thibault Saunier <tsaunier@igalia.com>
+Date: Wed, 3 Oct 2018 18:23:01 +0200
+Subject: [PATCH 2/2] protection: Fix the string to define unspecified system
+ id
+
+Setting it to "unspecified-system-id".
+---
+ gst/gstprotection.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gst/gstprotection.h b/gst/gstprotection.h
+index 0ed87e427..f77a7bf97 100644
+--- a/gst/gstprotection.h
++++ b/gst/gstprotection.h
+@@ -50,7 +50,7 @@ G_BEGIN_DECLS
+  *
+  * Since: 1.16
+  */
+-#define GST_PROTECTION_UNSPECIFIED_SYSTEM_ID "unspecified.gstreamer.org"
++#define GST_PROTECTION_UNSPECIFIED_SYSTEM_ID "unspecified-system-id"
+ 
+ typedef struct _GstProtectionMeta GstProtectionMeta;
+ /**
+-- 
+2.15.0
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-omx-1.10.4/0001-Don-t-try-to-acquire-buffer-when-src-pad-isn-t-activ.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-omx-1.10.4/0001-Don-t-try-to-acquire-buffer-when-src-pad-isn-t-activ.patch
@@ -1,0 +1,48 @@
+From 2e111e52f96f0b942abda120c30a876629bd73fc Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Enrique=20Oca=C3=B1a=20Gonz=C3=A1lez?= <eocanha@igalia.com>
+Date: Mon, 25 May 2015 14:53:35 +0200
+Subject: [PATCH] Don't try to acquire buffer when src pad isn't active
+
+This solves a race condition when setting the pipeline from PAUSE to
+NULL while the decoder loop is still running. Without this patch, the
+thread which interacts with the decode sink pad gets blocked here:
+
+  gst_element_change_state()
+  gst_element_change_state_func()
+  gst_element_pads_activate() --> Deactivating pads
+  activate_pads()
+  gst_pad_set_active()
+  gst_pad_activate_mode()
+  post_activate()
+  GST_PAD_STREAM_LOCK()
+
+while gst_omx_port_acquire_buffer() gets stalled forever in
+gst_omx_component_wait_message() waiting for a message that will never
+arrive:
+
+  gst_omx_video_dec_loop()
+  gst_omx_port_acquire_buffer()
+  gst_omx_component_wait_message()
+---
+ omx/gstomxvideodec.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/omx/gstomxvideodec.c b/omx/gstomxvideodec.c
+index cd24944..57a61dd 100644
+--- a/omx/gstomxvideodec.c
++++ b/omx/gstomxvideodec.c
+@@ -1247,6 +1247,11 @@ gst_omx_video_dec_loop (GstOMXVideoDec * self)
+   GstClockTimeDiff deadline;
+   OMX_ERRORTYPE err;
+ 
++  if (!gst_pad_is_active(GST_VIDEO_DECODER_SRC_PAD (self))) {
++    GST_DEBUG_OBJECT (self, "Src pad not active, not acquiring buffer and flushing instead");
++      goto flushing;
++  }
++
+ #if defined (USE_OMX_TARGET_RPI) && defined (HAVE_GST_GL)
+   port = self->eglimage ? self->egl_out_port : self->dec_out_port;
+ #else
+-- 
+1.8.3.2
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-omx-1.10.4/0002-fix-decoder-flushing.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-omx-1.10.4/0002-fix-decoder-flushing.patch
@@ -1,0 +1,16 @@
+diff --git a/omx/gstomx.c b/omx/gstomx.c
+index 69696c4..c382019 100644
+--- a/omx/gstomx.c
++++ b/omx/gstomx.c
+@@ -1508,8 +1508,8 @@ gst_omx_port_set_flushing (GstOMXPort * port, GstClockTime timeout,
+     last_error = OMX_ErrorNone;
+     gst_omx_component_handle_messages (comp);
+     while (signalled && last_error == OMX_ErrorNone && !port->flushed
+-        && port->buffers
+-        && port->buffers->len > g_queue_get_length (&port->pending_buffers)) {
++     /* && port->buffers
++        && port->buffers->len > g_queue_get_length (&port->pending_buffers) */) {
+       signalled = gst_omx_component_wait_message (comp, timeout);
+       if (signalled)
+         gst_omx_component_handle_messages (comp);
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-omx-1.10.4/0003-no-timeout-on-get-state.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-omx-1.10.4/0003-no-timeout-on-get-state.patch
@@ -1,0 +1,16 @@
+diff --git a/omx/gstomxvideodec.c b/omx/gstomxvideodec.c
+index 0d4e7a1..a0d9c74 100644
+--- a/omx/gstomxvideodec.c
++++ b/omx/gstomxvideodec.c
+@@ -1697,9 +1697,9 @@ gst_omx_video_dec_stop (GstVideoDecoder * decoder)
+   g_cond_broadcast (&self->drain_cond);
+   g_mutex_unlock (&self->drain_lock);
+ 
+-  gst_omx_component_get_state (self->dec, 5 * GST_SECOND);
++  gst_omx_component_get_state (self->dec, 0);
+ #if defined (USE_OMX_TARGET_RPI) && defined (HAVE_GST_GL)
+-  gst_omx_component_get_state (self->egl_render, 1 * GST_SECOND);
++  gst_omx_component_get_state (self->egl_render, 0);
+ #endif
+ 
+   gst_buffer_replace (&self->codec_data, NULL);

--- a/recipes-multimedia/gstreamer/gstreamer1.0-omx-1.10.4/0005-Don-t-abort-gst_omx_video_dec_set_format-if-there-s-.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-omx-1.10.4/0005-Don-t-abort-gst_omx_video_dec_set_format-if-there-s-.patch
@@ -1,0 +1,30 @@
+From 12103842d5f347cf245e71071d0c44297bcdb1f9 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Enrique=20Oca=C3=B1a=20Gonz=C3=A1lez?= <eocanha@igalia.com>
+Date: Fri, 4 Dec 2015 18:39:59 +0100
+Subject: [PATCH] Don't abort gst_omx_video_dec_set_format() if there's a
+ timeout releasing the buffers taken by the egl_render out port
+
+---
+ omx/gstomxvideodec.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/omx/gstomxvideodec.c b/omx/gstomxvideodec.c
+index 2368f34..da35e0d 100644
+--- a/omx/gstomxvideodec.c
++++ b/omx/gstomxvideodec.c
+@@ -1905,8 +1905,11 @@ gst_omx_video_dec_set_format (GstVideoDecoder * decoder,
+               5 * GST_SECOND) != OMX_ErrorNone)
+         return FALSE;
+       if (gst_omx_port_wait_buffers_released (out_port,
+-              1 * GST_SECOND) != OMX_ErrorNone)
++              1 * GST_SECOND) != OMX_ErrorNone) {
++#if !(defined (USE_OMX_TARGET_RPI) && defined (HAVE_GST_GL))
+         return FALSE;
++#endif
++      }
+       if (gst_omx_port_deallocate_buffers (self->dec_in_port) != OMX_ErrorNone)
+         return FALSE;
+       if (gst_omx_video_dec_deallocate_output_buffers (self) != OMX_ErrorNone)
+-- 
+2.1.4
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-omx-1.10.4/0006-omxvideodec-fix-deadlock-on-downstream-EOS.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-omx-1.10.4/0006-omxvideodec-fix-deadlock-on-downstream-EOS.patch
@@ -1,0 +1,31 @@
+From 50751075eaa745f82526b15832af1957ea1a7379 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Enrique=20Oca=C3=B1a=20Gonz=C3=A1lez?= <eocanha@igalia.com>
+Date: Tue, 4 Dec 2018 11:59:17 +0000
+Subject: [PATCH] omxvideodec: fix deadlock on downstream EOS
+
+Wake the _drain condition when downstream signals GST_FLOW_EOS to
+prevent the upstream streaming thread to keep waiting forever.
+
+This scenario can be triggered when seeking near EOS.
+---
+ omx/gstomxvideodec.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/omx/gstomxvideodec.c b/omx/gstomxvideodec.c
+index 6034d53..c8af722 100644
+--- a/omx/gstomxvideodec.c
++++ b/omx/gstomxvideodec.c
+@@ -1598,6 +1598,10 @@ flow_error:
+           gst_event_new_eos ());
+       gst_pad_pause_task (GST_VIDEO_DECODER_SRC_PAD (self));
+       self->started = FALSE;
++      if (self->draining) {
++        self->draining = FALSE;
++        g_cond_broadcast (&self->drain_cond);
++      }
+     } else if (flow_ret < GST_FLOW_EOS) {
+       GST_ELEMENT_ERROR (self, STREAM, FAILED,
+           ("Internal data stream error."), ("stream stopped, reason %s",
+-- 
+2.17.0
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-omx.inc
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-omx.inc
@@ -1,0 +1,50 @@
+SUMMARY = "OpenMAX IL plugins for GStreamer"
+HOMEPAGE = "http://gstreamer.freedesktop.org/"
+SECTION = "multimedia"
+
+LICENSE = "LGPLv2.1"
+LICENSE_FLAGS = "commercial"
+
+DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-bad"
+
+inherit autotools pkgconfig gettext gtk-doc upstream-version-is-even
+
+acpaths = "-I ${S}/common/m4 -I ${S}/m4"
+
+# RPI specific
+GSTREAMER_1_0_OMX_TARGET_rpi = "rpi"
+GSTREAMER_1_0_OMX_CORE_NAME_rpi = "${libdir}/libopenmaxil.so"
+
+EXTRA_OECONF_append_rpi  = ' CFLAGS="$CFLAGS -I${STAGING_DIR_TARGET}/usr/include/IL -I${STAGING_DIR_TARGET}/usr/include/interface/vcos/pthreads -I${STAGING_DIR_TARGET}/usr/include/interface/vmcs_host/linux"'
+EXTRA_OECONF_append_rpi = " --disable-examples"
+
+# -------------
+
+GSTREAMER_1_0_OMX_TARGET ?= "bellagio"
+GSTREAMER_1_0_OMX_CORE_NAME ?= "${libdir}/libomxil-bellagio.so.0"
+
+EXTRA_OECONF += "--disable-valgrind --with-omx-target=${GSTREAMER_1_0_OMX_TARGET}"
+
+python __anonymous () {
+    omx_target = d.getVar("GSTREAMER_1_0_OMX_TARGET", True)
+    if omx_target in ['generic', 'bellagio']:
+        # Bellagio headers are incomplete (they are missing the OMX_VERSION_MAJOR,#
+        # OMX_VERSION_MINOR, OMX_VERSION_REVISION, and OMX_VERSION_STEP macros);
+        # appending a directory path to gst-omx' internal OpenMAX IL headers fixes this
+        d.appendVar("CFLAGS", " -I${S}/omx/openmax")
+    elif omx_target == "rpi":
+        # Dedicated Raspberry Pi OpenMAX IL support makes this package machine specific
+        d.setVar("PACKAGE_ARCH", d.getVar("MACHINE_ARCH", True))
+}
+
+set_omx_core_name() {
+	sed -i -e "s;^core-name=.*;core-name=${GSTREAMER_1_0_OMX_CORE_NAME};" "${D}${sysconfdir}/xdg/gstomx.conf"
+}
+
+do_install[postfuncs] += " set_omx_core_name "
+
+FILES_${PN} += "${libdir}/gstreamer-1.0/*.so"
+FILES_${PN}-dev += "${libdir}/gstreamer-1.0/*.la"
+FILES_${PN}-staticdev += "${libdir}/gstreamer-1.0/*.a"
+
+RDEPENDS_${PN} = "libomxil"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-omx.inc
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-omx.inc
@@ -1,11 +1,13 @@
 SUMMARY = "OpenMAX IL plugins for GStreamer"
+DESCRIPTION = "GStreamer OpenMAX IL wrapper plugin. This plugin wraps available \
+OpenMAX IL components and makes them available as standard GStreamer elements."
 HOMEPAGE = "http://gstreamer.freedesktop.org/"
 SECTION = "multimedia"
 
 LICENSE = "LGPLv2.1"
 LICENSE_FLAGS = "commercial"
 
-DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-bad"
+DEPENDS_append = " gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-bad"
 
 inherit autotools pkgconfig gettext gtk-doc upstream-version-is-even
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-omx_1.10.4.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-omx_1.10.4.bb
@@ -1,14 +1,17 @@
 include gstreamer1.0-omx.inc
 
-LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c \
-                    file://omx/gstomx.h;beginline=1;endline=21;md5=5c8e1fca32704488e76d2ba9ddfa935f"
+LIC_FILES_CHKSUM = "\
+    file://COPYING;md5=4fbd65380cdd255951079008b364516c \
+    file://omx/gstomx.h;beginline=1;endline=21;md5=5c8e1fca32704488e76d2ba9ddfa935f \
+"
 
-SRC_URI = "http://gstreamer.freedesktop.org/src/gst-omx/gst-omx-${PV}.tar.xz \
-		  file://0001-Don-t-try-to-acquire-buffer-when-src-pad-isn-t-activ.patch \
-		  file://0002-fix-decoder-flushing.patch \
-		  file://0003-no-timeout-on-get-state.patch \
-		  file://0005-Don-t-abort-gst_omx_video_dec_set_format-if-there-s-.patch \
-		  file://0006-omxvideodec-fix-deadlock-on-downstream-EOS.patch \
+SRC_URI = "\
+    http://gstreamer.freedesktop.org/src/gst-omx/gst-omx-${PV}.tar.xz \
+    file://0001-Don-t-try-to-acquire-buffer-when-src-pad-isn-t-activ.patch \
+    file://0002-fix-decoder-flushing.patch \
+    file://0003-no-timeout-on-get-state.patch \
+    file://0005-Don-t-abort-gst_omx_video_dec_set_format-if-there-s-.patch \
+    file://0006-omxvideodec-fix-deadlock-on-downstream-EOS.patch \
 "
 
 SRC_URI[md5sum] = "cedb230f1c47d0cf4b575d70dff66ff2"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-omx_1.10.4.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-omx_1.10.4.bb
@@ -1,0 +1,17 @@
+include gstreamer1.0-omx.inc
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c \
+                    file://omx/gstomx.h;beginline=1;endline=21;md5=5c8e1fca32704488e76d2ba9ddfa935f"
+
+SRC_URI = "http://gstreamer.freedesktop.org/src/gst-omx/gst-omx-${PV}.tar.xz \
+		  file://0001-Don-t-try-to-acquire-buffer-when-src-pad-isn-t-activ.patch \
+		  file://0002-fix-decoder-flushing.patch \
+		  file://0003-no-timeout-on-get-state.patch \
+		  file://0005-Don-t-abort-gst_omx_video_dec_set_format-if-there-s-.patch \
+		  file://0006-omxvideodec-fix-deadlock-on-downstream-EOS.patch \
+"
+
+SRC_URI[md5sum] = "cedb230f1c47d0cf4b575d70dff66ff2"
+SRC_URI[sha256sum] = "45072925cf262f0fd528fab78f0de52734e46a5a88aa802fae51c67c09c81aa2"
+
+S = "${WORKDIR}/gst-omx-${PV}"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-omx_1.16.%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-omx_1.16.%.bbappend
@@ -4,7 +4,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/gstreamer1.0-omx-1.16:"
 SRC_URI_remove = "file://0004-Properly-handle-drain-requests-while-flushing.patch"
 SRC_URI_remove = "file://0005-Don-t-abort-gst_omx_video_dec_set_format-if-there-s-.patch"
 
-SRC_URI_append = "\
+SRC_URI_append = " \
     file://0003-omxvideodec-fix-deadlock-on-downstream-EOS.patch \
     file://0004-Enable-video-decoder-when-the-output-buffer-pool-is-.patch \
     file://0005-Manual-revert-of-0603e44-omxvideodec-enc-delay-alloc.patch \

--- a/recipes-multimedia/gstreamer/gstreamer1.0-omx_1.16.%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-omx_1.16.%.bbappend
@@ -4,7 +4,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/gstreamer1.0-omx-1.16:"
 SRC_URI_remove = "file://0004-Properly-handle-drain-requests-while-flushing.patch"
 SRC_URI_remove = "file://0005-Don-t-abort-gst_omx_video_dec_set_format-if-there-s-.patch"
 
-SRC_URI += "\
+SRC_URI_append = "\
     file://0003-omxvideodec-fix-deadlock-on-downstream-EOS.patch \
     file://0004-Enable-video-decoder-when-the-output-buffer-pool-is-.patch \
     file://0005-Manual-revert-of-0603e44-omxvideodec-enc-delay-alloc.patch \

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad.inc
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad.inc
@@ -2,7 +2,7 @@ require gstreamer1.0-plugins.inc
 
 LICENSE = "GPLv2+ & LGPLv2+ & LGPLv2.1+"
 
-DEPENDS += "gstreamer1.0-plugins-base libpng jpeg"
+DEPENDS_append = " gstreamer1.0-plugins-base libpng jpeg"
 
 inherit gettext bluetooth
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad.inc
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad.inc
@@ -1,0 +1,165 @@
+require gstreamer1.0-plugins.inc
+
+LICENSE = "GPLv2+ & LGPLv2+ & LGPLv2.1+"
+
+DEPENDS += "gstreamer1.0-plugins-base libpng jpeg"
+
+inherit gettext bluetooth
+
+SRC_URI_append = " \
+    file://0001-Makefile.am-don-t-hardcode-libtool-name-when-running.patch \
+"
+
+# opengl packageconfig factored out to make it easy for distros
+# and BSP layers to pick either (desktop) opengl, gles2, or no GL
+PACKAGECONFIG_GL ?= "${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'gles2 egl', '', d)}"
+
+# gtk is not in the PACKAGECONFIG variable by default until
+# the transition to gtk+3 is finished
+PACKAGECONFIG ??= " \
+    ${GSTREAMER_ORC} \
+    ${PACKAGECONFIG_GL} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'bluez', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'directfb', 'directfb', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'egl', '', d)} \
+    bz2 curl dash dtls hls neon rsvg sbc smoothstreaming sndfile uvch264 webp \
+    opusparse \
+    hls libmms faad \
+"
+
+PACKAGECONFIG_append_rpi = " zzrpiextras"
+PACKAGECONFIG[zzrpiextras] = "--enable-gles2 --enable-egl --enable-gl --enable-dispmanx,,virtual/libgles2 virtual/egl"
+
+PACKAGECONFIG[assrender]       = "--enable-assrender,--disable-assrender,libass"
+PACKAGECONFIG[bluez]           = "--enable-bluez,--disable-bluez,${BLUEZ}"
+PACKAGECONFIG[bz2]             = "--enable-bz2,--disable-bz2,bzip2"
+PACKAGECONFIG[curl]            = "--enable-curl,--disable-curl,curl"
+PACKAGECONFIG[dash]            = "--enable-dash,--disable-dash,libxml2"
+PACKAGECONFIG[dc1394]          = "--enable-dc1394,--disable-dc1394,libdc1394"
+PACKAGECONFIG[directfb]        = "--enable-directfb,--disable-directfb,directfb"
+PACKAGECONFIG[dtls]            = "--enable-dtls,--disable-dtls,openssl"
+PACKAGECONFIG[egl]             = "--enable-egl,--disable-egl,virtual/egl"
+PACKAGECONFIG[faac]            = "--enable-faac,--disable-faac,faac"
+PACKAGECONFIG[faad]            = "--enable-faad,--disable-faad,faad2"
+PACKAGECONFIG[flite]           = "--enable-flite,--disable-flite,flite-alsa"
+PACKAGECONFIG[fluidsynth]      = "--enable-fluidsynth,--disable-fluidsynth,fluidsynth"
+PACKAGECONFIG[gles2]           = "--enable-gles2,--disable-gles2,virtual/libgles2"
+PACKAGECONFIG[gtk]             = "--enable-gtk3,--disable-gtk3,gtk+3"
+# ensure OpenSSL is used for HLS AES description instead of nettle
+# (OpenSSL is a shared dependency with dtls)
+PACKAGECONFIG[hls]             = "--enable-hls --with-hls-crypto=openssl,--disable-hls,openssl"
+PACKAGECONFIG[kms]             = "--enable-kms,--disable-kms,libdrm"
+PACKAGECONFIG[libmms]          = "--enable-libmms,--disable-libmms,libmms"
+PACKAGECONFIG[libssh2]         = "--enable-libssh2,--disable-libssh2,libssh2"
+PACKAGECONFIG[modplug]         = "--enable-modplug,--disable-modplug,libmodplug"
+PACKAGECONFIG[neon]            = "--enable-neon,--disable-neon,neon"
+PACKAGECONFIG[openal]          = "--enable-openal,--disable-openal,openal-soft"
+PACKAGECONFIG[opencv]          = "--enable-opencv,--disable-opencv,opencv"
+PACKAGECONFIG[opengl]          = "--enable-opengl,--disable-opengl,virtual/libgl libglu"
+PACKAGECONFIG[openjpeg]        = "--enable-openjpeg,--disable-openjpeg,openjpeg"
+# the opus encoder/decoder elements are now in the -base package,
+# but the opus parser remains in -bad
+PACKAGECONFIG[opusparse]       = "--enable-opus,--disable-opus,libopus"
+PACKAGECONFIG[resindvd]        = "--enable-resindvd,--disable-resindvd,libdvdread libdvdnav"
+PACKAGECONFIG[rsvg]            = "--enable-rsvg,--disable-rsvg,librsvg"
+PACKAGECONFIG[rtmp]            = "--enable-rtmp,--disable-rtmp,rtmpdump"
+PACKAGECONFIG[sbc]             = "--enable-sbc,--disable-sbc,sbc"
+PACKAGECONFIG[schroedinger]    = "--enable-schro,--disable-schro,schroedinger"
+PACKAGECONFIG[smoothstreaming] = "--enable-smoothstreaming,--disable-smoothstreaming,libxml2"
+PACKAGECONFIG[sndfile]         = "--enable-sndfile,--disable-sndfile,libsndfile1"
+PACKAGECONFIG[srtp]            = "--enable-srtp,--disable-srtp,libsrtp"
+PACKAGECONFIG[uvch264]         = "--enable-uvch264,--disable-uvch264,libusb1 libgudev"
+PACKAGECONFIG[voaacenc]        = "--enable-voaacenc,--disable-voaacenc,vo-aacenc"
+PACKAGECONFIG[voamrwbenc]      = "--enable-voamrwbenc,--disable-voamrwbenc,vo-amrwbenc"
+PACKAGECONFIG[wayland]         = "--enable-wayland,--disable-wayland,wayland-native wayland wayland-protocols"
+PACKAGECONFIG[webp]            = "--enable-webp,--disable-webp,libwebp"
+
+# these plugins have not been ported to 1.0 (yet):
+#   apexsink linsys nas timidity sdl xvid wininet
+#   sndio cdxaparse dccp faceoverlay hdvparse tta mve nuvdemux
+#   patchdetect sdi videomeasure
+
+# these plugins have no corresponding library in OE-core or meta-openembedded:
+#   openni2 winks direct3d directsound winscreencap acm apple_media
+#   android_media avc bs2b chromaprint daala dts fdkaac gme gsm kate ladspa libde265
+#   lv2 mimic mpeg2enc mplex musepack nvenc ofa openh264 opensles pvr soundtouch spandsp
+#   spc teletextdec tinyalsa vdpau vulkan wasapi x265 zbar
+
+# qt5 support is disabled, because it is not present in OE core, and requires more work than
+# just adding a packageconfig (it requires access to moc, uic, rcc, and qmake paths).
+# This is better done in a separate qt5 layer (which then should add a "qt5" packageconfig
+# in a gstreamer1.0-plugins-bad bbappend).
+
+EXTRA_OECONF += " \
+    --enable-decklink \
+    --enable-dvb \
+    --enable-fbdev \
+    --enable-netsim \
+    --enable-shm \
+    --enable-vcd \
+    --enable-introspection=no \
+    --disable-acm \
+    --disable-android_media \
+    --disable-apexsink \
+    --disable-apple_media \
+    --disable-avc \
+    --disable-bs2b \
+    --disable-chromaprint \
+    --disable-cocoa \
+    --disable-daala \
+    --disable-direct3d \
+    --disable-directsound \
+    --disable-dts \
+    --disable-fdk_aac \
+    --disable-gme \
+    --disable-gsm \
+    --disable-kate \
+    --disable-ladspa \
+    --disable-libde265 \
+    --disable-libvisual \
+    --disable-linsys \
+    --disable-lv2 \
+    --disable-mimic \
+    --disable-mpeg2enc \
+    --disable-mplex \
+    --disable-musepack \
+    --disable-nas \
+    --disable-nvenc \
+    --disable-ofa \
+    --disable-openexr \
+    --disable-openh264 \
+    --disable-openni2 \
+    --disable-opensles \
+    --disable-pvr \
+    --disable-qt \
+    --disable-sdl \
+    --disable-sdltest \
+    --disable-sndio \
+    --disable-soundtouch \
+    --disable-spandsp \
+    --disable-spc \
+    --disable-teletextdec \
+    --disable-timidity \
+    --disable-tinyalsa \
+    --disable-vdpau \
+    --disable-vulkan \
+    --disable-wasapi \
+    --disable-wildmidi \
+    --disable-wininet \
+    --disable-winks \
+    --disable-winscreencap \
+    --disable-x265 \
+    --disable-xvid \
+    --disable-zbar \
+    ${@bb.utils.contains("TUNE_FEATURES", "mx32", "--disable-yadif", "", d)} \
+"
+
+export OPENCV_PREFIX = "${STAGING_DIR_TARGET}${prefix}"
+
+ARM_INSTRUCTION_SET_armv4 = "arm"
+ARM_INSTRUCTION_SET_armv5 = "arm"
+
+FILES_${PN}-dev += "${libdir}/gstreamer-${LIBV}/include/gst/gl/gstglconfig.h"
+FILES_${PN}-freeverb += "${datadir}/gstreamer-${LIBV}/presets/GstFreeverb.prs"
+FILES_${PN}-opencv += "${datadir}/gst-plugins-bad/${LIBV}/opencv*"
+FILES_${PN}-voamrwbenc += "${datadir}/gstreamer-${LIBV}/presets/GstVoAmrwbEnc.prs"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0001-Makefile.am-don-t-hardcode-libtool-name-when-running.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0001-Makefile.am-don-t-hardcode-libtool-name-when-running.patch
@@ -1,0 +1,54 @@
+From cff6fbf555a072408c21da1e818209c9d3814dd3 Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Tue, 27 Oct 2015 14:36:58 +0200
+Subject: [PATCH] Makefile.am: don't hardcode libtool name when running
+ introspection tools
+
+Upstream-Status: Pending [review on oe-core list]
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+
+---
+ gst-libs/gst/gl/Makefile.am        | 2 +-
+ gst-libs/gst/insertbin/Makefile.am | 2 +-
+ gst-libs/gst/mpegts/Makefile.am    | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+Index: gst-plugins-bad-1.10.1/gst-libs/gst/gl/Makefile.am
+===================================================================
+--- gst-plugins-bad-1.10.1.orig/gst-libs/gst/gl/Makefile.am
++++ gst-plugins-bad-1.10.1/gst-libs/gst/gl/Makefile.am
+@@ -171,7 +171,7 @@ GstGL-@GST_API_VERSION@.gir: $(INTROSPEC
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstBase-@GST_API_VERSION@ \
+ 		--include=GstVideo-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg gstreamer-base-@GST_API_VERSION@ \
+ 		--pkg gstreamer-video-@GST_API_VERSION@ \
+Index: gst-plugins-bad-1.10.1/gst-libs/gst/insertbin/Makefile.am
+===================================================================
+--- gst-plugins-bad-1.10.1.orig/gst-libs/gst/insertbin/Makefile.am
++++ gst-plugins-bad-1.10.1/gst-libs/gst/insertbin/Makefile.am
+@@ -45,7 +45,7 @@ GstInsertBin-@GST_API_VERSION@.gir: $(IN
+ 		--library=libgstinsertbin-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstBase-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg gstreamer-base-@GST_API_VERSION@ \
+ 		--pkg-export gstreamer-insertbin-@GST_API_VERSION@ \
+Index: gst-plugins-bad-1.10.1/gst-libs/gst/mpegts/Makefile.am
+===================================================================
+--- gst-plugins-bad-1.10.1.orig/gst-libs/gst/mpegts/Makefile.am
++++ gst-plugins-bad-1.10.1/gst-libs/gst/mpegts/Makefile.am
+@@ -79,7 +79,7 @@ GstMpegts-@GST_API_VERSION@.gir: $(INTRO
+ 		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-video-@GST_API_VERSION@` \
+ 		--library=libgstmpegts-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg gstreamer-video-@GST_API_VERSION@ \
+ 		--pkg-export gstreamer-mpegts-@GST_API_VERSION@ \

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0001-mssdemux-improved-live-playback-support.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0001-mssdemux-improved-live-playback-support.patch
@@ -1,0 +1,893 @@
+From 12b9645c4c5b94ff4fd5062bdb02b63db7648db9 Mon Sep 17 00:00:00 2001
+From: Philippe Normand <philn@igalia.com>
+Date: Thu, 10 Sep 2015 16:13:30 +0200
+Subject: [PATCH 1/6] mssdemux: improved live playback support
+
+When a MSS server hosts a live stream the fragments listed in the
+manifest usually don't have accurate timestamps and duration, except
+for the first fragment, which additionally stores timing information
+for the few upcoming fragments. In this scenario it is useless to
+periodically fetch and update the manifest and the fragments list can
+be incrementally built by parsing the first/current fragment.
+
+https://bugzilla.gnome.org/show_bug.cgi?id=755036
+---
+ ext/smoothstreaming/Makefile.am               |   2 +
+ ext/smoothstreaming/gstmssdemux.c             |  61 ++++++
+ ext/smoothstreaming/gstmssfragmentparser.c    | 255 ++++++++++++++++++++++++++
+ ext/smoothstreaming/gstmssfragmentparser.h    |  84 +++++++++
+ ext/smoothstreaming/gstmssmanifest.c          | 155 ++++++++++++++--
+ ext/smoothstreaming/gstmssmanifest.h          |   3 +
+ gst-libs/gst/adaptivedemux/gstadaptivedemux.c |  28 ++-
+ gst-libs/gst/adaptivedemux/gstadaptivedemux.h |  14 ++
+ 8 files changed, 586 insertions(+), 16 deletions(-)
+ create mode 100644 ext/smoothstreaming/gstmssfragmentparser.c
+ create mode 100644 ext/smoothstreaming/gstmssfragmentparser.h
+
+diff --git a/ext/smoothstreaming/Makefile.am b/ext/smoothstreaming/Makefile.am
+index 4faf9df..a5e1ad6 100644
+--- a/ext/smoothstreaming/Makefile.am
++++ b/ext/smoothstreaming/Makefile.am
+@@ -13,8 +13,10 @@ libgstsmoothstreaming_la_LIBADD = \
+ libgstsmoothstreaming_la_LDFLAGS = ${GST_PLUGIN_LDFLAGS}
+ libgstsmoothstreaming_la_SOURCES = gstsmoothstreaming-plugin.c \
+ 	gstmssdemux.c \
++	gstmssfragmentparser.c \
+ 	gstmssmanifest.c
+ libgstsmoothstreaming_la_LIBTOOLFLAGS = --tag=disable-static
+ 
+ noinst_HEADERS = gstmssdemux.h \
++	gstmssfragmentparser.h \
+ 	gstmssmanifest.h
+diff --git a/ext/smoothstreaming/gstmssdemux.c b/ext/smoothstreaming/gstmssdemux.c
+index 9d0aece..70b541e 100644
+--- a/ext/smoothstreaming/gstmssdemux.c
++++ b/ext/smoothstreaming/gstmssdemux.c
+@@ -135,9 +135,16 @@ gst_mss_demux_stream_update_fragment_info (GstAdaptiveDemuxStream * stream);
+ static gboolean gst_mss_demux_seek (GstAdaptiveDemux * demux, GstEvent * seek);
+ static gint64
+ gst_mss_demux_get_manifest_update_interval (GstAdaptiveDemux * demux);
++static gint64
++gst_mss_demux_stream_get_fragment_waiting_time (GstAdaptiveDemuxStream *
++    stream);
+ static GstFlowReturn
+ gst_mss_demux_update_manifest_data (GstAdaptiveDemux * demux,
+     GstBuffer * buffer);
++static GstFlowReturn gst_mss_demux_data_received (GstAdaptiveDemux * demux,
++    GstAdaptiveDemuxStream * stream);
++static gboolean
++gst_mss_demux_requires_periodical_playlist_update (GstAdaptiveDemux * demux);
+ 
+ static void
+ gst_mss_demux_class_init (GstMssDemuxClass * klass)
+@@ -190,8 +197,13 @@ gst_mss_demux_class_init (GstMssDemuxClass * klass)
+       gst_mss_demux_stream_select_bitrate;
+   gstadaptivedemux_class->stream_update_fragment_info =
+       gst_mss_demux_stream_update_fragment_info;
++  gstadaptivedemux_class->stream_get_fragment_waiting_time =
++      gst_mss_demux_stream_get_fragment_waiting_time;
+   gstadaptivedemux_class->update_manifest_data =
+       gst_mss_demux_update_manifest_data;
++  gstadaptivedemux_class->data_received = gst_mss_demux_data_received;
++  gstadaptivedemux_class->requires_periodical_playlist_update =
++      gst_mss_demux_requires_periodical_playlist_update;
+ 
+   GST_DEBUG_CATEGORY_INIT (mssdemux_debug, "mssdemux", 0, "mssdemux plugin");
+ }
+@@ -648,6 +660,17 @@ gst_mss_demux_get_manifest_update_interval (GstAdaptiveDemux * demux)
+   return interval;
+ }
+ 
++static gint64
++gst_mss_demux_stream_get_fragment_waiting_time (GstAdaptiveDemuxStream * stream)
++{
++  GstMssDemuxStream *mssstream = (GstMssDemuxStream *) stream;
++  GstMssStreamType streamtype =
++      gst_mss_stream_get_type (mssstream->manifest_stream);
++
++  /* Wait a second for live audio streams so we don't try premature fragments downloading */
++  return streamtype == MSS_STREAM_TYPE_AUDIO ? GST_SECOND : 0;
++}
++
+ static GstFlowReturn
+ gst_mss_demux_update_manifest_data (GstAdaptiveDemux * demux,
+     GstBuffer * buffer)
+@@ -659,3 +682,41 @@ gst_mss_demux_update_manifest_data (GstAdaptiveDemux * demux,
+   gst_mss_manifest_reload_fragments (mssdemux->manifest, buffer);
+   return GST_FLOW_OK;
+ }
++
++
++static GstFlowReturn
++gst_mss_demux_data_received (GstAdaptiveDemux * demux,
++    GstAdaptiveDemuxStream * stream)
++{
++  GstMssDemux *mssdemux = GST_MSS_DEMUX_CAST (demux);
++  GstMssDemuxStream *mssstream = (GstMssDemuxStream *) stream;
++  gsize available;
++
++  if (!gst_mss_manifest_is_live (mssdemux->manifest)) {
++    return GST_ADAPTIVE_DEMUX_CLASS (parent_class)->data_received (demux,
++        stream);
++  }
++
++  if (gst_mss_stream_fragment_parsing_needed (mssstream->manifest_stream)) {
++    available = gst_adapter_available (stream->adapter);
++    // FIXME: try to reduce this minimal size.
++    if (available < 4096) {
++      return GST_FLOW_OK;
++    } else {
++      GstBuffer *buffer = gst_adapter_get_buffer (stream->adapter, available);
++      GST_LOG_OBJECT (stream->pad, "enough data, parsing fragment.");
++      gst_mss_stream_fragment_parse (mssstream->manifest_stream, buffer);
++      gst_buffer_unref (buffer);
++    }
++  }
++
++  return GST_ADAPTIVE_DEMUX_CLASS (parent_class)->data_received (demux, stream);
++}
++
++static gboolean
++gst_mss_demux_requires_periodical_playlist_update (GstAdaptiveDemux * demux)
++{
++  GstMssDemux *mssdemux = GST_MSS_DEMUX_CAST (demux);
++
++  return (!gst_mss_manifest_is_live (mssdemux->manifest));
++}
+diff --git a/ext/smoothstreaming/gstmssfragmentparser.c b/ext/smoothstreaming/gstmssfragmentparser.c
+new file mode 100644
+index 0000000..01c3b15
+--- /dev/null
++++ b/ext/smoothstreaming/gstmssfragmentparser.c
+@@ -0,0 +1,255 @@
++/*
++ * Microsoft Smooth-Streaming fragment parsing library
++ *
++ * gstmssfragmentparser.h
++ *
++ * Copyright (C) 2015 Igalia S.L
++ * Copyright (C) 2015 Metrological
++ *   Author: Philippe Normand <philn@igalia.com>
++ *
++ * This library is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Library General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * This library is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Library General Public License for more details.
++ *
++ * You should have received a copy of the GNU Library General Public
++ * License along with this library (COPYING); if not, write to the
++ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
++ * Boston, MA 02111-1307, USA.
++ */
++
++#include "gstmssfragmentparser.h"
++#include <gst/base/gstbytereader.h>
++#include <string.h>
++
++GST_DEBUG_CATEGORY_EXTERN (mssdemux_debug);
++#define GST_CAT_DEFAULT mssdemux_debug
++
++void
++gst_mss_fragment_parser_init (GstMssFragmentParser * parser)
++{
++  parser->status = GST_MSS_FRAGMENT_HEADER_PARSER_INIT;
++  parser->tfrf.entries_count = 0;
++}
++
++void
++gst_mss_fragment_parser_clear (GstMssFragmentParser * parser)
++{
++  parser->tfrf.entries_count = 0;
++  if (parser->tfrf.entries) {
++    g_free (parser->tfrf.entries);
++    parser->tfrf.entries = 0;
++  }
++}
++
++static gboolean
++_parse_tfrf_box (GstMssFragmentParser * parser, GstByteReader * reader)
++{
++  guint8 version;
++  guint32 flags = 0;
++  guint8 fragment_count = 0;
++  guint8 index = 0;
++
++  if (!gst_byte_reader_get_uint8 (reader, &version)) {
++    GST_ERROR ("Error getting box's version field");
++    return FALSE;
++  }
++
++  if (!gst_byte_reader_get_uint24_be (reader, &flags)) {
++    GST_ERROR ("Error getting box's flags field");
++    return FALSE;
++  }
++
++  gst_byte_reader_get_uint8 (reader, &fragment_count);
++  parser->tfrf.entries_count = fragment_count;
++  parser->tfrf.entries =
++      g_malloc (sizeof (GstTfrfBoxEntry) * parser->tfrf.entries_count);
++  for (index = 0; index < fragment_count; index++) {
++    guint64 absolute_time = 0;
++    guint64 absolute_duration = 0;
++    if (version & 0x01) {
++      gst_byte_reader_get_uint64_be (reader, &absolute_time);
++      gst_byte_reader_get_uint64_be (reader, &absolute_duration);
++    } else {
++      guint32 time = 0;
++      guint32 duration = 0;
++      gst_byte_reader_get_uint32_be (reader, &time);
++      gst_byte_reader_get_uint32_be (reader, &duration);
++      time = ~time;
++      duration = ~duration;
++      absolute_time = ~time;
++      absolute_duration = ~duration;
++    }
++    parser->tfrf.entries[index].time = absolute_time;
++    parser->tfrf.entries[index].duration = absolute_duration;
++  }
++
++  GST_LOG ("tfrf box parsed");
++  return TRUE;
++}
++
++static gboolean
++_parse_tfxd_box (GstMssFragmentParser * parser, GstByteReader * reader)
++{
++  guint8 version;
++  guint32 flags = 0;
++  guint64 absolute_time = 0;
++  guint64 absolute_duration = 0;
++
++  if (!gst_byte_reader_get_uint8 (reader, &version)) {
++    GST_ERROR ("Error getting box's version field");
++    return FALSE;
++  }
++
++  if (!gst_byte_reader_get_uint24_be (reader, &flags)) {
++    GST_ERROR ("Error getting box's flags field");
++    return FALSE;
++  }
++
++  if (version & 0x01) {
++    gst_byte_reader_get_uint64_be (reader, &absolute_time);
++    gst_byte_reader_get_uint64_be (reader, &absolute_duration);
++  } else {
++    guint32 time = 0;
++    guint32 duration = 0;
++    gst_byte_reader_get_uint32_be (reader, &time);
++    gst_byte_reader_get_uint32_be (reader, &duration);
++    time = ~time;
++    duration = ~duration;
++    absolute_time = ~time;
++    absolute_duration = ~duration;
++  }
++
++  parser->tfxd.time = absolute_time;
++  parser->tfxd.duration = absolute_duration;
++  GST_LOG ("tfxd box parsed");
++  return TRUE;
++}
++
++gboolean
++gst_mss_fragment_parser_add_buffer (GstMssFragmentParser * parser,
++    GstBuffer * buffer)
++{
++  GstByteReader reader;
++  GstMapInfo info;
++  guint32 size;
++  guint32 fourcc;
++  const guint8 *uuid;
++  gboolean error = FALSE;
++  gboolean mdat_box_found = FALSE;
++
++  static const guint8 tfrf_uuid[] = {
++    0xd4, 0x80, 0x7e, 0xf2, 0xca, 0x39, 0x46, 0x95,
++    0x8e, 0x54, 0x26, 0xcb, 0x9e, 0x46, 0xa7, 0x9f
++  };
++
++  static const guint8 tfxd_uuid[] = {
++    0x6d, 0x1d, 0x9b, 0x05, 0x42, 0xd5, 0x44, 0xe6,
++    0x80, 0xe2, 0x14, 0x1d, 0xaf, 0xf7, 0x57, 0xb2
++  };
++
++  static const guint8 piff_uuid[] = {
++    0xa2, 0x39, 0x4f, 0x52, 0x5a, 0x9b, 0x4f, 0x14,
++    0xa2, 0x44, 0x6c, 0x42, 0x7c, 0x64, 0x8d, 0xf4
++  };
++
++  if (!gst_buffer_map (buffer, &info, GST_MAP_READ)) {
++    return FALSE;
++  }
++
++  gst_byte_reader_init (&reader, info.data, info.size);
++  GST_TRACE ("Total buffer size: %u", gst_byte_reader_get_size (&reader));
++
++  size = gst_byte_reader_get_uint32_be_unchecked (&reader);
++  fourcc = gst_byte_reader_get_uint32_le_unchecked (&reader);
++  if (fourcc == GST_MSS_FRAGMENT_FOURCC_MOOF) {
++    GST_TRACE ("moof box found");
++    size = gst_byte_reader_get_uint32_be_unchecked (&reader);
++    fourcc = gst_byte_reader_get_uint32_le_unchecked (&reader);
++    if (fourcc == GST_MSS_FRAGMENT_FOURCC_MFHD) {
++      gst_byte_reader_skip_unchecked (&reader, size - 8);
++
++      size = gst_byte_reader_get_uint32_be_unchecked (&reader);
++      fourcc = gst_byte_reader_get_uint32_le_unchecked (&reader);
++      if (fourcc == GST_MSS_FRAGMENT_FOURCC_TRAF) {
++        size = gst_byte_reader_get_uint32_be_unchecked (&reader);
++        fourcc = gst_byte_reader_get_uint32_le_unchecked (&reader);
++        if (fourcc == GST_MSS_FRAGMENT_FOURCC_TFHD) {
++          gst_byte_reader_skip_unchecked (&reader, size - 8);
++
++          size = gst_byte_reader_get_uint32_be_unchecked (&reader);
++          fourcc = gst_byte_reader_get_uint32_le_unchecked (&reader);
++          if (fourcc == GST_MSS_FRAGMENT_FOURCC_TRUN) {
++            gst_byte_reader_skip_unchecked (&reader, size - 8);
++            GST_TRACE ("trun box found, size: %u", size);
++          }
++        }
++      }
++    }
++  }
++
++  while (!mdat_box_found) {
++    GST_TRACE ("remaining data: %u", gst_byte_reader_get_remaining (&reader));
++    if (!gst_byte_reader_get_uint32_be (&reader, &size)) {
++      GST_WARNING ("Failed to get box size, enough data?");
++      error = TRUE;
++      break;
++    }
++
++    GST_TRACE ("box size: %" G_GUINT32_FORMAT, size);
++    fourcc = gst_byte_reader_get_uint32_le_unchecked (&reader);
++
++    if (fourcc == GST_MSS_FRAGMENT_FOURCC_MDAT) {
++      GST_LOG ("mdat box found");
++      mdat_box_found = TRUE;
++      break;
++    }
++
++    if (fourcc != GST_MSS_FRAGMENT_FOURCC_UUID) {
++      GST_ERROR ("invalid UUID fourcc");
++      error = TRUE;
++      break;
++    }
++
++    if (!gst_byte_reader_peek_data (&reader, 16, &uuid)) {
++      GST_ERROR ("not enough data in UUID box");
++      error = TRUE;
++      break;
++    }
++
++    if (memcmp (uuid, piff_uuid, 16) == 0) {
++      gst_byte_reader_skip_unchecked (&reader, size - 8);
++      GST_LOG ("piff box detected");
++    }
++
++    if (memcmp (uuid, tfrf_uuid, 16) == 0) {
++      gst_byte_reader_get_data (&reader, 16, &uuid);
++      if (!_parse_tfrf_box (parser, &reader)) {
++        GST_ERROR ("txrf box parsing error");
++        error = TRUE;
++        break;
++      }
++    }
++
++    if (memcmp (uuid, tfxd_uuid, 16) == 0) {
++      gst_byte_reader_get_data (&reader, 16, &uuid);
++      if (!_parse_tfxd_box (parser, &reader)) {
++        GST_ERROR ("tfrf box parsing error");
++        error = TRUE;
++        break;
++      }
++    }
++  }
++
++  if (!error)
++    parser->status = GST_MSS_FRAGMENT_HEADER_PARSER_FINISHED;
++
++  GST_LOG ("Fragment parsing successful: %s", error ? "no" : "yes");
++  gst_buffer_unmap (buffer, &info);
++  return !error;
++}
+diff --git a/ext/smoothstreaming/gstmssfragmentparser.h b/ext/smoothstreaming/gstmssfragmentparser.h
+new file mode 100644
+index 0000000..6626358
+--- /dev/null
++++ b/ext/smoothstreaming/gstmssfragmentparser.h
+@@ -0,0 +1,84 @@
++/*
++ * Microsoft Smooth-Streaming fragment parsing library
++ *
++ * gstmssfragmentparser.h
++ *
++ * Copyright (C) 2015 Igalia S.L
++ * Copyright (C) 2015 Metrological
++ *   Author: Philippe Normand <philn@igalia.com>
++ *
++ * This library is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Library General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * This library is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Library General Public License for more details.
++ *
++ * You should have received a copy of the GNU Library General Public
++ * License along with this library (COPYING); if not, write to the
++ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
++ * Boston, MA 02111-1307, USA.
++ */
++
++#ifndef __GST_MSS_FRAGMENT_PARSER_H__
++#define __GST_MSS_FRAGMENT_PARSER_H__
++
++#include <gst/gst.h>
++
++G_BEGIN_DECLS
++
++#define GST_MSS_FRAGMENT_FOURCC_MOOF GST_MAKE_FOURCC('m','o','o','f')
++#define GST_MSS_FRAGMENT_FOURCC_MFHD GST_MAKE_FOURCC('m','f','h','d')
++#define GST_MSS_FRAGMENT_FOURCC_TRAF GST_MAKE_FOURCC('t','r','a','f')
++#define GST_MSS_FRAGMENT_FOURCC_TFHD GST_MAKE_FOURCC('t','f','h','d')
++#define GST_MSS_FRAGMENT_FOURCC_TRUN GST_MAKE_FOURCC('t','r','u','n')
++#define GST_MSS_FRAGMENT_FOURCC_UUID GST_MAKE_FOURCC('u','u','i','d')
++#define GST_MSS_FRAGMENT_FOURCC_MDAT GST_MAKE_FOURCC('m','d','a','t')
++
++typedef struct _GstTfxdBox
++{
++  guint8 version;
++  guint32 flags;
++
++  guint64 time;
++  guint64 duration;
++} GstTfxdBox;
++
++typedef struct _GstTfrfBoxEntry
++{
++  guint64 time;
++  guint64 duration;
++} GstTfrfBoxEntry;
++
++typedef struct _GstTfrfBox
++{
++  guint8 version;
++  guint32 flags;
++
++  gint entries_count;
++  GstTfrfBoxEntry *entries;
++} GstTfrfBox;
++
++typedef enum _GstFragmentHeaderParserStatus
++{
++  GST_MSS_FRAGMENT_HEADER_PARSER_INIT,
++  GST_MSS_FRAGMENT_HEADER_PARSER_FINISHED
++} GstFragmentHeaderParserStatus;
++
++typedef struct _GstMssFragmentParser
++{
++  GstFragmentHeaderParserStatus status;
++  GstTfxdBox tfxd;
++  GstTfrfBox tfrf;
++} GstMssFragmentParser;
++
++void gst_mss_fragment_parser_init (GstMssFragmentParser * parser);
++void gst_mss_fragment_parser_clear (GstMssFragmentParser * parser);
++gboolean gst_mss_fragment_parser_add_buffer (GstMssFragmentParser * parser, GstBuffer * buf);
++
++G_END_DECLS
++
++#endif /* __GST_MSS_FRAGMENT_PARSER_H__ */
+diff --git a/ext/smoothstreaming/gstmssmanifest.c b/ext/smoothstreaming/gstmssmanifest.c
+index 1b72e8d..d50a51a 100644
+--- a/ext/smoothstreaming/gstmssmanifest.c
++++ b/ext/smoothstreaming/gstmssmanifest.c
+@@ -1,5 +1,7 @@
+ /* GStreamer
+  * Copyright (C) 2012 Smart TV Alliance
++ * Copyright (C) 2015 Igalia S.L
++ * Copyright (C) 2015 Metrological
+  *  Author: Thiago Sousa Santos <thiago.sousa.santos@collabora.com>, Collabora Ltd.
+  *
+  * gstmssmanifest.c:
+@@ -31,6 +33,7 @@
+ #include <gst/codecparsers/gsth264parser.h>
+ 
+ #include "gstmssmanifest.h"
++#include "gstmssfragmentparser.h"
+ 
+ GST_DEBUG_CATEGORY_EXTERN (mssdemux_debug);
+ #define GST_CAT_DEFAULT mssdemux_debug
+@@ -73,12 +76,17 @@ struct _GstMssStream
+   gboolean active;              /* if the stream is currently being used */
+   gint selectedQualityIndex;
+ 
++  gboolean has_live_fragments;
++  GQueue live_fragments;
++
+   GList *fragments;
+   GList *qualities;
+ 
+   gchar *url;
+   gchar *lang;
+ 
++  GstMssFragmentParser fragment_parser;
++
+   guint fragment_repetition_index;
+   GList *current_fragment;
+   GList *current_quality;
+@@ -94,6 +102,7 @@ struct _GstMssManifest
+   xmlNodePtr xmlrootnode;
+ 
+   gboolean is_live;
++  guint64 look_ahead_fragment_count;
+ 
+   GString *protection_system_id;
+   gchar *protection_data;
+@@ -233,7 +242,8 @@ compare_bitrate (GstMssStreamQuality * a, GstMssStreamQuality * b)
+ }
+ 
+ static void
+-_gst_mss_stream_init (GstMssStream * stream, xmlNodePtr node)
++_gst_mss_stream_init (GstMssManifest * manifest, GstMssStream * stream,
++    xmlNodePtr node)
+ {
+   xmlNodePtr iter;
+   GstMssFragmentListBuilder builder;
+@@ -246,9 +256,18 @@ _gst_mss_stream_init (GstMssStream * stream, xmlNodePtr node)
+   stream->url = (gchar *) xmlGetProp (node, (xmlChar *) MSS_PROP_URL);
+   stream->lang = (gchar *) xmlGetProp (node, (xmlChar *) MSS_PROP_LANGUAGE);
+ 
++  /* for live playback each fragment usually has timing
++   * information for the few next look-ahead fragments so the
++   * playlist can be built incrementally from the first fragment
++   * of the manifest.
++   */
++  stream->has_live_fragments = manifest->is_live
++      && manifest->look_ahead_fragment_count;
++
+   for (iter = node->children; iter; iter = iter->next) {
+     if (node_has_type (iter, MSS_NODE_STREAM_FRAGMENT)) {
+-      gst_mss_fragment_list_builder_add (&builder, iter);
++      if (!stream->has_live_fragments || !builder.fragments)
++        gst_mss_fragment_list_builder_add (&builder, iter);
+     } else if (node_has_type (iter, MSS_NODE_STREAM_QUALITY)) {
+       GstMssStreamQuality *quality = gst_mss_stream_quality_new (iter);
+       stream->qualities = g_list_prepend (stream->qualities, quality);
+@@ -257,17 +276,26 @@ _gst_mss_stream_init (GstMssStream * stream, xmlNodePtr node)
+     }
+   }
+ 
+-  stream->fragments = g_list_reverse (builder.fragments);
++  if (stream->has_live_fragments) {
++    g_queue_init (&stream->live_fragments);
++    g_queue_push_tail (&stream->live_fragments, builder.fragments->data);
++    stream->current_fragment = g_queue_peek_head_link (&stream->live_fragments);
++  }
++
++  if (builder.fragments) {
++    stream->fragments = g_list_reverse (builder.fragments);
++    stream->current_fragment = stream->fragments;
++  }
+ 
+   /* order them from smaller to bigger based on bitrates */
+   stream->qualities =
+       g_list_sort (stream->qualities, (GCompareFunc) compare_bitrate);
+-
+-  stream->current_fragment = stream->fragments;
+   stream->current_quality = stream->qualities;
+ 
+   stream->regex_bitrate = g_regex_new ("\\{[Bb]itrate\\}", 0, 0, NULL);
+   stream->regex_position = g_regex_new ("\\{start[ _]time\\}", 0, 0, NULL);
++
++  gst_mss_fragment_parser_init (&stream->fragment_parser);
+ }
+ 
+ 
+@@ -313,6 +341,7 @@ gst_mss_manifest_new (GstBuffer * data)
+   xmlNodePtr nodeiter;
+   gchar *live_str;
+   GstMapInfo mapinfo;
++  gchar *look_ahead_fragment_count_str;
+ 
+   if (!gst_buffer_map (data, &mapinfo, GST_MAP_READ)) {
+     return NULL;
+@@ -330,13 +359,21 @@ gst_mss_manifest_new (GstBuffer * data)
+     xmlFree (live_str);
+   }
+ 
++  look_ahead_fragment_count_str =
++      (gchar *) xmlGetProp (root, (xmlChar *) "LookAheadFragmentCount");
++  if (look_ahead_fragment_count_str) {
++    manifest->look_ahead_fragment_count =
++        g_ascii_strtoull (look_ahead_fragment_count_str, NULL, 10);
++    xmlFree (look_ahead_fragment_count_str);
++  }
++
+   for (nodeiter = root->children; nodeiter; nodeiter = nodeiter->next) {
+     if (nodeiter->type == XML_ELEMENT_NODE
+         && (strcmp ((const char *) nodeiter->name, "StreamIndex") == 0)) {
+       GstMssStream *stream = g_new0 (GstMssStream, 1);
+ 
+       manifest->streams = g_slist_append (manifest->streams, stream);
+-      _gst_mss_stream_init (stream, nodeiter);
++      _gst_mss_stream_init (manifest, stream, nodeiter);
+     }
+ 
+     if (nodeiter->type == XML_ELEMENT_NODE
+@@ -353,13 +390,19 @@ gst_mss_manifest_new (GstBuffer * data)
+ static void
+ gst_mss_stream_free (GstMssStream * stream)
+ {
+-  g_list_free_full (stream->fragments, g_free);
++  if (stream->has_live_fragments) {
++    g_queue_foreach (&stream->live_fragments, (GFunc) g_free, NULL);
++    g_queue_clear (&stream->live_fragments);
++  } else {
++    g_list_free_full (stream->fragments, g_free);
++  }
+   g_list_free_full (stream->qualities,
+       (GDestroyNotify) gst_mss_stream_quality_free);
+   xmlFree (stream->url);
+   xmlFree (stream->lang);
+   g_regex_unref (stream->regex_position);
+   g_regex_unref (stream->regex_bitrate);
++  gst_mss_fragment_parser_clear (&stream->fragment_parser);
+   g_free (stream);
+ }
+ 
+@@ -984,7 +1027,12 @@ gst_mss_stream_get_fragment_gst_timestamp (GstMssStream * stream)
+   g_return_val_if_fail (stream->active, GST_CLOCK_TIME_NONE);
+ 
+   if (!stream->current_fragment) {
+-    GList *last = g_list_last (stream->fragments);
++    GList *last;
++
++    if (stream->has_live_fragments)
++      last = g_queue_peek_tail_link (&stream->live_fragments);
++    else
++      last = g_list_last (stream->fragments);
+     if (last == NULL)
+       return GST_CLOCK_TIME_NONE;
+ 
+@@ -1037,21 +1085,54 @@ GstFlowReturn
+ gst_mss_stream_advance_fragment (GstMssStream * stream)
+ {
+   GstMssStreamFragment *fragment;
++  GstMssStreamFragment *prev_fragment;
++  const gchar *stream_type_name =
++      gst_mss_stream_type_name (gst_mss_stream_get_type (stream));
++
+   g_return_val_if_fail (stream->active, GST_FLOW_ERROR);
+ 
+   if (stream->current_fragment == NULL)
+     return GST_FLOW_EOS;
+ 
+-  fragment = stream->current_fragment->data;
++  prev_fragment = fragment = stream->current_fragment->data;
+   stream->fragment_repetition_index++;
+-  if (stream->fragment_repetition_index < fragment->repetitions) {
+-    return GST_FLOW_OK;
+-  }
++  if (stream->fragment_repetition_index < fragment->repetitions)
++    goto beach;
+ 
+   stream->fragment_repetition_index = 0;
+-  stream->current_fragment = g_list_next (stream->current_fragment);
++
++  if (stream->has_live_fragments)
++    stream->current_fragment = g_queue_pop_head_link (&stream->live_fragments);
++  else
++    stream->current_fragment = g_list_next (stream->current_fragment);
++
++  if (stream->current_fragment != NULL) {
++    fragment = stream->current_fragment->data;
++    if (fragment->time <= prev_fragment->time) {
++      while (fragment->time <= prev_fragment->time) {
++        if (stream->has_live_fragments)
++          stream->current_fragment =
++              g_queue_pop_head_link (&stream->live_fragments);
++        else
++          stream->current_fragment = g_list_next (stream->current_fragment);
++        if (stream->current_fragment == NULL)
++          break;
++        fragment = stream->current_fragment->data;
++      }
++    }
++  }
++
++  GST_DEBUG ("Advanced to fragment #%d on %s stream", fragment->number,
++      stream_type_name);
++  if (stream->has_live_fragments)
++    GST_LOG ("%u fragments left in the %s stream queue",
++        g_queue_get_length (&stream->live_fragments), stream_type_name);
+   if (stream->current_fragment == NULL)
+     return GST_FLOW_EOS;
++
++beach:
++  gst_mss_fragment_parser_clear (&stream->fragment_parser);
++  gst_mss_fragment_parser_init (&stream->fragment_parser);
+   return GST_FLOW_OK;
+ }
+ 
+@@ -1125,6 +1206,10 @@ gst_mss_stream_seek (GstMssStream * stream, gboolean forward,
+   guint64 timescale;
+   GstMssStreamFragment *fragment = NULL;
+ 
++  // FIXME: Seek support for live scenario using DVR window.
++  if (stream->has_live_fragments)
++    return;
++
+   timescale = gst_mss_stream_get_timescale (stream);
+   time = gst_util_uint64_scale_round (time, timescale, GST_SECOND);
+ 
+@@ -1406,3 +1491,47 @@ gst_mss_stream_get_lang (GstMssStream * stream)
+ {
+   return stream->lang;
+ }
++
++gboolean
++gst_mss_stream_fragment_parsing_needed (GstMssStream * stream)
++{
++  return stream->fragment_parser.status == GST_MSS_FRAGMENT_HEADER_PARSER_INIT;
++}
++
++void
++gst_mss_stream_fragment_parse (GstMssStream * stream, GstBuffer * buffer)
++{
++  GstMssStreamFragment *current_fragment = NULL;
++  const gchar *stream_type_name =
++      gst_mss_stream_type_name (gst_mss_stream_get_type (stream));
++
++  if (!stream->has_live_fragments)
++    return;
++
++  if (!gst_mss_fragment_parser_add_buffer (&stream->fragment_parser, buffer))
++    return;
++
++  current_fragment = stream->current_fragment->data;
++  current_fragment->time = stream->fragment_parser.tfxd.time;
++  current_fragment->duration = stream->fragment_parser.tfxd.duration;
++
++  for (guint8 index = 0; index < stream->fragment_parser.tfrf.entries_count;
++      index++) {
++    GstMssStreamFragment *last = g_queue_peek_tail (&stream->live_fragments);
++    GstMssStreamFragment *fragment;
++
++    if (last == NULL)
++        break;
++    fragment = g_new (GstMssStreamFragment, 1);
++    fragment->number = last->number + 1;
++    fragment->repetitions = 1;
++    fragment->time = stream->fragment_parser.tfrf.entries[index].time;
++    fragment->duration = stream->fragment_parser.tfrf.entries[index].duration;
++
++    g_queue_push_tail (&stream->live_fragments, fragment);
++    GST_LOG ("Adding fragment number: %u to %s stream, time: %" G_GUINT64_FORMAT
++        ", duration: %" G_GUINT64_FORMAT ", repetitions: %u",
++        fragment->number, stream_type_name,
++        fragment->time, fragment->duration, fragment->repetitions);
++  }
++}
+diff --git a/ext/smoothstreaming/gstmssmanifest.h b/ext/smoothstreaming/gstmssmanifest.h
+index af7419c..039877f 100644
+--- a/ext/smoothstreaming/gstmssmanifest.h
++++ b/ext/smoothstreaming/gstmssmanifest.h
+@@ -72,5 +72,8 @@ const gchar * gst_mss_stream_get_lang (GstMssStream * stream);
+ 
+ const gchar * gst_mss_stream_type_name (GstMssStreamType streamtype);
+ 
++gboolean gst_mss_stream_fragment_parsing_needed(GstMssStream * stream);
++void gst_mss_stream_fragment_parse(GstMssStream * stream, GstBuffer * buffer);
++
+ G_END_DECLS
+ #endif /* __GST_MSS_MANIFEST_H__ */
+diff --git a/gst-libs/gst/adaptivedemux/gstadaptivedemux.c b/gst-libs/gst/adaptivedemux/gstadaptivedemux.c
+index bf311d3..20bd839 100644
+--- a/gst-libs/gst/adaptivedemux/gstadaptivedemux.c
++++ b/gst-libs/gst/adaptivedemux/gstadaptivedemux.c
+@@ -291,6 +291,9 @@ gst_adaptive_demux_wait_until (GstClock * clock, GCond * cond, GMutex * mutex,
+     GstClockTime end_time);
+ static gboolean gst_adaptive_demux_clock_callback (GstClock * clock,
+     GstClockTime time, GstClockID id, gpointer user_data);
++static gboolean
++gst_adaptive_demux_requires_periodical_playlist_update_default (GstAdaptiveDemux
++    * demux);
+ 
+ /* we can't use G_DEFINE_ABSTRACT_TYPE because we need the klass in the _init
+  * method to get to the padtemplates */
+@@ -412,6 +415,9 @@ gst_adaptive_demux_class_init (GstAdaptiveDemuxClass * klass)
+   klass->data_received = gst_adaptive_demux_stream_data_received_default;
+   klass->finish_fragment = gst_adaptive_demux_stream_finish_fragment_default;
+   klass->update_manifest = gst_adaptive_demux_update_manifest_default;
++  klass->requires_periodical_playlist_update =
++      gst_adaptive_demux_requires_periodical_playlist_update_default;
++
+ }
+ 
+ static void
+@@ -686,7 +692,9 @@ gst_adaptive_demux_sink_event (GstPad * pad, GstObject * parent,
+             demux->priv->stop_updates_task = FALSE;
+             g_mutex_unlock (&demux->priv->updates_timed_lock);
+             /* Task to periodically update the manifest */
+-            gst_task_start (demux->priv->updates_task);
++            if (demux_class->requires_periodical_playlist_update (demux)) {
++              gst_task_start (demux->priv->updates_task);
++            }
+           }
+         } else {
+           /* no streams */
+@@ -2113,6 +2121,13 @@ gst_adaptive_demux_stream_data_received_default (GstAdaptiveDemux * demux,
+   return gst_adaptive_demux_stream_push_buffer (stream, buffer);
+ }
+ 
++static gboolean
++gst_adaptive_demux_requires_periodical_playlist_update_default (GstAdaptiveDemux
++    * demux)
++{
++  return TRUE;
++}
++
+ static GstFlowReturn
+ _src_chain (GstPad * pad, GstObject * parent, GstBuffer * buffer)
+ {
+@@ -2209,7 +2224,7 @@ _src_chain (GstPad * pad, GstObject * parent, GstBuffer * buffer)
+       stream->download_chunk_start_time;
+   stream->download_total_bytes += gst_buffer_get_size (buffer);
+ 
+-  GST_DEBUG_OBJECT (stream->pad, "Received buffer of size %" G_GSIZE_FORMAT,
++  GST_LOG_OBJECT (stream->pad, "Received buffer of size %" G_GSIZE_FORMAT,
+       gst_buffer_get_size (buffer));
+ 
+   ret = klass->data_received (demux, stream, buffer);
+@@ -3326,7 +3341,14 @@ gst_adaptive_demux_stream_download_loop (GstAdaptiveDemuxStream * stream)
+       GST_DEBUG_OBJECT (stream->pad, "EOS, checking to stop download loop");
+       /* we push the EOS after releasing the object lock */
+       if (gst_adaptive_demux_is_live (demux)) {
+-        if (gst_adaptive_demux_stream_wait_manifest_update (demux, stream)) {
++        GstAdaptiveDemuxClass *demux_class =
++          GST_ADAPTIVE_DEMUX_GET_CLASS (demux);
++
++        /* this might be a fragment download error, refresh the manifest, just in case */
++        if (!demux_class->requires_periodical_playlist_update (demux)) {
++          ret = gst_adaptive_demux_update_manifest (demux);
++          break;
++        } else if (gst_adaptive_demux_stream_wait_manifest_update (demux, stream)) {
+           goto end;
+         }
+         gst_task_stop (stream->download_task);
+diff --git a/gst-libs/gst/adaptivedemux/gstadaptivedemux.h b/gst-libs/gst/adaptivedemux/gstadaptivedemux.h
+index 780f4d9..9a1a1b7 100644
+--- a/gst-libs/gst/adaptivedemux/gstadaptivedemux.h
++++ b/gst-libs/gst/adaptivedemux/gstadaptivedemux.h
+@@ -459,6 +459,20 @@ struct _GstAdaptiveDemuxClass
+    * selected period.
+    */
+   GstClockTime (*get_period_start_time) (GstAdaptiveDemux *demux);
++
++  /**
++   * requires_periodical_playlist_update:
++   * @demux: #GstAdaptiveDemux
++   *
++   * Some adaptive streaming protocols allow the client to download
++   * the playlist once and build up the fragment list based on the
++   * current fragment metadata. For those protocols the demuxer
++   * doesn't need to periodically refresh the playlist. This vfunc
++   * is relevant only for live playback scenarios.
++   *
++   * Return: %TRUE if the playlist needs to be refreshed periodically by the demuxer.
++   */
++  gboolean (*requires_periodical_playlist_update) (GstAdaptiveDemux * demux);
+ };
+ 
+ GType    gst_adaptive_demux_get_type (void);
+-- 
+2.7.4
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0002-mssdemux-Handle-the-adapter-in-the-subclass-after-bu.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0002-mssdemux-Handle-the-adapter-in-the-subclass-after-bu.patch
@@ -1,0 +1,130 @@
+From 8878df617892b7e19a9de7ee28c5a405238556be Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Enrique=20Oca=C3=B1a=20Gonz=C3=A1lez?= <eocanha@igalia.com>
+Date: Tue, 17 Jan 2017 16:43:53 +0000
+Subject: [PATCH 2/6] mssdemux: Handle the adapter in the subclass after bug
+ 764684
+
+The adapter on GstAdaptiveDemux was removed on
+https://bugzilla.gnome.org/show_bug.cgi?id=764684
+"adaptivedemux: Get rid of internal stream adapter and let subclasses handle this directly"
+commit ca9f62e1d062ac1e87f13c9ddddab9164a3cb892
+
+This commit readds and manages the adapter in gstmssdemux.
+---
+ ext/smoothstreaming/gstmssdemux.c | 33 ++++++++++++++++++++++++++-------
+ ext/smoothstreaming/gstmssdemux.h |  1 +
+ 2 files changed, 27 insertions(+), 7 deletions(-)
+
+diff --git a/ext/smoothstreaming/gstmssdemux.c b/ext/smoothstreaming/gstmssdemux.c
+index 70b541e..1a122d4 100644
+--- a/ext/smoothstreaming/gstmssdemux.c
++++ b/ext/smoothstreaming/gstmssdemux.c
+@@ -121,6 +121,7 @@ static gboolean gst_mss_demux_process_manifest (GstAdaptiveDemux * demux,
+     GstBuffer * buffer);
+ static GstClockTime gst_mss_demux_get_duration (GstAdaptiveDemux * demux);
+ static void gst_mss_demux_reset (GstAdaptiveDemux * demux);
++static void gst_mss_demux_stream_free (GstAdaptiveDemuxStream * stream);
+ static GstFlowReturn gst_mss_demux_stream_seek (GstAdaptiveDemuxStream * stream,
+     gboolean forward, GstSeekFlags flags, GstClockTime ts,
+     GstClockTime * final_ts);
+@@ -142,7 +143,7 @@ static GstFlowReturn
+ gst_mss_demux_update_manifest_data (GstAdaptiveDemux * demux,
+     GstBuffer * buffer);
+ static GstFlowReturn gst_mss_demux_data_received (GstAdaptiveDemux * demux,
+-    GstAdaptiveDemuxStream * stream);
++    GstAdaptiveDemuxStream * stream, GstBuffer * buffer);
+ static gboolean
+ gst_mss_demux_requires_periodical_playlist_update (GstAdaptiveDemux * demux);
+ 
+@@ -188,6 +189,7 @@ gst_mss_demux_class_init (GstMssDemuxClass * klass)
+       gst_mss_demux_get_manifest_update_interval;
+   gstadaptivedemux_class->reset = gst_mss_demux_reset;
+   gstadaptivedemux_class->seek = gst_mss_demux_seek;
++  gstadaptivedemux_class->stream_free = gst_mss_demux_stream_free;
+   gstadaptivedemux_class->stream_seek = gst_mss_demux_stream_seek;
+   gstadaptivedemux_class->stream_advance_fragment =
+       gst_mss_demux_stream_advance_fragment;
+@@ -316,6 +318,14 @@ gst_mss_demux_stream_update_fragment_info (GstAdaptiveDemuxStream * stream)
+   return ret;
+ }
+ 
++static void
++gst_mss_demux_stream_free (GstAdaptiveDemuxStream * stream)
++{
++  GstMssDemuxStream *mssstream = (GstMssDemuxStream *) stream;
++
++  g_object_unref (mssstream->adapter);
++}
++
+ static GstFlowReturn
+ gst_mss_demux_stream_seek (GstAdaptiveDemuxStream * stream, gboolean forward,
+     GstSeekFlags flags, GstClockTime ts, GstClockTime * final_ts)
+@@ -451,6 +461,7 @@ gst_mss_demux_setup_streams (GstAdaptiveDemux * demux)
+         gst_adaptive_demux_stream_new (GST_ADAPTIVE_DEMUX_CAST (mssdemux),
+         srcpad);
+     stream->manifest_stream = manifeststream;
++    stream->adapter = gst_adapter_new();
+     gst_mss_stream_set_active (manifeststream, TRUE);
+     active_streams = g_slist_prepend (active_streams, stream);
+   }
+@@ -686,7 +697,7 @@ gst_mss_demux_update_manifest_data (GstAdaptiveDemux * demux,
+ 
+ static GstFlowReturn
+ gst_mss_demux_data_received (GstAdaptiveDemux * demux,
+-    GstAdaptiveDemuxStream * stream)
++    GstAdaptiveDemuxStream * stream, GstBuffer *buffer)
+ {
+   GstMssDemux *mssdemux = GST_MSS_DEMUX_CAST (demux);
+   GstMssDemuxStream *mssstream = (GstMssDemuxStream *) stream;
+@@ -694,23 +705,31 @@ gst_mss_demux_data_received (GstAdaptiveDemux * demux,
+ 
+   if (!gst_mss_manifest_is_live (mssdemux->manifest)) {
+     return GST_ADAPTIVE_DEMUX_CLASS (parent_class)->data_received (demux,
+-        stream);
++        stream, buffer);
+   }
+ 
+   if (gst_mss_stream_fragment_parsing_needed (mssstream->manifest_stream)) {
+-    available = gst_adapter_available (stream->adapter);
++    gst_adapter_push (mssstream->adapter, buffer);
++
++    GST_DEBUG_OBJECT (stream->pad, "Received buffer of size %" G_GSIZE_FORMAT
++        ". Now %" G_GSIZE_FORMAT " on adapter", gst_buffer_get_size (buffer),
++        gst_adapter_available (mssstream->adapter));
++
++    available = gst_adapter_available (mssstream->adapter);
+     // FIXME: try to reduce this minimal size.
+     if (available < 4096) {
+       return GST_FLOW_OK;
+     } else {
+-      GstBuffer *buffer = gst_adapter_get_buffer (stream->adapter, available);
++      // We use here the accumulated buffer from the adapter instead o the
++      // original one.
++      buffer = gst_adapter_get_buffer (mssstream->adapter, available);
++      gst_adapter_clear (mssstream->adapter);
+       GST_LOG_OBJECT (stream->pad, "enough data, parsing fragment.");
+       gst_mss_stream_fragment_parse (mssstream->manifest_stream, buffer);
+-      gst_buffer_unref (buffer);
+     }
+   }
+ 
+-  return GST_ADAPTIVE_DEMUX_CLASS (parent_class)->data_received (demux, stream);
++  return GST_ADAPTIVE_DEMUX_CLASS (parent_class)->data_received (demux, stream, buffer);
+ }
+ 
+ static gboolean
+diff --git a/ext/smoothstreaming/gstmssdemux.h b/ext/smoothstreaming/gstmssdemux.h
+index f3ea6cf..3fcf55f 100644
+--- a/ext/smoothstreaming/gstmssdemux.h
++++ b/ext/smoothstreaming/gstmssdemux.h
+@@ -56,6 +56,7 @@ struct _GstMssDemuxStream {
+   GstAdaptiveDemuxStream parent;
+ 
+   GstMssStream *manifest_stream;
++  GstAdapter *adapter;
+ };
+ 
+ struct _GstMssDemux {
+-- 
+1.8.3.2
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0003-adaptivedemux-minimal-HTTP-context-support.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0003-adaptivedemux-minimal-HTTP-context-support.patch
@@ -1,0 +1,142 @@
+From 992bd23193978742029966e0a2232b1bfcc06122 Mon Sep 17 00:00:00 2001
+From: Philippe Normand <philn@igalia.com>
+Date: Wed, 28 Oct 2015 11:52:49 +0100
+Subject: [PATCH 3/6] adaptivedemux: minimal HTTP context support
+
+The uridownloader is now querying the source element for an HTTP
+context, which stores session data (cookies only for now), and reusing
+the data when fetching data over HTTP. Additionally the context is set
+on adaptivedemux, which allows it to also properly use session data
+when downloading fragments.
+
+https://bugzilla.gnome.org/show_bug.cgi?id=726314
+---
+ gst-libs/gst/adaptivedemux/gstadaptivedemux.c | 16 ++++++++++++-
+ gst-libs/gst/uridownloader/gsturidownloader.c | 34 +++++++++++++++++++++++++--
+ gst-libs/gst/uridownloader/gsturidownloader.h |  2 +-
+ 3 files changed, 48 insertions(+), 4 deletions(-)
+
+diff --git a/gst-libs/gst/adaptivedemux/gstadaptivedemux.c b/gst-libs/gst/adaptivedemux/gstadaptivedemux.c
+index 20bd839..1b5cace 100644
+--- a/gst-libs/gst/adaptivedemux/gstadaptivedemux.c
++++ b/gst-libs/gst/adaptivedemux/gstadaptivedemux.c
+@@ -432,7 +432,7 @@ gst_adaptive_demux_init (GstAdaptiveDemux * demux,
+ 
+   demux->priv = GST_ADAPTIVE_DEMUX_GET_PRIVATE (demux);
+   demux->priv->input_adapter = gst_adapter_new ();
+-  demux->downloader = gst_uri_downloader_new ();
++  demux->downloader = gst_uri_downloader_new (GST_ELEMENT (demux));
+   demux->stream_struct_size = sizeof (GstAdaptiveDemuxStream);
+   demux->priv->segment_seqnum = gst_util_seqnum_next ();
+   demux->have_group_id = FALSE;
+@@ -2547,6 +2547,7 @@ gst_adaptive_demux_stream_update_source (GstAdaptiveDemuxStream * stream,
+     GstPadLinkReturn pad_link_ret;
+     GObjectClass *gobject_class;
+     gchar *internal_name, *bin_name;
++    GstContext *context = NULL;
+ 
+     /* Our src consists of a bin containing uri_handler -> queue2 . The
+      * purpose of the queue2 is to allow the uri_handler to download an
+@@ -2598,6 +2599,19 @@ gst_adaptive_demux_stream_update_source (GstAdaptiveDemuxStream * stream,
+       }
+     }
+ 
++    context =
++        gst_element_get_context (GST_ELEMENT_CAST (demux), "http-headers");
++    if (context) {
++      const GstStructure *s = gst_context_get_structure (context);
++      const gchar **cookies = NULL;
++      gst_structure_get (s, "cookies", G_TYPE_STRV, &cookies, NULL);
++      if (cookies) {
++        GST_DEBUG_OBJECT (demux, "Passing cookies through");
++        g_object_set (uri_handler, "cookies", cookies, NULL);
++      }
++      gst_context_unref (context);
++    }
++
+     /* Source bin creation */
+     bin_name = g_strdup_printf ("srcbin-%s", GST_PAD_NAME (stream->pad));
+     stream->src = gst_bin_new (bin_name);
+diff --git a/gst-libs/gst/uridownloader/gsturidownloader.c b/gst-libs/gst/uridownloader/gsturidownloader.c
+index 47b6f29..1f61250 100644
+--- a/gst-libs/gst/uridownloader/gsturidownloader.c
++++ b/gst-libs/gst/uridownloader/gsturidownloader.c
+@@ -33,6 +33,8 @@ GST_DEBUG_CATEGORY (uridownloader_debug);
+ 
+ struct _GstUriDownloaderPrivate
+ {
++  GstElement *parent;
++
+   /* Fragments fetcher */
+   GstElement *urisrc;
+   GstBus *bus;
+@@ -148,9 +150,11 @@ gst_uri_downloader_finalize (GObject * object)
+ }
+ 
+ GstUriDownloader *
+-gst_uri_downloader_new (void)
++gst_uri_downloader_new (GstElement * parent)
+ {
+-  return g_object_new (GST_TYPE_URI_DOWNLOADER, NULL);
++  GstUriDownloader *downloader = g_object_new (GST_TYPE_URI_DOWNLOADER, NULL);
++  downloader->priv->parent = parent;
++  return downloader;
+ }
+ 
+ static gboolean
+@@ -413,6 +417,7 @@ gst_uri_downloader_set_uri (GstUriDownloader * downloader, const gchar * uri,
+ {
+   GstPad *pad;
+   GObjectClass *gobject_class;
++  GstContext *context = NULL;
+ 
+   if (!gst_uri_is_valid (uri))
+     return FALSE;
+@@ -449,6 +454,31 @@ gst_uri_downloader_set_uri (GstUriDownloader * downloader, const gchar * uri,
+     }
+   }
+ 
++  context = gst_element_get_context (downloader->priv->parent, "http-headers");
++  if (!context) {
++    GstQuery *context_query = gst_query_new_context ("http-headers");
++    GstPad *parent_sink_pad =
++        gst_element_get_static_pad (downloader->priv->parent, "sink");
++    if (gst_pad_peer_query (parent_sink_pad, context_query)) {
++
++      gst_query_parse_context (context_query, &context);
++      gst_element_set_context (downloader->priv->parent, context);
++    }
++    gst_object_unref (parent_sink_pad);
++    gst_query_unref (context_query);
++  }
++
++  if (context) {
++    const GstStructure *s = gst_context_get_structure (context);
++    const gchar **cookies = NULL;
++    gst_structure_get (s, "cookies", G_TYPE_STRV, &cookies, NULL);
++    if (cookies) {
++      GST_DEBUG_OBJECT (downloader, "Passing cookies through");
++      g_object_set (downloader->priv->urisrc, "cookies", cookies, NULL);
++    }
++    gst_context_unref (context);
++  }
++
+   /* add a sync handler for the bus messages to detect errors in the download */
+   gst_element_set_bus (GST_ELEMENT (downloader->priv->urisrc),
+       downloader->priv->bus);
+diff --git a/gst-libs/gst/uridownloader/gsturidownloader.h b/gst-libs/gst/uridownloader/gsturidownloader.h
+index 80b8a3e..36cbf65 100644
+--- a/gst-libs/gst/uridownloader/gsturidownloader.h
++++ b/gst-libs/gst/uridownloader/gsturidownloader.h
+@@ -60,7 +60,7 @@ struct _GstUriDownloaderClass
+ 
+ GType gst_uri_downloader_get_type (void);
+ 
+-GstUriDownloader * gst_uri_downloader_new (void);
++GstUriDownloader * gst_uri_downloader_new (GstElement * parent);
+ GstFragment * gst_uri_downloader_fetch_uri (GstUriDownloader * downloader, const gchar * uri, const gchar * referer, gboolean compress, gboolean refresh, gboolean allow_cache, GError ** err);
+ GstFragment * gst_uri_downloader_fetch_uri_with_range (GstUriDownloader * downloader, const gchar * uri, const gchar * referer, gboolean compress, gboolean refresh, gboolean allow_cache, gint64 range_start, gint64 range_end, GError ** err);
+ void gst_uri_downloader_reset (GstUriDownloader *downloader);
+-- 
+2.7.4
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0004-Fix-to-set-current_fragment-for-live-streaming.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0004-Fix-to-set-current_fragment-for-live-streaming.patch
@@ -1,0 +1,38 @@
+From fdffb5d0e74ef902f405895c9a388bca7bc0ce70 Mon Sep 17 00:00:00 2001
+From: Srinivas Kakarla <srinivas.kakarla@valuelabs.com>
+Date: Thu, 14 Jul 2016 17:12:51 +0530
+Subject: [PATCH 4/6] Fix to set current_fragment for live streaming.
+
+---
+ ext/smoothstreaming/gstmssmanifest.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/ext/smoothstreaming/gstmssmanifest.c b/ext/smoothstreaming/gstmssmanifest.c
+index d50a51a..532c6c3 100644
+--- a/ext/smoothstreaming/gstmssmanifest.c
++++ b/ext/smoothstreaming/gstmssmanifest.c
+@@ -1216,6 +1216,11 @@ gst_mss_stream_seek (GstMssStream * stream, gboolean forward,
+   GST_DEBUG ("Stream %s seeking to %" G_GUINT64_FORMAT, stream->url, time);
+   for (iter = stream->fragments; iter; iter = g_list_next (iter)) {
+     fragment = iter->data;
++    if(stream->has_live_fragments){
++      if (fragment->time + fragment->repetitions * fragment->duration > time)
++        stream->current_fragment = iter;
++      break;
++    }
+     if (fragment->time + fragment->repetitions * fragment->duration > time) {
+       stream->current_fragment = iter;
+       stream->fragment_repetition_index =
+@@ -1319,7 +1324,8 @@ gst_mss_stream_reload_fragments (GstMssStream * stream, xmlNodePtr streamIndex)
+   if (builder.fragments) {
+     g_list_free_full (stream->fragments, g_free);
+     stream->fragments = g_list_reverse (builder.fragments);
+-    stream->current_fragment = stream->fragments;
++    if (!stream->has_live_fragments)
++      stream->current_fragment = stream->fragments;
+     /* TODO Verify how repositioning here works for reverse
+      * playback - it might start from the wrong fragment */
+     gst_mss_stream_seek (stream, TRUE, 0, current_gst_time, NULL);
+-- 
+2.7.4
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0005-mpdparser-MS-PlayReady-ContentProtection-parsing.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0005-mpdparser-MS-PlayReady-ContentProtection-parsing.patch
@@ -1,0 +1,109 @@
+From cbf3d75b3d693e50722534d30a8f51995a419803 Mon Sep 17 00:00:00 2001
+From: Philippe Normand <philn@igalia.com>
+Date: Fri, 4 Nov 2016 09:56:33 +0100
+Subject: [PATCH 5/6] mpdparser: MS PlayReady ContentProtection parsing
+
+The "pro" (PlayReady Object) element contents are now base64-decoded
+and properly stored in Protection events.
+
+https://bugzilla.gnome.org/show_bug.cgi?id=773936
+---
+ ext/dash/gstdashdemux.c |  2 +-
+ ext/dash/gstmpdparser.c | 41 ++++++++++++++++++++++++++++++++++++++++-
+ ext/dash/gstmpdparser.h |  1 +
+ 3 files changed, 42 insertions(+), 2 deletions(-)
+
+diff --git a/ext/dash/gstdashdemux.c b/ext/dash/gstdashdemux.c
+index 271f70f..b10465e 100644
+--- a/ext/dash/gstdashdemux.c
++++ b/ext/dash/gstdashdemux.c
+@@ -745,7 +745,7 @@ gst_dash_demux_send_content_protection_event (gpointer data, gpointer userdata)
+   /* RFC 2141 states: The leading "urn:" sequence is case-insensitive */
+   schemeIdUri = g_ascii_strdown (cp->schemeIdUri, -1);
+   if (g_str_has_prefix (schemeIdUri, "urn:uuid:")) {
+-    pssi_len = strlen (cp->value);
++    pssi_len = cp->value_len;
+     pssi = gst_buffer_new_wrapped (g_memdup (cp->value, pssi_len), pssi_len);
+     GST_LOG_OBJECT (stream, "Queuing Protection event on source pad");
+     /* RFC 4122 states that the hex part of a UUID is in lower case,
+diff --git a/ext/dash/gstmpdparser.c b/ext/dash/gstmpdparser.c
+index 15d6d98..f0b3ceb 100644
+--- a/ext/dash/gstmpdparser.c
++++ b/ext/dash/gstmpdparser.c
+@@ -1313,6 +1313,7 @@ gst_mpdparser_parse_descriptor_type_node (GList ** list, xmlNode * a_node)
+     /* if no value attribute, use XML string representation of the node */
+     gst_mpdparser_get_xml_node_as_string (a_node, &new_descriptor->value);
+   }
++  new_descriptor->value_len = strlen(new_descriptor->value);
+ }
+ 
+ static void
+@@ -1734,6 +1735,44 @@ error:
+ }
+ 
+ static void
++gst_mpdparser_parse_content_protection_node (GList ** list, xmlNode * a_node)
++{
++  gchar *value = NULL;
++  if (gst_mpdparser_get_xml_prop_string (a_node, "value", &value)) {
++    if (!g_strcmp0 (value, "MSPR 2.0")) {
++      xmlNode *cur_node;
++      for (cur_node = a_node->children; cur_node; cur_node = cur_node->next) {
++        if (cur_node->type == XML_ELEMENT_NODE) {
++          if (xmlStrcmp (cur_node->name, (xmlChar *) "pro") == 0) {
++            gsize decoded_len;
++            GstDescriptorType *new_descriptor;
++            new_descriptor = g_slice_new0 (GstDescriptorType);
++            *list = g_list_append (*list, new_descriptor);
++
++            gst_mpdparser_get_xml_prop_string (a_node, "schemeIdUri",
++                &new_descriptor->schemeIdUri);
++
++            gst_mpdparser_get_xml_node_content (cur_node,
++                &new_descriptor->value);
++            g_base64_decode_inplace (new_descriptor->value, &decoded_len);
++            *(new_descriptor->value + decoded_len) = '\0';
++            new_descriptor->value_len = decoded_len;
++            goto beach;
++          }
++        }
++      }
++    } else {
++      gst_mpdparser_parse_descriptor_type_node (list, a_node);
++    }
++  } else {
++    gst_mpdparser_parse_descriptor_type_node (list, a_node);
++  }
++beach:
++  if (value)
++    g_free (value);
++}
++
++static void
+ gst_mpdparser_parse_representation_base_type (GstRepresentationBaseType **
+     pointer, xmlNode * a_node)
+ {
+@@ -1788,7 +1827,7 @@ gst_mpdparser_parse_representation_base_type (GstRepresentationBaseType **
+             (&representation_base->AudioChannelConfiguration, cur_node);
+       } else if (xmlStrcmp (cur_node->name,
+               (xmlChar *) "ContentProtection") == 0) {
+-        gst_mpdparser_parse_descriptor_type_node
++        gst_mpdparser_parse_content_protection_node
+             (&representation_base->ContentProtection, cur_node);
+       }
+     }
+diff --git a/ext/dash/gstmpdparser.h b/ext/dash/gstmpdparser.h
+index 85b97ea..738de68 100644
+--- a/ext/dash/gstmpdparser.h
++++ b/ext/dash/gstmpdparser.h
+@@ -277,6 +277,7 @@ struct _GstDescriptorType
+ {
+   gchar *schemeIdUri;
+   gchar *value;
++  glong value_len;
+ };
+ 
+ struct _GstContentComponentNode
+-- 
+2.7.4
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0006-Workaround-mss-live-streams-fragments.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0006-Workaround-mss-live-streams-fragments.patch
@@ -1,0 +1,33 @@
+From 0290ef5afb9b466cd3c040f3d136c25993eef460 Mon Sep 17 00:00:00 2001
+From: Zan Dobersek <zdobersek@igalia.com>
+Date: Thu, 10 Nov 2016 02:17:01 -0800
+Subject: [PATCH 6/6] Add a workaround patch for the mss live stream fragments
+ issue
+
+---
+ ext/smoothstreaming/gstmssmanifest.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/ext/smoothstreaming/gstmssmanifest.c b/ext/smoothstreaming/gstmssmanifest.c
+index 532c6c3..b9dacb3 100644
+--- a/ext/smoothstreaming/gstmssmanifest.c
++++ b/ext/smoothstreaming/gstmssmanifest.c
+@@ -1304,9 +1304,14 @@ static void
+ gst_mss_stream_reload_fragments (GstMssStream * stream, xmlNodePtr streamIndex)
+ {
+   xmlNodePtr iter;
+-  guint64 current_gst_time = gst_mss_stream_get_fragment_gst_timestamp (stream);
++  guint64 current_gst_time;
+   GstMssFragmentListBuilder builder;
+ 
++  if (stream->has_live_fragments)
++    return;
++
++  current_gst_time = gst_mss_stream_get_fragment_gst_timestamp (stream);
++
+   gst_mss_fragment_list_builder_init (&builder);
+ 
+   GST_DEBUG ("Current position: %" GST_TIME_FORMAT,
+-- 
+2.7.4
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0007-smoothstreaming-implement-adaptivedemux-s-get_live_s.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0007-smoothstreaming-implement-adaptivedemux-s-get_live_s.patch
@@ -1,0 +1,188 @@
+From e8155c77d8dcaf39ec564b85c4a56e64fce6de2b Mon Sep 17 00:00:00 2001
+From: Matthew Waters <matthew@centricular.com>
+Date: Thu, 10 Nov 2016 17:18:36 +1100
+Subject: [PATCH 1/2] smoothstreaming: implement adaptivedemux's
+ get_live_seek_range()
+
+Allows seeking through the available fragments that are still available
+on the server as specified by the DVRWindowLength attribute in the
+manifest.
+
+https://bugzilla.gnome.org/show_bug.cgi?id=774178
+---
+ ext/smoothstreaming/gstmssdemux.c    | 14 +++++-
+ ext/smoothstreaming/gstmssmanifest.c | 84 ++++++++++++++++++++++++++++++++++++
+ ext/smoothstreaming/gstmssmanifest.h |  1 +
+ 3 files changed, 98 insertions(+), 1 deletion(-)
+
+diff --git a/ext/smoothstreaming/gstmssdemux.c b/ext/smoothstreaming/gstmssdemux.c
+index 1a122d4..26147fd 100644
+--- a/ext/smoothstreaming/gstmssdemux.c
++++ b/ext/smoothstreaming/gstmssdemux.c
+@@ -146,6 +146,8 @@ static GstFlowReturn gst_mss_demux_data_received (GstAdaptiveDemux * demux,
+     GstAdaptiveDemuxStream * stream, GstBuffer * buffer);
+ static gboolean
+ gst_mss_demux_requires_periodical_playlist_update (GstAdaptiveDemux * demux);
++static gboolean gst_mss_demux_get_live_seek_range (GstAdaptiveDemux * demux,
++    gint64 * start, gint64 * stop);
+ 
+ static void
+ gst_mss_demux_class_init (GstMssDemuxClass * klass)
+@@ -206,6 +208,8 @@ gst_mss_demux_class_init (GstMssDemuxClass * klass)
+   gstadaptivedemux_class->data_received = gst_mss_demux_data_received;
+   gstadaptivedemux_class->requires_periodical_playlist_update =
+       gst_mss_demux_requires_periodical_playlist_update;
++  gstadaptivedemux_class->get_live_seek_range =
++      gst_mss_demux_get_live_seek_range;
+ 
+   GST_DEBUG_CATEGORY_INIT (mssdemux_debug, "mssdemux", 0, "mssdemux plugin");
+ }
+@@ -694,7 +698,6 @@ gst_mss_demux_update_manifest_data (GstAdaptiveDemux * demux,
+   return GST_FLOW_OK;
+ }
+ 
+-
+ static GstFlowReturn
+ gst_mss_demux_data_received (GstAdaptiveDemux * demux,
+     GstAdaptiveDemuxStream * stream, GstBuffer *buffer)
+@@ -739,3 +742,12 @@ gst_mss_demux_requires_periodical_playlist_update (GstAdaptiveDemux * demux)
+ 
+   return (!gst_mss_manifest_is_live (mssdemux->manifest));
+ }
++
++static gboolean
++gst_mss_demux_get_live_seek_range (GstAdaptiveDemux * demux, gint64 * start,
++    gint64 * stop)
++{
++  GstMssDemux *mssdemux = GST_MSS_DEMUX_CAST (demux);
++
++  return gst_mss_manifest_get_live_seek_range (mssdemux->manifest, start, stop);
++}
+diff --git a/ext/smoothstreaming/gstmssmanifest.c b/ext/smoothstreaming/gstmssmanifest.c
+index b9dacb3..291080a 100644
+--- a/ext/smoothstreaming/gstmssmanifest.c
++++ b/ext/smoothstreaming/gstmssmanifest.c
+@@ -45,6 +45,7 @@ GST_DEBUG_CATEGORY_EXTERN (mssdemux_debug);
+ 
+ #define MSS_PROP_BITRATE              "Bitrate"
+ #define MSS_PROP_DURATION             "d"
++#define MSS_PROP_DVR_WINDOW_LENGTH    "DVRWindowLength"
+ #define MSS_PROP_LANGUAGE             "Language"
+ #define MSS_PROP_NUMBER               "n"
+ #define MSS_PROP_REPETITIONS          "r"
+@@ -103,6 +104,7 @@ struct _GstMssManifest
+ 
+   gboolean is_live;
+   guint64 look_ahead_fragment_count;
++  gint64 dvr_window;
+ 
+   GString *protection_system_id;
+   gchar *protection_data;
+@@ -367,6 +369,22 @@ gst_mss_manifest_new (GstBuffer * data)
+     xmlFree (look_ahead_fragment_count_str);
+   }
+ 
++  /* the entire file is always available for non-live streams */
++  if (!manifest->is_live) {
++    manifest->dvr_window = 0;
++  } else {
++    /* if 0, or non-existent, the length is infinite */
++    gchar *dvr_window_str = (gchar *) xmlGetProp (root,
++        (xmlChar *) MSS_PROP_DVR_WINDOW_LENGTH);
++    if (dvr_window_str) {
++      manifest->dvr_window = g_ascii_strtoull (dvr_window_str, NULL, 10);
++      xmlFree (dvr_window_str);
++      if (manifest->dvr_window <= 0) {
++        manifest->dvr_window = 0;
++      }
++    }
++  }
++
+   for (nodeiter = root->children; nodeiter; nodeiter = nodeiter->next) {
+     if (nodeiter->type == XML_ELEMENT_NODE
+         && (strcmp ((const char *) nodeiter->name, "StreamIndex") == 0)) {
+@@ -1546,3 +1564,69 @@ gst_mss_stream_fragment_parse (GstMssStream * stream, GstBuffer * buffer)
+         fragment->time, fragment->duration, fragment->repetitions);
+   }
+ }
++
++static GstClockTime
++gst_mss_manifest_get_dvr_window_length_clock_time (GstMssManifest * manifest)
++{
++  gint64 timescale;
++
++  /* the entire file is always available for non-live streams */
++  if (manifest->dvr_window == 0)
++    return GST_CLOCK_TIME_NONE;
++
++  timescale = gst_mss_manifest_get_timescale (manifest);
++  return (GstClockTime) gst_util_uint64_scale_round (manifest->dvr_window,
++      GST_SECOND, timescale);
++}
++
++static gboolean
++gst_mss_stream_get_live_seek_range (GstMssStream * stream, gint64 * start,
++    gint64 * stop)
++{
++  GList *l;
++  GstMssStreamFragment *fragment;
++  guint64 timescale = gst_mss_stream_get_timescale (stream);
++
++  g_return_val_if_fail (stream->active, FALSE);
++
++  /* XXX: assumes all the data in the stream is still available */
++  l = g_list_first (stream->fragments);
++  fragment = (GstMssStreamFragment *) l->data;
++  *start = gst_util_uint64_scale_round (fragment->time, GST_SECOND, timescale);
++
++  l = g_list_last (stream->fragments);
++  fragment = (GstMssStreamFragment *) l->data;
++  *stop = gst_util_uint64_scale_round (fragment->time + fragment->duration *
++      fragment->repetitions, GST_SECOND, timescale);
++
++  return TRUE;
++}
++
++gboolean
++gst_mss_manifest_get_live_seek_range (GstMssManifest * manifest, gint64 * start,
++    gint64 * stop)
++{
++  GSList *iter;
++  gboolean ret = FALSE;
++
++  for (iter = manifest->streams; iter; iter = g_slist_next (iter)) {
++    GstMssStream *stream = iter->data;
++
++    if (stream->active) {
++      /* FIXME: bound this correctly for multiple streams */
++      if (!(ret = gst_mss_stream_get_live_seek_range (stream, start, stop)))
++        break;
++    }
++  }
++
++  if (ret && gst_mss_manifest_is_live (manifest)) {
++    GstClockTime dvr_window =
++        gst_mss_manifest_get_dvr_window_length_clock_time (manifest);
++
++    if (GST_CLOCK_TIME_IS_VALID (dvr_window) && *stop - *start > dvr_window) {
++      *start = *stop - dvr_window;
++    }
++  }
++
++  return ret;
++}
+diff --git a/ext/smoothstreaming/gstmssmanifest.h b/ext/smoothstreaming/gstmssmanifest.h
+index 039877f..29545af 100644
+--- a/ext/smoothstreaming/gstmssmanifest.h
++++ b/ext/smoothstreaming/gstmssmanifest.h
+@@ -54,6 +54,7 @@ void gst_mss_manifest_reload_fragments (GstMssManifest * manifest, GstBuffer * d
+ GstClockTime gst_mss_manifest_get_min_fragment_duration (GstMssManifest * manifest);
+ const gchar * gst_mss_manifest_get_protection_system_id (GstMssManifest * manifest);
+ const gchar * gst_mss_manifest_get_protection_data (GstMssManifest * manifest);
++gboolean gst_mss_manifest_get_live_seek_range (GstMssManifest * manifest, gint64 * start, gint64 * stop);
+ 
+ GstMssStreamType gst_mss_stream_get_type (GstMssStream *stream);
+ GstCaps * gst_mss_stream_get_caps (GstMssStream * stream);
+-- 
+1.8.3.2
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0008-mssdemux-Fix-fragment-parsing-issue-during-video-rep.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0008-mssdemux-Fix-fragment-parsing-issue-during-video-rep.patch
@@ -1,0 +1,36 @@
+From 253ed5475fed7147954756c2de98580299d967b0 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Enrique=20Oca=C3=B1a=20Gonz=C3=A1lez?= <eocanha@igalia.com>
+Date: Wed, 13 Sep 2017 10:30:41 +0000
+Subject: [PATCH] mssdemux: Fix fragment parsing issue during video replay
+
+The fragment parser was hardcoded and expected an uuid box, but a different
+one was coming on replayed live videos. This patch allows those boxes and
+simply skips them until an uuid one is found.
+---
+ ext/smoothstreaming/gstmssfragmentparser.c | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/ext/smoothstreaming/gstmssfragmentparser.c b/ext/smoothstreaming/gstmssfragmentparser.c
+index 01c3b15..7de9947 100644
+--- a/ext/smoothstreaming/gstmssfragmentparser.c
++++ b/ext/smoothstreaming/gstmssfragmentparser.c
+@@ -211,11 +211,13 @@ gst_mss_fragment_parser_add_buffer (GstMssFragmentParser * parser,
+     }
+ 
+     if (fourcc != GST_MSS_FRAGMENT_FOURCC_UUID) {
+-      GST_ERROR ("invalid UUID fourcc");
+-      error = TRUE;
+-      break;
++      GST_TRACE ("%" GST_FOURCC_FORMAT " box, skipping", GST_FOURCC_ARGS(fourcc));
++      gst_byte_reader_skip_unchecked (&reader, size - 8);
++      continue;
+     }
+ 
++    GST_LOG ("uuid box found");
++
+     if (!gst_byte_reader_peek_data (&reader, 16, &uuid)) {
+       GST_ERROR ("not enough data in UUID box");
+       error = TRUE;
+-- 
+1.8.3.2
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0009-Fix-HLS-live-stream-issues-with-http-cdn.metrologica.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0009-Fix-HLS-live-stream-issues-with-http-cdn.metrologica.patch
@@ -1,0 +1,69 @@
+From 74716972edc64c073169c994ad616dfca8cff0ab Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Enrique=20Oca=C3=B1a=20Gonz=C3=A1lez?= <eocanha@igalia.com>
+Date: Fri, 9 Feb 2018 15:03:45 +0000
+Subject: [PATCH] Fix HLS live stream issues with
+ http://cdn.metrological.com/hls/master.m3u8
+
+This live stream has index{0-3}.ts blocks which repeat forever. The
+first issue is that the fetch of an updated playlist takes too much and
+the playback stalls. This has been fixed by increasing
+GST_M3U8_LIVE_MIN_FRAGMENT_DISTANCE from 3 to 4, which gives more
+buffer at the expense of latency in the stream (it's less realtime).
+
+The second issue was that index0.ts starts with a non-zero Program
+Clock Reference (PCR, the timing used in MPEG TS). When the blocks wrap
+around from index3.ts to index0.ts, the PCR reset code detects a
+non-zero gap and screws the timestamps. This is fixed by correcting the
+out_time, but requires to disable PCR wraparound management, which
+seems a bit fishy.
+
+WARNING: This patch is experimental and can produce regressions!
+---
+ ext/hls/m3u8.h                     | 3 ++-
+ gst/mpegtsdemux/mpegtspacketizer.c | 9 ++++++++-
+ 2 files changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/ext/hls/m3u8.h b/ext/hls/m3u8.h
+index 3a5023b..951f95c 100644
+--- a/ext/hls/m3u8.h
++++ b/ext/hls/m3u8.h
+@@ -47,7 +47,8 @@ typedef struct _GstHLSMasterPlaylist GstHLSMasterPlaylist;
+    GST_M3U8_LIVE_MIN_FRAGMENT_DISTANCE fragments. Section 6.3.3
+    "Playing the Playlist file" of the HLS draft states that this
+    value is three fragments */
+-#define GST_M3U8_LIVE_MIN_FRAGMENT_DISTANCE 3
++/* Let's give more buffer and use 4 */
++#define GST_M3U8_LIVE_MIN_FRAGMENT_DISTANCE 4
+ 
+ struct _GstM3U8
+ {
+diff --git a/gst/mpegtsdemux/mpegtspacketizer.c b/gst/mpegtsdemux/mpegtspacketizer.c
+index cc46ebb..6317bf5 100644
+--- a/gst/mpegtsdemux/mpegtspacketizer.c
++++ b/gst/mpegtsdemux/mpegtspacketizer.c
+@@ -1333,7 +1333,8 @@ calculate_skew (MpegTSPacketizer2 * packetizer,
+   /* Handle PCR wraparound and resets */
+   if (GST_CLOCK_TIME_IS_VALID (pcr->last_pcrtime) &&
+       gstpcrtime < pcr->last_pcrtime) {
+-    if (pcr->last_pcrtime - gstpcrtime > PCR_GST_MAX_VALUE / 2) {
++    /* DISABLED!!! */
++    if (FALSE && pcr->last_pcrtime - gstpcrtime > PCR_GST_MAX_VALUE / 2) {
+       /* PCR wraparound */
+       GST_DEBUG ("PCR wrap");
+       pcr->pcroffset += PCR_GST_MAX_VALUE;
+@@ -1521,6 +1522,12 @@ no_skew:
+       out_time = 0;
+     } else {
+       out_time += pcr->skew;
++      /* If out_time is reset to 0, keep counting where we were last time.
++       * But this needs PCR wraparound detection to be disabled in order to work consistently */
++      if (out_time == 0) {
++        pcr->base_time += pcr->prev_out_time;
++        out_time = pcr->base_time + send_diff;
++      }
+     }
+     /* check if timestamps are not going backwards, we can only check this if we
+      * have a previous out time and a previous send_diff */
+-- 
+1.8.3.2
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0010-mssdemux-Reduce-SmoothStreaming-latency-on-live-stre.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0010-mssdemux-Reduce-SmoothStreaming-latency-on-live-stre.patch
@@ -1,0 +1,82 @@
+From 7921d2fd18b73c45429543e59dd44c5bf6e592d8 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Enrique=20Oca=C3=B1a=20Gonz=C3=A1lez?= <eocanha@igalia.com>
+Date: Wed, 25 Apr 2018 08:32:20 +0000
+Subject: [PATCH] mssdemux: Reduce SmoothStreaming latency on live streams
+
+by skipping the fragments affected by dvr_window, minus the ones reserved by
+look_ahead_fragment_count. Otherwise, the playback would start at the begining
+of the dvr_window, creating a large latency (typically 1 minute).
+---
+ ext/smoothstreaming/gstmssmanifest.c | 37 ++++++++++++++++++++++++++++++++++--
+ 1 file changed, 35 insertions(+), 2 deletions(-)
+
+diff --git a/ext/smoothstreaming/gstmssmanifest.c b/ext/smoothstreaming/gstmssmanifest.c
+index 291080a..e5ecf5a 100644
+--- a/ext/smoothstreaming/gstmssmanifest.c
++++ b/ext/smoothstreaming/gstmssmanifest.c
+@@ -249,6 +249,7 @@ _gst_mss_stream_init (GstMssManifest * manifest, GstMssStream * stream,
+ {
+   xmlNodePtr iter;
+   GstMssFragmentListBuilder builder;
++  GstClockTime first_fragment_time, dvr_window;
+ 
+   gst_mss_fragment_list_builder_init (&builder);
+ 
+@@ -266,10 +267,34 @@ _gst_mss_stream_init (GstMssManifest * manifest, GstMssStream * stream,
+   stream->has_live_fragments = manifest->is_live
+       && manifest->look_ahead_fragment_count;
+ 
++  first_fragment_time = dvr_window = GST_CLOCK_TIME_NONE;
++
++  if (stream->has_live_fragments && manifest->dvr_window)
++    dvr_window = manifest->dvr_window * GST_SECOND / DEFAULT_TIMESCALE;
++
+   for (iter = node->children; iter; iter = iter->next) {
+     if (node_has_type (iter, MSS_NODE_STREAM_FRAGMENT)) {
+-      if (!stream->has_live_fragments || !builder.fragments)
+-        gst_mss_fragment_list_builder_add (&builder, iter);
++      gst_mss_fragment_list_builder_add (&builder, iter);
++
++      if (stream->has_live_fragments) {
++        /* Build enough fragments to hold dvr_window minus
++         * look_ahead_fragment_count
++         */
++        GstClockTime accumulated_time, look_ahead_estimation_time;
++
++        if (first_fragment_time == GST_CLOCK_TIME_NONE && builder.fragments)
++            first_fragment_time = builder.fragment_time_accum;
++        accumulated_time =
++            (builder.fragment_time_accum
++            + ((GstMssStreamFragment*)builder.fragments->data)->duration
++            - first_fragment_time) * GST_SECOND / DEFAULT_TIMESCALE;
++        look_ahead_estimation_time = accumulated_time
++            * (builder.fragment_number + manifest->look_ahead_fragment_count)
++            / builder.fragment_number;
++        if (dvr_window == GST_CLOCK_TIME_NONE
++            || look_ahead_estimation_time >= dvr_window)
++            break;
++      }
+     } else if (node_has_type (iter, MSS_NODE_STREAM_QUALITY)) {
+       GstMssStreamQuality *quality = gst_mss_stream_quality_new (iter);
+       stream->qualities = g_list_prepend (stream->qualities, quality);
+@@ -279,9 +304,17 @@ _gst_mss_stream_init (GstMssManifest * manifest, GstMssStream * stream,
+   }
+ 
+   if (stream->has_live_fragments) {
++    /* Skip all fragments except the first one (more recently added) */
++    GList* skipped;
++
++    stream->fragments = builder.fragments;
++    skipped = g_list_remove_link(builder.fragments, builder.fragments);
++    g_list_free_full (skipped, g_free);
++
+     g_queue_init (&stream->live_fragments);
+     g_queue_push_tail (&stream->live_fragments, builder.fragments->data);
+     stream->current_fragment = g_queue_peek_head_link (&stream->live_fragments);
++    stream->fragments = NULL;
+   }
+ 
+   if (builder.fragments) {
+-- 
+1.8.3.2
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0011-mpegdash-live-seek-timestamp-fix.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0011-mpegdash-live-seek-timestamp-fix.patch
@@ -1,0 +1,22 @@
+diff --git a/ext/dash/gstmpdparser.c b/ext/dash/gstmpdparser.c
+index 6535cae..f587a13 100644
+--- a/ext/dash/gstmpdparser.c
++++ b/ext/dash/gstmpdparser.c
+@@ -5040,6 +5040,7 @@ gst_mpd_client_get_next_fragment_timestamp (GstMpdClient * client,
+ {
+   GstActiveStream *stream;
+   GstMediaSegment *currentChunk;
++  GstStreamPeriod *stream_period;
+ 
+   GST_DEBUG ("Stream index: %i", stream_idx);
+   stream = g_list_nth_data (client->active_streams, stream_idx);
+@@ -5066,7 +5067,8 @@ gst_mpd_client_get_next_fragment_timestamp (GstMpdClient * client,
+             && stream->segment_index >= segments_count)) {
+       return FALSE;
+     }
+-    *ts = stream->segment_index * duration;
++    stream_period = gst_mpdparser_get_stream_period (client);
++    *ts = stream_period->start + stream->segment_index * duration;
+   }
+ 
+   return TRUE;

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0012-adaptivedemux-Fix-bitrate-printed-in-debug.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0012-adaptivedemux-Fix-bitrate-printed-in-debug.patch
@@ -1,0 +1,29 @@
+From bb9807311a8e5c68406230167340c8bf0087682f Mon Sep 17 00:00:00 2001
+From: Jan Schmidt <jan@centricular.com>
+Date: Fri, 13 Jan 2017 23:10:52 +1100
+Subject: [PATCH 1/5] adaptivedemux: Fix bitrate printed in debug
+
+The download bitrate is already in bits per second,
+no need to multiply it by 8 again when printing it
+for debug.
+---
+ gst-libs/gst/adaptivedemux/gstadaptivedemux.c | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/gst-libs/gst/adaptivedemux/gstadaptivedemux.c b/gst-libs/gst/adaptivedemux/gstadaptivedemux.c
+index b485b0095..b3e354e6f 100644
+--- a/gst-libs/gst/adaptivedemux/gstadaptivedemux.c
++++ b/gst-libs/gst/adaptivedemux/gstadaptivedemux.c
+@@ -1914,8 +1914,7 @@ gst_adaptive_demux_stream_update_current_bitrate (GstAdaptiveDemux * demux,
+ 
+   stream->current_download_rate *= demux->bitrate_limit;
+   GST_DEBUG_OBJECT (demux, "Bitrate after bitrate limit (%0.2f): %"
+-      G_GUINT64_FORMAT, demux->bitrate_limit,
+-      stream->current_download_rate * 8);
++      G_GUINT64_FORMAT, demux->bitrate_limit, stream->current_download_rate);
+ 
+ #if 0
+   /* Debugging code, modulate the bitrate every few fragments */
+-- 
+2.17.0
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0013-adaptivemutex-Fix-double-mutex-unlock.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0013-adaptivemutex-Fix-double-mutex-unlock.patch
@@ -1,0 +1,41 @@
+From 3004ec54e1b5515d4bc3971bf9d07a34007d7df7 Mon Sep 17 00:00:00 2001
+From: Thomas Bluemel <tbluemel@control4.com>
+Date: Mon, 27 Feb 2017 14:54:43 -0700
+Subject: [PATCH 2/5] adaptivemutex: Fix double mutex unlock
+
+https://bugzilla.gnome.org/show_bug.cgi?id=779480
+---
+ gst-libs/gst/adaptivedemux/gstadaptivedemux.c | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/gst-libs/gst/adaptivedemux/gstadaptivedemux.c b/gst-libs/gst/adaptivedemux/gstadaptivedemux.c
+index b3e354e6f..baa2685ea 100644
+--- a/gst-libs/gst/adaptivedemux/gstadaptivedemux.c
++++ b/gst-libs/gst/adaptivedemux/gstadaptivedemux.c
+@@ -2831,6 +2831,11 @@ gst_adaptive_demux_stream_download_uri (GstAdaptiveDemux * demux,
+         *http_status = stream->last_status_code;
+       }
+     }
++
++    /* changing src element state might try to join the streaming thread, so
++     * we must not hold the manifest lock.
++     */
++    GST_MANIFEST_UNLOCK (demux);
+   } else {
+     GST_MANIFEST_UNLOCK (demux);
+     if (stream->last_ret == GST_FLOW_OK)
+@@ -2838,11 +2843,6 @@ gst_adaptive_demux_stream_download_uri (GstAdaptiveDemux * demux,
+     ret = GST_FLOW_CUSTOM_ERROR;
+   }
+ 
+-  /* changing src element state might try to join the streaming thread, so
+-   * we must not hold the manifest lock.
+-   */
+-  GST_MANIFEST_UNLOCK (demux);
+-
+   stream->src_at_ready = FALSE;
+ 
+   gst_element_set_locked_state (stream->src, TRUE);
+-- 
+2.17.0
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0014-adaptivedemux-retry-download-MAX_DOWNLOAD_RETRY_COUN.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0014-adaptivedemux-retry-download-MAX_DOWNLOAD_RETRY_COUN.patch
@@ -1,0 +1,33 @@
+From 29f733ab28651d2d6130918ae8b7cac0c6678ecd Mon Sep 17 00:00:00 2001
+From: Matthew Waters <matthew@centricular.com>
+Date: Fri, 2 Dec 2016 17:51:57 +1100
+Subject: [PATCH 3/5] adaptivedemux: retry download MAX_DOWNLOAD_RETRY_COUNT
+ times before erroring
+
+What we want is to retry downloading the fragment on 4xx/5xx errors
+however returning EOS will cause waiting for a manifest update for live
+(which may be a really long time) or stop everything for non-live.
+
+Change that to only return EOS/ERROR once we've reached the error limit.
+
+https://bugzilla.gnome.org/show_bug.cgi?id=776609
+---
+ gst-libs/gst/adaptivedemux/gstadaptivedemux.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gst-libs/gst/adaptivedemux/gstadaptivedemux.c b/gst-libs/gst/adaptivedemux/gstadaptivedemux.c
+index baa2685ea..1f4f8013f 100644
+--- a/gst-libs/gst/adaptivedemux/gstadaptivedemux.c
++++ b/gst-libs/gst/adaptivedemux/gstadaptivedemux.c
+@@ -3113,7 +3113,7 @@ again:
+     }
+ 
+   flushing:
+-    if (++stream->download_error_count <= MAX_DOWNLOAD_ERROR_COUNT) {
++    if (stream->download_error_count >= MAX_DOWNLOAD_ERROR_COUNT) {
+       /* looks like there is no way of knowing when a live stream has ended
+        * Have to assume we are falling behind and cause a manifest reload */
+       GST_DEBUG_OBJECT (stream->pad, "Converting error of live stream to EOS");
+-- 
+2.17.0
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0015-adaptivedemux-Don-t-hold-locks-when-pushing-FLUSH_ST.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0015-adaptivedemux-Don-t-hold-locks-when-pushing-FLUSH_ST.patch
@@ -1,0 +1,36 @@
+From dc99f7652391096253fff925487c0f9be813c412 Mon Sep 17 00:00:00 2001
+From: Edward Hervey <edward@centricular.com>
+Date: Fri, 14 Apr 2017 18:16:28 +0200
+Subject: [PATCH 4/5] adaptivedemux: Don't hold locks when pushing FLUSH_START
+
+Some actions (Qos, reconfigure, ...) might take place before we finish pushing out flush_start.
+
+One problem would be that:
+1) The QOS handling in adaptivedemux takes the MANIFEST LOCK
+  That QOS event comes from basesink with its PREROLL_LOCK taken
+2) FLUSH_START is sent from adaptivedemux with the MANIFEST_LOCK taken and the basesink flushing handler needs to take the PREROLL_LOCK
+
+ => deadlock
+
+https://bugzilla.gnome.org/show_bug.cgi?id=781320
+---
+ gst-libs/gst/adaptivedemux/gstadaptivedemux.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/gst-libs/gst/adaptivedemux/gstadaptivedemux.c b/gst-libs/gst/adaptivedemux/gstadaptivedemux.c
+index 1f4f8013f..ae0a2bb53 100644
+--- a/gst-libs/gst/adaptivedemux/gstadaptivedemux.c
++++ b/gst-libs/gst/adaptivedemux/gstadaptivedemux.c
+@@ -1404,7 +1404,9 @@ gst_adaptive_demux_handle_seek_event (GstAdaptiveDemux * demux, GstPad * pad,
+     GST_DEBUG_OBJECT (demux, "sending flush start");
+     fevent = gst_event_new_flush_start ();
+     gst_event_set_seqnum (fevent, seqnum);
++    GST_MANIFEST_UNLOCK (demux);
+     gst_adaptive_demux_push_src_event (demux, fevent);
++    GST_MANIFEST_LOCK (demux);
+ 
+     gst_adaptive_demux_stop_tasks (demux);
+   } else if ((rate > 0 && start_type != GST_SEEK_TYPE_NONE) ||
+-- 
+2.17.0
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0016-dashdemux-Fix-issue-when-manifest-update-sets-slow-s.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0016-dashdemux-Fix-issue-when-manifest-update-sets-slow-s.patch
@@ -1,0 +1,81 @@
+From 6980121d0e216baae19d972fbf5b9e4ab764c1ad Mon Sep 17 00:00:00 2001
+From: WeiChungChang <r97922153@gmail.com>
+Date: Tue, 17 Jan 2017 10:33:03 +0800
+Subject: [PATCH 5/5] dashdemux: Fix issue when manifest update sets slow start
+ without passing necessary header & caps changes downstream
+
+https://bugzilla.gnome.org/show_bug.cgi?id=777206
+---
+ ext/dash/gstdashdemux.c | 29 +++++++++++++++++++++++++++++
+ ext/dash/gstdashdemux.h |  1 +
+ 2 files changed, 30 insertions(+)
+
+diff --git a/ext/dash/gstdashdemux.c b/ext/dash/gstdashdemux.c
+index b10465eb9..0bc58f136 100644
+--- a/ext/dash/gstdashdemux.c
++++ b/ext/dash/gstdashdemux.c
+@@ -711,6 +711,7 @@ gst_dash_demux_setup_all_streams (GstDashDemux * demux)
+           (stream), tags);
+     stream->index = i;
+     stream->pending_seek_ts = GST_CLOCK_TIME_NONE;
++    stream->last_representation_id = NULL;
+     if (active_stream->cur_adapt_set &&
+         active_stream->cur_adapt_set->RepresentationBase &&
+         active_stream->cur_adapt_set->RepresentationBase->ContentProtection) {
+@@ -1149,6 +1150,33 @@ gst_dash_demux_stream_update_fragment_info (GstAdaptiveDemuxStream * stream)
+ 
+   if (gst_mpd_client_get_next_fragment_timestamp (dashdemux->client,
+           dashstream->index, &ts)) {
++    if (gst_mpd_client_is_live (dashdemux->client)) {
++      if (!GST_ADAPTIVE_DEMUX_STREAM_NEED_HEADER (stream)) {
++        if (dashstream->active_stream
++            && dashstream->active_stream->cur_representation) {
++          /* id specifies an identifier for this Representation. The
++           * identifier shall be unique within a Period unless the
++           * Representation is functionally identically to another
++           * Representation in the same Period. */
++          if (!g_strcmp0 (dashstream->active_stream->cur_representation->id,
++                  dashstream->last_representation_id)) {
++            GstCaps *caps;
++            stream->need_header = TRUE;
++
++            GST_INFO_OBJECT (dashdemux, "Switching bitrate to %d",
++                dashstream->active_stream->cur_representation->bandwidth);
++            caps =
++                gst_dash_demux_get_input_caps (dashdemux,
++                dashstream->active_stream);
++            gst_adaptive_demux_stream_set_caps (stream, caps);
++          }
++        }
++      }
++      g_free (dashstream->last_representation_id);
++      dashstream->last_representation_id =
++          g_strdup (dashstream->active_stream->cur_representation->id);
++    }
++
+     if (GST_ADAPTIVE_DEMUX_STREAM_NEED_HEADER (stream)) {
+       gst_adaptive_demux_stream_fragment_clear (&stream->fragment);
+       gst_dash_demux_stream_update_headers_info (stream);
+@@ -2680,6 +2708,7 @@ gst_dash_demux_stream_free (GstAdaptiveDemuxStream * stream)
+     gst_isoff_moof_box_free (dash_stream->moof);
+   if (dash_stream->moof_sync_samples)
+     g_array_free (dash_stream->moof_sync_samples, TRUE);
++  g_free (dash_stream->last_representation_id);
+ }
+ 
+ static GstDashDemuxClockDrift *
+diff --git a/ext/dash/gstdashdemux.h b/ext/dash/gstdashdemux.h
+index 0757d76b1..2bbd4f18b 100644
+--- a/ext/dash/gstdashdemux.h
++++ b/ext/dash/gstdashdemux.h
+@@ -96,6 +96,7 @@ struct _GstDashDemuxStream
+ 
+   guint64 moof_average_size, first_sync_sample_average_size;
+   gboolean first_sync_sample_after_moof, first_sync_sample_always_after_moof;
++  gchar *last_representation_id;
+ };
+ 
+ /**
+-- 
+2.17.0
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0017-adaptivedemux-Fix-startup-SEGMENT-seeking-and-settin.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0017-adaptivedemux-Fix-startup-SEGMENT-seeking-and-settin.patch
@@ -1,0 +1,60 @@
+From a6cefff08613bbadb1e6ad825f30076efaae3274 Mon Sep 17 00:00:00 2001
+From: Seungha Yang <sh.yang@lge.com>
+Date: Thu, 10 Nov 2016 23:07:50 +0900
+Subject: [PATCH] adaptivedemux: Fix startup SEGMENT seeking and setting for
+ live
+
+Because fragment.timestamp is relative value to period_start,
+startup SEGMENT seeking should be pointed to "fragment.timestamp + period_start"
+
+https://bugzilla.gnome.org/show_bug.cgi?id=774196
+---
+ gst-libs/gst/adaptivedemux/gstadaptivedemux.c | 16 +++++++++++-----
+ 1 file changed, 11 insertions(+), 5 deletions(-)
+
+diff --git a/gst-libs/gst/adaptivedemux/gstadaptivedemux.c b/gst-libs/gst/adaptivedemux/gstadaptivedemux.c
+index ae0a2bb..774a68a 100644
+--- a/gst-libs/gst/adaptivedemux/gstadaptivedemux.c
++++ b/gst-libs/gst/adaptivedemux/gstadaptivedemux.c
+@@ -997,6 +997,8 @@ gst_adaptive_demux_expose_streams (GstAdaptiveDemux * demux,
+     }
+   }
+ 
++  period_start = gst_adaptive_demux_get_period_start_time (demux);
++
+   /* For live streams, the subclass is supposed to seek to the current
+    * fragment and then tell us its timestamp in stream->fragment.timestamp.
+    * We now also have to seek our demuxer segment to reflect this.
+@@ -1005,12 +1007,10 @@ gst_adaptive_demux_expose_streams (GstAdaptiveDemux * demux,
+    */
+   if (first_and_live) {
+     gst_segment_do_seek (&demux->segment, demux->segment.rate, GST_FORMAT_TIME,
+-        GST_SEEK_FLAG_FLUSH, GST_SEEK_TYPE_SET, min_pts, GST_SEEK_TYPE_NONE, -1,
+-        NULL);
++        GST_SEEK_FLAG_FLUSH, GST_SEEK_TYPE_SET, min_pts + period_start,
++        GST_SEEK_TYPE_NONE, -1, NULL);
+   }
+ 
+-  period_start = gst_adaptive_demux_get_period_start_time (demux);
+-
+   for (iter = demux->streams; iter; iter = g_list_next (iter)) {
+     GstAdaptiveDemuxStream *stream = iter->data;
+     GstClockTime offset;
+@@ -1067,7 +1067,13 @@ gst_adaptive_demux_expose_streams (GstAdaptiveDemux * demux,
+      * equivalent.
+      */
+ 
+-    if (demux->segment.start > period_start) {
++    /* If first and live, demuxer did seek to the current position already */
++    if (first_and_live) {
++      stream->segment.start = demux->segment.start - period_start + offset;
++      stream->segment.position = stream->segment.start;
++      stream->segment.time = demux->segment.time;
++      stream->segment.base = demux->segment.base;
++    } else if (demux->segment.start > period_start) {
+       stream->segment.start = demux->segment.start - period_start + offset;
+       stream->segment.position = offset;
+       stream->segment.time = demux->segment.time;
+-- 
+2.17.0
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0018-mssdemux-parse-protection-data.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0018-mssdemux-parse-protection-data.patch
@@ -1,0 +1,302 @@
+From 712021979a34a3949a27b6d38b7fe445ab0a0e69 Mon Sep 17 00:00:00 2001
+From: Charlie Turner <chturne@gmail.com>
+Date: Fri, 25 May 2018 09:43:30 +0100
+Subject: [PATCH] Parse playready payload.
+
+Look at the playready specific data payload to extract default key ids
+for decrypting samples. The format of this payload seems to be
+proprietary.
+---
+ ext/smoothstreaming/gstmssdemux.c    |  19 +++-
+ ext/smoothstreaming/gstmssmanifest.c | 146 ++++++++++++++++++++++++++-
+ ext/smoothstreaming/gstmssmanifest.h |   1 +
+ 3 files changed, 159 insertions(+), 7 deletions(-)
+
+diff --git a/ext/smoothstreaming/gstmssdemux.c b/ext/smoothstreaming/gstmssdemux.c
+index 26147fd..5802c98 100644
+--- a/ext/smoothstreaming/gstmssdemux.c
++++ b/ext/smoothstreaming/gstmssdemux.c
+@@ -465,7 +465,7 @@ gst_mss_demux_setup_streams (GstAdaptiveDemux * demux)
+         gst_adaptive_demux_stream_new (GST_ADAPTIVE_DEMUX_CAST (mssdemux),
+         srcpad);
+     stream->manifest_stream = manifeststream;
+-    stream->adapter = gst_adapter_new();
++    stream->adapter = gst_adapter_new ();
+     gst_mss_stream_set_active (manifeststream, TRUE);
+     active_streams = g_slist_prepend (active_streams, stream);
+   }
+@@ -508,6 +508,18 @@ gst_mss_demux_setup_streams (GstAdaptiveDemux * demux)
+           gst_event_new_protection (protection_system_id, protection_buffer,
+           "smooth-streaming");
+ 
++      GstBuffer *key_id = gst_mss_manifest_get_key_id (mssdemux->manifest);
++      if (!gst_buffer_get_size (key_id)) {
++        GST_WARNING_OBJECT (stream,
++            "protected manifest, but no key ids available");
++      } else {
++        GST_LOG_OBJECT (stream,
++            "Adding key id to the protection event of size %lu",
++            gst_buffer_get_size (key_id));
++        GstStructure *structure = gst_event_writable_structure (event);
++        gst_structure_set (structure, "key_id", GST_TYPE_BUFFER, key_id, NULL);
++      }
++
+       GST_LOG_OBJECT (stream, "Queuing Protection event on source pad");
+       gst_adaptive_demux_stream_queue_event ((GstAdaptiveDemuxStream *) stream,
+           event);
+@@ -700,7 +712,7 @@ gst_mss_demux_update_manifest_data (GstAdaptiveDemux * demux,
+ 
+ static GstFlowReturn
+ gst_mss_demux_data_received (GstAdaptiveDemux * demux,
+-    GstAdaptiveDemuxStream * stream, GstBuffer *buffer)
++    GstAdaptiveDemuxStream * stream, GstBuffer * buffer)
+ {
+   GstMssDemux *mssdemux = GST_MSS_DEMUX_CAST (demux);
+   GstMssDemuxStream *mssstream = (GstMssDemuxStream *) stream;
+@@ -732,7 +744,8 @@ gst_mss_demux_data_received (GstAdaptiveDemux * demux,
+     }
+   }
+ 
+-  return GST_ADAPTIVE_DEMUX_CLASS (parent_class)->data_received (demux, stream, buffer);
++  return GST_ADAPTIVE_DEMUX_CLASS (parent_class)->data_received (demux, stream,
++      buffer);
+ }
+ 
+ static gboolean
+diff --git a/ext/smoothstreaming/gstmssmanifest.c b/ext/smoothstreaming/gstmssmanifest.c
+index e5ecf5a..7a2b2e9 100644
+--- a/ext/smoothstreaming/gstmssmanifest.c
++++ b/ext/smoothstreaming/gstmssmanifest.c
+@@ -28,6 +28,8 @@
+ #include <ctype.h>
+ #include <libxml/parser.h>
+ #include <libxml/tree.h>
++#include <libxml/xpath.h>
++#include <libxml/xpathInternals.h>
+ 
+ /* for parsing h264 codec data */
+ #include <gst/codecparsers/gsth264parser.h>
+@@ -109,6 +111,10 @@ struct _GstMssManifest
+   GString *protection_system_id;
+   gchar *protection_data;
+ 
++  // FIXME: There can be multiple key ids present in protected manifests.
++  gchar *key_id;
++  gsize key_id_len;
++
+   GSList *streams;
+ };
+ 
+@@ -305,10 +311,10 @@ _gst_mss_stream_init (GstMssManifest * manifest, GstMssStream * stream,
+ 
+   if (stream->has_live_fragments) {
+     /* Skip all fragments except the first one (more recently added) */
+-    GList* skipped;
++    GList *skipped;
+ 
+     stream->fragments = builder.fragments;
+-    skipped = g_list_remove_link(builder.fragments, builder.fragments);
++    skipped = g_list_remove_link (builder.fragments, builder.fragments);
+     g_list_free_full (skipped, g_free);
+ 
+     g_queue_init (&stream->live_fragments);
+@@ -333,6 +339,122 @@ _gst_mss_stream_init (GstMssManifest * manifest, GstMssStream * stream,
+   gst_mss_fragment_parser_init (&stream->fragment_parser);
+ }
+ 
++static void
++_gst_mss_parse_protection_data (GstMssManifest * manifest)
++{
++  guchar *decoded_protection_data = NULL;
++  gsize decoded_protection_data_len = 0;
++  xmlChar *protection_data_text = NULL;
++  int protection_data_text_len = 0;
++  xmlDocPtr protection_data_xml = NULL;
++  // Note, this does not need to free'd, freeing the doc ptr will free this.
++  xmlNode *protection_data_root_element = NULL;
++  const xmlChar *protection_data_namespace = NULL;
++  xmlXPathContextPtr xpath_ctx = NULL;
++  xmlXPathObjectPtr xpath_obj = NULL;
++  xmlNodeSetPtr key_id_node = NULL;
++  gsize protection_data_xml_len = 0;
++  guchar *start_tag = NULL;
++
++  decoded_protection_data =
++      g_base64_decode (manifest->protection_data, &decoded_protection_data_len);
++
++  start_tag = decoded_protection_data;
++
++  // The protection data starts with a 10-byte PlayReady version
++  // header that needs to be skipped over to avoid XML parsing
++  // errors.
++  while (start_tag && *start_tag != '<')
++    start_tag++;
++
++  if (!start_tag) {
++    GST_ERROR ("failed to find a start tag in protection data payload");
++    goto beach;
++  }
++
++  protection_data_xml_len =
++      decoded_protection_data_len - (start_tag - decoded_protection_data);
++  protection_data_xml =
++      xmlReadMemory ((const gchar *) start_tag, protection_data_xml_len,
++      "protection_data", "utf-16", 0);
++
++  if (!protection_data_xml) {
++    GST_ERROR ("failed to parse protection data XML");
++    goto beach;
++  }
++
++  if (gst_debug_category_get_threshold (GST_CAT_DEFAULT) >= GST_LEVEL_MEMDUMP) {
++    xmlDocDumpMemoryEnc (protection_data_xml, &protection_data_text,
++        &protection_data_text_len, "utf8");
++    GST_MEMDUMP ("protection data XML", protection_data_text,
++        protection_data_text_len);
++    xmlFree (protection_data_text);
++  }
++
++  protection_data_root_element = xmlDocGetRootElement (protection_data_xml);
++  if (protection_data_root_element->type != XML_ELEMENT_NODE ||
++      xmlStrcmp (protection_data_root_element->name,
++          (const xmlChar *) "WRMHEADER") || !protection_data_root_element->ns) {
++    GST_ERROR ("invalid protection data XML");
++    goto beach;
++  }
++
++  xpath_ctx = xmlXPathNewContext (protection_data_xml);
++  if (!xpath_ctx) {
++    GST_ERROR ("failed to create xpath context");
++    goto beach;
++  }
++
++  protection_data_namespace = protection_data_root_element->ns->href;
++  if (xmlXPathRegisterNs (xpath_ctx, (const xmlChar *) "prhdr",
++          protection_data_namespace) < 0) {
++    GST_ERROR ("failed to register XML namespace");
++    goto beach;
++  }
++
++  xpath_obj =
++      xmlXPathEvalExpression ((const xmlChar *) "//prhdr:KID", xpath_ctx);
++  if (!xpath_obj) {
++    GST_DEBUG ("failed to eval XPath expression");
++    goto beach;
++  }
++
++  key_id_node = xpath_obj->nodesetval;
++  int num_key_ids = key_id_node ? key_id_node->nodeNr : 0;
++
++  GST_DEBUG ("found %d key ids", num_key_ids);
++
++  if (num_key_ids != 0 && (key_id_node->nodeTab[0]->type == XML_ELEMENT_NODE)) {
++    xmlChar *encoded_key_id = xmlNodeGetContent (key_id_node->nodeTab[0]);
++    gsize decoded_key_id_len;
++    guchar *decoded_key_id =
++        g_base64_decode ((const gchar *) encoded_key_id, &decoded_key_id_len);
++
++    GST_MEMDUMP ("key retrieved", decoded_key_id, decoded_key_id_len);
++
++    manifest->key_id = g_realloc (manifest->key_id, decoded_key_id_len);
++    memcpy (manifest->key_id, decoded_key_id, decoded_key_id_len);
++    manifest->key_id_len = decoded_key_id_len;
++
++    xmlFree (encoded_key_id);
++    g_free (decoded_key_id);
++  } else {
++    GST_ERROR ("invalid XML payload");
++    goto beach;
++  }
++
++beach:
++  if (decoded_protection_data)
++    g_free (decoded_protection_data);
++  if (xpath_ctx)
++    xmlXPathFreeContext (xpath_ctx);
++  if (xpath_obj)
++    xmlXPathFreeObject (xpath_obj);
++  if (protection_data_xml)
++    xmlFreeDoc (protection_data_xml);
++
++  return;
++}
+ 
+ static void
+ _gst_mss_parse_protection (GstMssManifest * manifest,
+@@ -362,6 +484,7 @@ _gst_mss_parse_protection (GstMssManifest * manifest,
+ 
+       manifest->protection_system_id = system_id;
+       manifest->protection_data = (gchar *) xmlNodeGetContent (nodeiter);
++      _gst_mss_parse_protection_data (manifest);
+       xmlFree (system_id_attribute);
+       break;
+     }
+@@ -418,6 +541,9 @@ gst_mss_manifest_new (GstBuffer * data)
+     }
+   }
+ 
++  manifest->key_id = NULL;
++  manifest->key_id_len = 0;
++
+   for (nodeiter = root->children; nodeiter; nodeiter = nodeiter->next) {
+     if (nodeiter->type == XML_ELEMENT_NODE
+         && (strcmp ((const char *) nodeiter->name, "StreamIndex") == 0)) {
+@@ -464,6 +590,9 @@ gst_mss_manifest_free (GstMssManifest * manifest)
+ 
+   g_slist_free_full (manifest->streams, (GDestroyNotify) gst_mss_stream_free);
+ 
++  if (manifest->key_id)
++    g_free (manifest->key_id);
++
+   if (manifest->protection_system_id != NULL)
+     g_string_free (manifest->protection_system_id, TRUE);
+   xmlFree (manifest->protection_data);
+@@ -486,6 +615,15 @@ gst_mss_manifest_get_protection_data (GstMssManifest * manifest)
+   return manifest->protection_data;
+ }
+ 
++GstBuffer *
++gst_mss_manifest_get_key_id (GstMssManifest * manifest)
++{
++  GstBuffer *key_id_buffer =
++      gst_buffer_new_allocate (NULL, manifest->key_id_len, NULL);
++  gst_buffer_fill (key_id_buffer, 0, manifest->key_id, manifest->key_id_len);
++  return key_id_buffer;
++}
++
+ GSList *
+ gst_mss_manifest_get_streams (GstMssManifest * manifest)
+ {
+@@ -1267,7 +1405,7 @@ gst_mss_stream_seek (GstMssStream * stream, gboolean forward,
+   GST_DEBUG ("Stream %s seeking to %" G_GUINT64_FORMAT, stream->url, time);
+   for (iter = stream->fragments; iter; iter = g_list_next (iter)) {
+     fragment = iter->data;
+-    if(stream->has_live_fragments){
++    if (stream->has_live_fragments) {
+       if (fragment->time + fragment->repetitions * fragment->duration > time)
+         stream->current_fragment = iter;
+       break;
+@@ -1583,7 +1721,7 @@ gst_mss_stream_fragment_parse (GstMssStream * stream, GstBuffer * buffer)
+     GstMssStreamFragment *fragment;
+ 
+     if (last == NULL)
+-        break;
++      break;
+     fragment = g_new (GstMssStreamFragment, 1);
+     fragment->number = last->number + 1;
+     fragment->repetitions = 1;
+diff --git a/ext/smoothstreaming/gstmssmanifest.h b/ext/smoothstreaming/gstmssmanifest.h
+index 29545af..3f9f49a 100644
+--- a/ext/smoothstreaming/gstmssmanifest.h
++++ b/ext/smoothstreaming/gstmssmanifest.h
+@@ -55,6 +55,7 @@ GstClockTime gst_mss_manifest_get_min_fragment_duration (GstMssManifest * manife
+ const gchar * gst_mss_manifest_get_protection_system_id (GstMssManifest * manifest);
+ const gchar * gst_mss_manifest_get_protection_data (GstMssManifest * manifest);
+ gboolean gst_mss_manifest_get_live_seek_range (GstMssManifest * manifest, gint64 * start, gint64 * stop);
++GstBuffer * gst_mss_manifest_get_key_id (GstMssManifest * manifest);
+ 
+ GstMssStreamType gst_mss_stream_get_type (GstMssStream *stream);
+ GstCaps * gst_mss_stream_get_caps (GstMssStream * stream);
+-- 
+2.17.0
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0019-mssdemux-support-for-live-content-as-vod.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0019-mssdemux-support-for-live-content-as-vod.patch
@@ -1,0 +1,162 @@
+From 747d71056c368136c30d4911c4bcf1a78e05a9e2 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Enrique=20Oca=C3=B1a=20Gonz=C3=A1lez?= <eocanha@igalia.com>
+Date: Thu, 22 Nov 2018 12:21:53 +0000
+Subject: [PATCH] mssdemux: support for live content as vod
+
+Some content providers store live videos (with initial PTS very far away from
+zero) and later serve them as regular video-on-demand content (isLive=false),
+which is expected to start from zero.
+
+This patch detects those contents (non-live, not-zero start) and uses probes
+on the MssDemux src pads to "fix" the PTS by offsetting it back to start from
+zero.
+---
+ ext/smoothstreaming/gstmssdemux.c    | 72 ++++++++++++++++++++++++++++
+ ext/smoothstreaming/gstmssmanifest.c | 28 +++++++++++
+ ext/smoothstreaming/gstmssmanifest.h |  1 +
+ 3 files changed, 101 insertions(+)
+
+diff --git a/ext/smoothstreaming/gstmssdemux.c b/ext/smoothstreaming/gstmssdemux.c
+index 1624cf7d7..49ebdee74 100644
+--- a/ext/smoothstreaming/gstmssdemux.c
++++ b/ext/smoothstreaming/gstmssdemux.c
+@@ -214,6 +214,76 @@ gst_mss_demux_class_init (GstMssDemuxClass * klass)
+   GST_DEBUG_CATEGORY_INIT (mssdemux_debug, "mssdemux", 0, "mssdemux plugin");
+ }
+ 
++static GstPadProbeReturn live_as_vod_pts_fixer_probe (GstPad *pad,
++    GstPadProbeInfo *info, gpointer user_data)
++{
++    const GstClockTime* live_as_vod_offset = (const GstClockTime*)user_data;
++    GstBuffer* buffer = GST_PAD_PROBE_INFO_BUFFER(info);
++
++    if (G_LIKELY(GST_BUFFER_PTS(buffer) != GST_CLOCK_TIME_NONE))
++        GST_BUFFER_PTS(buffer) -= *live_as_vod_offset;
++
++    return GST_PAD_PROBE_OK;
++}
++
++// This function installs probes to offset PTSs on those non-live streams
++// which don't start from zero (because they're just live streams reconverted
++// to non-live). The offset will adjust the PTSs to start from zero, so the
++// stream behaves as a well formed non-live stream.
++static void setup_live_as_vod_offset (GstElement *element, gpointer user_data)
++{
++    GstAdaptiveDemux *adaptivedemux = GST_ADAPTIVE_DEMUX_CAST (element);
++    GstMssDemux *mssdemux = GST_MSS_DEMUX_CAST (element);
++    GstClockTime stream_start_time, live_as_vod_offset = GST_CLOCK_TIME_NONE;
++    GList* streams;
++    GstIterator* it;
++    GValue item = G_VALUE_INIT;
++
++    GST_DEBUG_OBJECT(element, "No more pads, setting up live-as-VoD offset");
++
++    if (gst_mss_manifest_is_live (mssdemux->manifest)) {
++        GST_DEBUG_OBJECT(element, "Stream is live, doing nothing");
++        return;
++    }
++
++    if (!adaptivedemux->streams) {
++        GST_WARNING_OBJECT (adaptivedemux, "No streams yet");
++        return;
++    }
++
++    for (streams = adaptivedemux->streams; streams; streams = streams->next) {
++      GstMssDemuxStream* mssdemuxstream = (GstMssDemuxStream*)(adaptivedemux->streams->data);
++      stream_start_time = (gst_mss_manifest_is_live (mssdemux->manifest)) ? GST_CLOCK_TIME_NONE :
++          gst_mss_stream_get_first_fragment_gst_timestamp(mssdemuxstream->manifest_stream);
++      if (stream_start_time == 0)
++        stream_start_time = GST_CLOCK_TIME_NONE;
++
++      // This assumes that GST_CLOCK_TIME_NONE is larger than any valid time value
++      if (stream_start_time < live_as_vod_offset)
++          live_as_vod_offset = stream_start_time;
++    }
++
++    if (live_as_vod_offset == GST_CLOCK_TIME_NONE) {
++        GST_DEBUG_OBJECT(element, "All streams start at zero, doing nothing");
++        return;
++    }
++
++    GST_DEBUG_OBJECT (mssdemux, "Minimal offset: %" GST_TIME_FORMAT ", installing probes",
++        GST_TIME_ARGS(live_as_vod_offset));
++
++    it = gst_element_iterate_src_pads(element);
++    while (gst_iterator_next (it, &item) == GST_ITERATOR_OK) {
++      GstPad* pad = GST_PAD(g_value_get_object(&item));
++      GstClockTime* p = g_new (GstClockTime, 1);
++      *p = live_as_vod_offset;
++      GST_DEBUG_OBJECT (pad, "Adding live-as-VoD PTS fixer probe");
++      gst_pad_add_probe(pad, GST_PAD_PROBE_TYPE_BUFFER, live_as_vod_pts_fixer_probe, p, g_free);
++      g_value_reset (&item);
++    }
++    g_value_unset (&item);
++    gst_iterator_free (it);
++}
++
+ static void
+ gst_mss_demux_init (GstMssDemux * mssdemux)
+ {
+@@ -221,6 +291,8 @@ gst_mss_demux_init (GstMssDemux * mssdemux)
+ 
+   gst_adaptive_demux_set_stream_struct_size (GST_ADAPTIVE_DEMUX_CAST (mssdemux),
+       sizeof (GstMssDemuxStream));
++
++  g_signal_connect(GST_ELEMENT(mssdemux), "no-more-pads", G_CALLBACK(setup_live_as_vod_offset), NULL);
+ }
+ 
+ static void
+diff --git a/ext/smoothstreaming/gstmssmanifest.c b/ext/smoothstreaming/gstmssmanifest.c
+index 1ab19daa1..2deadf824 100644
+--- a/ext/smoothstreaming/gstmssmanifest.c
++++ b/ext/smoothstreaming/gstmssmanifest.c
+@@ -1240,6 +1240,34 @@ gst_mss_stream_get_fragment_gst_timestamp (GstMssStream * stream)
+       timescale);
+ }
+ 
++guint64 gst_mss_stream_get_first_fragment_gst_timestamp (GstMssStream * stream)
++{
++  guint64 time;
++  guint64 timescale;
++  GstMssStreamFragment *fragment;
++
++  g_return_val_if_fail (stream->active, GST_CLOCK_TIME_NONE);
++
++  GList *last;
++
++  if (stream->has_live_fragments)
++    last = g_queue_peek_head_link (&stream->live_fragments);
++  else
++    last = g_list_first (stream->fragments);
++  if (last == NULL)
++    return GST_CLOCK_TIME_NONE;
++
++  fragment = last->data;
++
++  GST_LOG_OBJECT (stream, "fragment #%d, time %" GST_TIME_FORMAT,
++      fragment->number, GST_TIME_ARGS(fragment->time));
++
++  time = fragment->time;
++  timescale = gst_mss_stream_get_timescale (stream);
++  return (GstClockTime) gst_util_uint64_scale_round (time, GST_SECOND,
++      timescale);
++}
++
+ GstClockTime
+ gst_mss_stream_get_fragment_gst_duration (GstMssStream * stream)
+ {
+diff --git a/ext/smoothstreaming/gstmssmanifest.h b/ext/smoothstreaming/gstmssmanifest.h
+index 3f9f49ada..c1c615fd3 100644
+--- a/ext/smoothstreaming/gstmssmanifest.h
++++ b/ext/smoothstreaming/gstmssmanifest.h
+@@ -71,6 +71,7 @@ GstFlowReturn gst_mss_stream_advance_fragment (GstMssStream * stream);
+ GstFlowReturn gst_mss_stream_regress_fragment (GstMssStream * stream);
+ void gst_mss_stream_seek (GstMssStream * stream, gboolean forward, GstSeekFlags flags, guint64 time, guint64 * final_time);
+ const gchar * gst_mss_stream_get_lang (GstMssStream * stream);
++guint64 gst_mss_stream_get_first_fragment_gst_timestamp (GstMssStream * stream);
+ 
+ const gchar * gst_mss_stream_type_name (GstMssStreamType streamtype);
+ 
+-- 
+2.17.0
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.10.4.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.10.4.bb
@@ -1,31 +1,34 @@
 require gstreamer1.0-plugins-bad.inc
 
-LIC_FILES_CHKSUM = "file://COPYING;md5=73a5855a8119deb017f5f13cf327095d \
-                    file://COPYING.LIB;md5=21682e4e8fea52413fd26c60acb907e5 \
-                    file://gst/tta/crc32.h;beginline=12;endline=29;md5=27db269c575d1e5317fffca2d33b3b50 \
-                    file://gst/tta/filters.h;beginline=12;endline=29;md5=8a08270656f2f8ad7bb3655b83138e5a"
+LIC_FILES_CHKSUM = "\
+    file://COPYING;md5=73a5855a8119deb017f5f13cf327095d \
+    file://COPYING.LIB;md5=21682e4e8fea52413fd26c60acb907e5 \
+    file://gst/tta/crc32.h;beginline=12;endline=29;md5=27db269c575d1e5317fffca2d33b3b50 \
+    file://gst/tta/filters.h;beginline=12;endline=29;md5=8a08270656f2f8ad7bb3655b83138e5a \
+"
 
-SRC_URI = "https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-1.10.4.tar.xz \
-           file://0001-mssdemux-improved-live-playback-support.patch \
-           file://0002-mssdemux-Handle-the-adapter-in-the-subclass-after-bu.patch \
-           file://0003-adaptivedemux-minimal-HTTP-context-support.patch \
-           file://0004-Fix-to-set-current_fragment-for-live-streaming.patch \
-           file://0005-mpdparser-MS-PlayReady-ContentProtection-parsing.patch \
-           file://0006-Workaround-mss-live-streams-fragments.patch \
-           file://0007-smoothstreaming-implement-adaptivedemux-s-get_live_s.patch \
-           file://0008-mssdemux-Fix-fragment-parsing-issue-during-video-rep.patch \
-           file://0009-Fix-HLS-live-stream-issues-with-http-cdn.metrologica.patch \
-           file://0010-mssdemux-Reduce-SmoothStreaming-latency-on-live-stre.patch \
-           file://0011-mpegdash-live-seek-timestamp-fix.patch \
-           file://0012-adaptivedemux-Fix-bitrate-printed-in-debug.patch \
-           file://0013-adaptivemutex-Fix-double-mutex-unlock.patch \
-           file://0014-adaptivedemux-retry-download-MAX_DOWNLOAD_RETRY_COUN.patch \
-           file://0015-adaptivedemux-Don-t-hold-locks-when-pushing-FLUSH_ST.patch \
-           file://0016-dashdemux-Fix-issue-when-manifest-update-sets-slow-s.patch \
-           file://0017-adaptivedemux-Fix-startup-SEGMENT-seeking-and-settin.patch \
-           file://0018-mssdemux-parse-protection-data.patch \
-           file://0019-mssdemux-support-for-live-content-as-vod.patch \
-           "
+SRC_URI = "\
+    https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-1.10.4.tar.xz \
+    file://0001-mssdemux-improved-live-playback-support.patch \
+    file://0002-mssdemux-Handle-the-adapter-in-the-subclass-after-bu.patch \
+    file://0003-adaptivedemux-minimal-HTTP-context-support.patch \
+    file://0004-Fix-to-set-current_fragment-for-live-streaming.patch \
+    file://0005-mpdparser-MS-PlayReady-ContentProtection-parsing.patch \
+    file://0006-Workaround-mss-live-streams-fragments.patch \
+    file://0007-smoothstreaming-implement-adaptivedemux-s-get_live_s.patch \
+    file://0008-mssdemux-Fix-fragment-parsing-issue-during-video-rep.patch \
+    file://0009-Fix-HLS-live-stream-issues-with-http-cdn.metrologica.patch \
+    file://0010-mssdemux-Reduce-SmoothStreaming-latency-on-live-stre.patch \
+    file://0011-mpegdash-live-seek-timestamp-fix.patch \
+    file://0012-adaptivedemux-Fix-bitrate-printed-in-debug.patch \
+    file://0013-adaptivemutex-Fix-double-mutex-unlock.patch \
+    file://0014-adaptivedemux-retry-download-MAX_DOWNLOAD_RETRY_COUN.patch \
+    file://0015-adaptivedemux-Don-t-hold-locks-when-pushing-FLUSH_ST.patch \
+    file://0016-dashdemux-Fix-issue-when-manifest-update-sets-slow-s.patch \
+    file://0017-adaptivedemux-Fix-startup-SEGMENT-seeking-and-settin.patch \
+    file://0018-mssdemux-parse-protection-data.patch \
+    file://0019-mssdemux-support-for-live-content-as-vod.patch \
+"
 
 SRC_URI[md5sum] = "2757103e57a096a1a05b3ab85b8381af"
 SRC_URI[sha256sum] = "23ddae506b3a223b94869a0d3eea3e9a12e847f94d2d0e0b97102ce13ecd6966"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.10.4.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.10.4.bb
@@ -1,0 +1,36 @@
+require gstreamer1.0-plugins-bad.inc
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=73a5855a8119deb017f5f13cf327095d \
+                    file://COPYING.LIB;md5=21682e4e8fea52413fd26c60acb907e5 \
+                    file://gst/tta/crc32.h;beginline=12;endline=29;md5=27db269c575d1e5317fffca2d33b3b50 \
+                    file://gst/tta/filters.h;beginline=12;endline=29;md5=8a08270656f2f8ad7bb3655b83138e5a"
+
+SRC_URI = "https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-1.10.4.tar.xz \
+           file://0001-mssdemux-improved-live-playback-support.patch \
+           file://0002-mssdemux-Handle-the-adapter-in-the-subclass-after-bu.patch \
+           file://0003-adaptivedemux-minimal-HTTP-context-support.patch \
+           file://0004-Fix-to-set-current_fragment-for-live-streaming.patch \
+           file://0005-mpdparser-MS-PlayReady-ContentProtection-parsing.patch \
+           file://0006-Workaround-mss-live-streams-fragments.patch \
+           file://0007-smoothstreaming-implement-adaptivedemux-s-get_live_s.patch \
+           file://0008-mssdemux-Fix-fragment-parsing-issue-during-video-rep.patch \
+           file://0009-Fix-HLS-live-stream-issues-with-http-cdn.metrologica.patch \
+           file://0010-mssdemux-Reduce-SmoothStreaming-latency-on-live-stre.patch \
+           file://0011-mpegdash-live-seek-timestamp-fix.patch \
+           file://0012-adaptivedemux-Fix-bitrate-printed-in-debug.patch \
+           file://0013-adaptivemutex-Fix-double-mutex-unlock.patch \
+           file://0014-adaptivedemux-retry-download-MAX_DOWNLOAD_RETRY_COUN.patch \
+           file://0015-adaptivedemux-Don-t-hold-locks-when-pushing-FLUSH_ST.patch \
+           file://0016-dashdemux-Fix-issue-when-manifest-update-sets-slow-s.patch \
+           file://0017-adaptivedemux-Fix-startup-SEGMENT-seeking-and-settin.patch \
+           file://0018-mssdemux-parse-protection-data.patch \
+           file://0019-mssdemux-support-for-live-content-as-vod.patch \
+           "
+
+SRC_URI[md5sum] = "2757103e57a096a1a05b3ab85b8381af"
+SRC_URI[sha256sum] = "23ddae506b3a223b94869a0d3eea3e9a12e847f94d2d0e0b97102ce13ecd6966"
+
+S = "${WORKDIR}/gst-plugins-bad-${PV}"
+
+EXTRA_OECONF += "WAYLAND_PROTOCOLS_SYSROOT_DIR=${RECIPE_SYSROOT}"
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.16.%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.16.%.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
 
-SRC_URI += "\
+SRC_URI_append = "\
     file://0001-adaptivedemux-minimal-HTTP-context-support.patch \
     file://0002-Fix-to-set-current_fragment-for-live-streaming.patch \
     file://0003-Add-a-workaround-patch-for-the-mss-live-stream-fragm.patch \

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.16.%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.16.%.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
 
-SRC_URI_append = "\
+SRC_URI_append = " \
     file://0001-adaptivedemux-minimal-HTTP-context-support.patch \
     file://0002-Fix-to-set-current_fragment-for-live-streaming.patch \
     file://0003-Add-a-workaround-patch-for-the-mss-live-stream-fragm.patch \

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base-1.10.4/0001-Revert-uridecodebin-Use-the-correct-caps-name-for-MS.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base-1.10.4/0001-Revert-uridecodebin-Use-the-correct-caps-name-for-MS.patch
@@ -1,0 +1,27 @@
+From 940df6998804e9b2b23614aa916e6c6bfc43de45 Mon Sep 17 00:00:00 2001
+From: Philippe Normand <philn@igalia.com>
+Date: Tue, 22 Sep 2015 09:00:15 +0200
+Subject: [PATCH] Revert "uridecodebin: Use the correct caps name for MS Smooth
+ Streaming manifests"
+
+This reverts commit 2a1e046dd9853fb13caf80e3b3bc11fbcae09d86.
+---
+ gst/playback/gsturidecodebin.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gst/playback/gsturidecodebin.c b/gst/playback/gsturidecodebin.c
+index 24e4427..784d010 100644
+--- a/gst/playback/gsturidecodebin.c
++++ b/gst/playback/gsturidecodebin.c
+@@ -1288,7 +1288,7 @@ static const gchar *blacklisted_uris[] = { NULL };
+ 
+ /* media types that use adaptive streaming */
+ static const gchar *adaptive_media[] = {
+-  "application/x-hls", "application/vnd.ms-sstr+xml",
++  "application/x-hls", "application/x-smoothstreaming-manifest",
+   "application/dash+xml", NULL
+ };
+ 
+-- 
+2.5.0
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base-1.10.4/0001-decodebin-Manually-sync-element-states-with-parent-a.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base-1.10.4/0001-decodebin-Manually-sync-element-states-with-parent-a.patch
@@ -1,0 +1,60 @@
+From e0b99cbbdebdc7983cba0acb6b4120cf0d580c3b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Enrique=20Oca=C3=B1a=20Gonz=C3=A1lez?= <eocanha@igalia.com>
+Date: Thu, 8 Aug 2019 12:13:03 +0000
+Subject: [PATCH] decodebin: Manually sync element states with parent after
+ unsetting locked_state
+
+When the pads of the new elements are connected in decodebin, the new element
+can remain in PAUSED state while decodebin is already in PLAYING. Decodebin
+isn't responsible anymore to set their children to PLAYING, so nobody will do
+it.
+
+This patch detects that situation and manually synchronizes the state of the
+new element to the same of its parent (decodebin).
+
+This change helps to solve some stalls in HLS videos when combined with
+certain hardware decoders.
+---
+ gst/playback/gstdecodebin2.c | 19 ++++++++++++++++++-
+ 1 file changed, 18 insertions(+), 1 deletion(-)
+
+diff --git a/gst/playback/gstdecodebin2.c b/gst/playback/gstdecodebin2.c
+index fa5d159e2..42f27db94 100644
+--- a/gst/playback/gstdecodebin2.c
++++ b/gst/playback/gstdecodebin2.c
+@@ -2110,7 +2110,7 @@ connect_pad (GstDecodeBin * dbin, GstElement * src, GstDecodePad * dpad,
+     GstAutoplugSelectResult ret;
+     GstElementFactory *factory;
+     GstDecodeElement *delem;
+-    GstElement *element;
++    GstElement *element, *parent;
+     GstPad *sinkpad;
+     GParamSpec *pspec;
+     gboolean subtitle;
+@@ -2589,6 +2589,23 @@ connect_pad (GstDecodeBin * dbin, GstElement * src, GstDecodePad * dpad,
+     /* Now let the bin handle the state */
+     gst_element_set_locked_state (element, FALSE);
+ 
++    parent = GST_ELEMENT_PARENT(element);
++
++    if (GST_STATE_TARGET(parent) != GST_STATE_TARGET(element)) {
++        GST_DEBUG_OBJECT (element, "Manually syncing %s state %s/%s/%s with "
++            "parent %s state %s/%s/%s because target state it's different "
++            "after having unset element locked_state",
++            GST_ELEMENT_NAME(element),
++            gst_element_state_get_name(GST_STATE(element)),
++            gst_element_state_get_name(GST_STATE_TARGET(element)),
++            gst_element_state_get_name(GST_STATE_PENDING(element)),
++            GST_ELEMENT_NAME(parent),
++            gst_element_state_get_name(GST_STATE(parent)),
++            gst_element_state_get_name(GST_STATE_TARGET(parent)),
++            gst_element_state_get_name(GST_STATE_PENDING(parent)));
++        gst_element_sync_state_with_parent(element);
++    }
++
+     if (subtitle) {
+       SUBTITLE_LOCK (dbin);
+       /* we added the element now, add it to the list of subtitle-encoding
+-- 
+2.17.1
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base.inc
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base.inc
@@ -9,7 +9,7 @@ SRC_URI_append = "\
 
 LICENSE = "GPLv2+ & LGPLv2+"
 
-DEPENDS += "iso-codes util-linux zlib"
+DEPENDS_append = " iso-codes util-linux zlib"
 
 inherit gettext
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base.inc
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base.inc
@@ -1,0 +1,52 @@
+require gstreamer1.0-plugins.inc
+
+SRC_URI_append = "\
+    file://0001-Makefile.am-don-t-hardcode-libtool-name-when-running.patch \
+    file://0002-Makefile.am-prefix-calls-to-pkg-config-with-PKG_CONF.patch \
+    file://0003-riff-add-missing-include-directories-when-calling-in.patch \
+    file://0004-rtsp-drop-incorrect-reference-to-gstreamer-sdp-in-Ma.patch \
+"
+
+LICENSE = "GPLv2+ & LGPLv2+"
+
+DEPENDS += "iso-codes util-linux zlib"
+
+inherit gettext
+
+PACKAGES_DYNAMIC =+ "^libgst.*"
+
+PACKAGECONFIG ??= " \
+    ${GSTREAMER_ORC} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'alsa', 'alsa', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'x11', '', d)} \
+    gio-unix-2.0 ogg pango opus theora vorbis \
+"
+
+X11DEPENDS = "virtual/libx11 libsm libxrender libxv"
+X11ENABLEOPTS = "--enable-x --enable-xvideo --enable-xshm"
+X11DISABLEOPTS = "--disable-x --disable-xvideo --disable-xshm"
+
+PACKAGECONFIG[alsa]         = "--enable-alsa,--disable-alsa,alsa-lib"
+PACKAGECONFIG[cdparanoia]   = "--enable-cdparanoia,--disable-cdparanoia,cdparanoia"
+PACKAGECONFIG[gio-unix-2.0] = "--enable-gio_unix_2_0,--disable-gio_unix_2_0,glib-2.0"
+PACKAGECONFIG[ivorbis]      = "--enable-ivorbis,--disable-ivorbis,tremor"
+PACKAGECONFIG[ogg]          = "--enable-ogg,--disable-ogg,libogg"
+PACKAGECONFIG[opus]         = "--enable-opus,--disable-opus,libopus"
+PACKAGECONFIG[pango]        = "--enable-pango,--disable-pango,pango"
+PACKAGECONFIG[theora]       = "--enable-theora,--disable-theora,libtheora"
+PACKAGECONFIG[visual]       = "--enable-libvisual,--disable-libvisual,libvisual"
+PACKAGECONFIG[vorbis]       = "--enable-vorbis,--disable-vorbis,libvorbis"
+PACKAGECONFIG[x11]          = "${X11ENABLEOPTS},${X11DISABLEOPTS},${X11DEPENDS}"
+
+EXTRA_OECONF += " \
+    --enable-zlib \
+    --enable-introspection=no \
+"
+
+CACHED_CONFIGUREVARS_append_x86 = " ac_cv_header_emmintrin_h=no ac_cv_header_xmmintrin_h=no"
+
+FILES_${MLPREFIX}libgsttag-1.0 += "${datadir}/gst-plugins-base/1.0/license-translations.dict"
+
+do_compile_prepend() {
+        export GIR_EXTRA_LIBS_PATH="${B}/gst-libs/gst/tag/.libs:${B}/gst-libs/gst/video/.libs:${B}/gst-libs/gst/audio/.libs:${B}/gst-libs/gst/rtp/.libs"
+}

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base.inc
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base.inc
@@ -1,6 +1,6 @@
 require gstreamer1.0-plugins.inc
 
-SRC_URI_append = "\
+SRC_URI_append = " \
     file://0001-Makefile.am-don-t-hardcode-libtool-name-when-running.patch \
     file://0002-Makefile.am-prefix-calls-to-pkg-config-with-PKG_CONF.patch \
     file://0003-riff-add-missing-include-directories-when-calling-in.patch \
@@ -15,7 +15,7 @@ inherit gettext
 
 PACKAGES_DYNAMIC =+ "^libgst.*"
 
-PACKAGECONFIG ??= " \
+PACKAGECONFIG ??= "\
     ${GSTREAMER_ORC} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'alsa', 'alsa', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'x11', '', d)} \
@@ -26,17 +26,17 @@ X11DEPENDS = "virtual/libx11 libsm libxrender libxv"
 X11ENABLEOPTS = "--enable-x --enable-xvideo --enable-xshm"
 X11DISABLEOPTS = "--disable-x --disable-xvideo --disable-xshm"
 
-PACKAGECONFIG[alsa]         = "--enable-alsa,--disable-alsa,alsa-lib"
-PACKAGECONFIG[cdparanoia]   = "--enable-cdparanoia,--disable-cdparanoia,cdparanoia"
+PACKAGECONFIG[alsa] = "--enable-alsa,--disable-alsa,alsa-lib"
+PACKAGECONFIG[cdparanoia] = "--enable-cdparanoia,--disable-cdparanoia,cdparanoia"
 PACKAGECONFIG[gio-unix-2.0] = "--enable-gio_unix_2_0,--disable-gio_unix_2_0,glib-2.0"
-PACKAGECONFIG[ivorbis]      = "--enable-ivorbis,--disable-ivorbis,tremor"
-PACKAGECONFIG[ogg]          = "--enable-ogg,--disable-ogg,libogg"
-PACKAGECONFIG[opus]         = "--enable-opus,--disable-opus,libopus"
-PACKAGECONFIG[pango]        = "--enable-pango,--disable-pango,pango"
-PACKAGECONFIG[theora]       = "--enable-theora,--disable-theora,libtheora"
-PACKAGECONFIG[visual]       = "--enable-libvisual,--disable-libvisual,libvisual"
-PACKAGECONFIG[vorbis]       = "--enable-vorbis,--disable-vorbis,libvorbis"
-PACKAGECONFIG[x11]          = "${X11ENABLEOPTS},${X11DISABLEOPTS},${X11DEPENDS}"
+PACKAGECONFIG[ivorbis] = "--enable-ivorbis,--disable-ivorbis,tremor"
+PACKAGECONFIG[ogg] = "--enable-ogg,--disable-ogg,libogg"
+PACKAGECONFIG[opus] = "--enable-opus,--disable-opus,libopus"
+PACKAGECONFIG[pango] = "--enable-pango,--disable-pango,pango"
+PACKAGECONFIG[theora] = "--enable-theora,--disable-theora,libtheora"
+PACKAGECONFIG[visual] = "--enable-libvisual,--disable-libvisual,libvisual"
+PACKAGECONFIG[vorbis] = "--enable-vorbis,--disable-vorbis,libvorbis"
+PACKAGECONFIG[x11] = "${X11ENABLEOPTS},${X11DISABLEOPTS},${X11DEPENDS}"
 
 EXTRA_OECONF += " \
     --enable-zlib \
@@ -48,5 +48,5 @@ CACHED_CONFIGUREVARS_append_x86 = " ac_cv_header_emmintrin_h=no ac_cv_header_xmm
 FILES_${MLPREFIX}libgsttag-1.0 += "${datadir}/gst-plugins-base/1.0/license-translations.dict"
 
 do_compile_prepend() {
-        export GIR_EXTRA_LIBS_PATH="${B}/gst-libs/gst/tag/.libs:${B}/gst-libs/gst/video/.libs:${B}/gst-libs/gst/audio/.libs:${B}/gst-libs/gst/rtp/.libs"
+    export GIR_EXTRA_LIBS_PATH="${B}/gst-libs/gst/tag/.libs:${B}/gst-libs/gst/video/.libs:${B}/gst-libs/gst/audio/.libs:${B}/gst-libs/gst/rtp/.libs"
 }

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0001-Makefile.am-don-t-hardcode-libtool-name-when-running.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0001-Makefile.am-don-t-hardcode-libtool-name-when-running.patch
@@ -1,0 +1,168 @@
+From f1d9652351e7754c63003104eceb526af424c7e0 Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Fri, 20 Nov 2015 16:53:04 +0200
+Subject: [PATCH 1/4] Makefile.am: don't hardcode libtool name when running
+ introspection tools
+
+Upstream-Status: Pending [review on oe-core maillist]
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+---
+ gst-libs/gst/allocators/Makefile.am | 2 +-
+ gst-libs/gst/app/Makefile.am        | 2 +-
+ gst-libs/gst/audio/Makefile.am      | 2 +-
+ gst-libs/gst/fft/Makefile.am        | 2 +-
+ gst-libs/gst/pbutils/Makefile.am    | 2 +-
+ gst-libs/gst/riff/Makefile.am       | 2 +-
+ gst-libs/gst/rtp/Makefile.am        | 2 +-
+ gst-libs/gst/rtsp/Makefile.am       | 2 +-
+ gst-libs/gst/sdp/Makefile.am        | 2 +-
+ gst-libs/gst/tag/Makefile.am        | 2 +-
+ gst-libs/gst/video/Makefile.am      | 2 +-
+ 11 files changed, 11 insertions(+), 11 deletions(-)
+
+diff --git a/gst-libs/gst/allocators/Makefile.am b/gst-libs/gst/allocators/Makefile.am
+index 9361bf9..bc7f53a 100644
+--- a/gst-libs/gst/allocators/Makefile.am
++++ b/gst-libs/gst/allocators/Makefile.am
+@@ -38,7 +38,7 @@ GstAllocators-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstallocators-@
+ 		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+ 		--library=libgstallocators-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg-export gstreamer-allocators-@GST_API_VERSION@ \
+ 		--output $@ \
+diff --git a/gst-libs/gst/app/Makefile.am b/gst-libs/gst/app/Makefile.am
+index 6d6de8d..dcc2fe0 100644
+--- a/gst-libs/gst/app/Makefile.am
++++ b/gst-libs/gst/app/Makefile.am
+@@ -53,7 +53,7 @@ GstApp-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstapp-@GST_API_VERSIO
+ 		--library=libgstapp-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstBase-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg gstreamer-base-@GST_API_VERSION@ \
+ 		--pkg-export gstreamer-app-@GST_API_VERSION@ \
+diff --git a/gst-libs/gst/audio/Makefile.am b/gst-libs/gst/audio/Makefile.am
+index 275d222..2374196 100644
+--- a/gst-libs/gst/audio/Makefile.am
++++ b/gst-libs/gst/audio/Makefile.am
+@@ -116,7 +116,7 @@ GstAudio-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstaudio-@GST_API_VE
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstBase-@GST_API_VERSION@ \
+ 		--include=GstTag-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg gstreamer-base-@GST_API_VERSION@ \
+ 		--pkg-export gstreamer-audio-@GST_API_VERSION@ \
+diff --git a/gst-libs/gst/fft/Makefile.am b/gst-libs/gst/fft/Makefile.am
+index 09b3d68..f545354 100644
+--- a/gst-libs/gst/fft/Makefile.am
++++ b/gst-libs/gst/fft/Makefile.am
+@@ -65,7 +65,7 @@ GstFft-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstfft-@GST_API_VERSIO
+ 		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+ 		--library=libgstfft-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg-export gstreamer-fft-@GST_API_VERSION@ \
+ 		--output $@ \
+diff --git a/gst-libs/gst/pbutils/Makefile.am b/gst-libs/gst/pbutils/Makefile.am
+index 64d5eb0..91dc214 100644
+--- a/gst-libs/gst/pbutils/Makefile.am
++++ b/gst-libs/gst/pbutils/Makefile.am
+@@ -99,7 +99,7 @@ GstPbutils-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstpbutils-@GST_AP
+ 		--include=GstTag-@GST_API_VERSION@ \
+ 		--include=GstVideo-@GST_API_VERSION@ \
+ 		--include=GstAudio-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg gstreamer-tag-@GST_API_VERSION@ \
+ 		--pkg gstreamer-video-@GST_API_VERSION@ \
+diff --git a/gst-libs/gst/riff/Makefile.am b/gst-libs/gst/riff/Makefile.am
+index 83d83cb..3bd8fc0 100644
+--- a/gst-libs/gst/riff/Makefile.am
++++ b/gst-libs/gst/riff/Makefile.am
+@@ -47,7 +47,7 @@ libgstriff_@GST_API_VERSION@_la_LDFLAGS = $(GST_LIB_LDFLAGS) $(GST_ALL_LDFLAGS)
+ #		--include=GstAudio-@GST_API_VERSION@ \
+ #		--include=GstTag-@GST_API_VERSION@ \
+ #		--include=Gst-@GST_API_VERSION@ \
+-#		--libtool="$(top_builddir)/libtool" \
++#		--libtool="$(LIBTOOL)" \
+ #		--pkg gstreamer-@GST_API_VERSION@ \
+ #		--pkg gstreamer-tag-@GST_API_VERSION@ \
+ #		--pkg gstreamer-audio-@GST_API_VERSION@ \
+diff --git a/gst-libs/gst/rtp/Makefile.am b/gst-libs/gst/rtp/Makefile.am
+index fdd01c1..f5445c1 100644
+--- a/gst-libs/gst/rtp/Makefile.am
++++ b/gst-libs/gst/rtp/Makefile.am
+@@ -65,7 +65,7 @@ GstRtp-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstrtp-@GST_API_VERSIO
+ 		--library=libgstrtp-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstBase-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg gstreamer-base-@GST_API_VERSION@ \
+ 		--pkg-export gstreamer-rtp-@GST_API_VERSION@ \
+diff --git a/gst-libs/gst/rtsp/Makefile.am b/gst-libs/gst/rtsp/Makefile.am
+index ede5706..9b0b258 100644
+--- a/gst-libs/gst/rtsp/Makefile.am
++++ b/gst-libs/gst/rtsp/Makefile.am
+@@ -72,7 +72,7 @@ GstRtsp-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstrtsp-@GST_API_VERS
+ 		--include=Gio-2.0 \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstSdp-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gio-2.0 \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg gstreamer-sdp-@GST_API_VERSION@ \
+diff --git a/gst-libs/gst/sdp/Makefile.am b/gst-libs/gst/sdp/Makefile.am
+index a90f30b..0e149b8 100644
+--- a/gst-libs/gst/sdp/Makefile.am
++++ b/gst-libs/gst/sdp/Makefile.am
+@@ -32,7 +32,7 @@ GstSdp-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstsdp-@GST_API_VERSIO
+ 		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+ 		--library=libgstsdp-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg-export gstreamer-sdp-@GST_API_VERSION@ \
+ 		--output $@ \
+diff --git a/gst-libs/gst/tag/Makefile.am b/gst-libs/gst/tag/Makefile.am
+index c534a4d..cafafd3 100644
+--- a/gst-libs/gst/tag/Makefile.am
++++ b/gst-libs/gst/tag/Makefile.am
+@@ -45,7 +45,7 @@ GstTag-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgsttag-@GST_API_VERSIO
+ 		--library=libgsttag-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstBase-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg gstreamer-base-@GST_API_VERSION@ \
+ 		--pkg-export gstreamer-tag-@GST_API_VERSION@ \
+diff --git a/gst-libs/gst/video/Makefile.am b/gst-libs/gst/video/Makefile.am
+index 5d31fa1..ac64eb3 100644
+--- a/gst-libs/gst/video/Makefile.am
++++ b/gst-libs/gst/video/Makefile.am
+@@ -116,7 +116,7 @@ GstVideo-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstvideo-@GST_API_VE
+ 		--library=libgstvideo-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstBase-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg gstreamer-base-@GST_API_VERSION@ \
+ 		--pkg-export gstreamer-video-@GST_API_VERSION@ \
+-- 
+2.6.2
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0002-Makefile.am-prefix-calls-to-pkg-config-with-PKG_CONF.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0002-Makefile.am-prefix-calls-to-pkg-config-with-PKG_CONF.patch
@@ -1,0 +1,298 @@
+From 990b653c7b6de1937ec759019982d6c5f15770f7 Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Mon, 26 Oct 2015 16:38:18 +0200
+Subject: [PATCH 2/4] Makefile.am: prefix calls to pkg-config with
+ PKG_CONFIG_SYSROOT_DIR
+
+Upstream-Status: Pending [review on oe-core maillist]
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+---
+ gst-libs/gst/allocators/Makefile.am |  4 ++--
+ gst-libs/gst/app/Makefile.am        |  4 ++--
+ gst-libs/gst/audio/Makefile.am      | 12 ++++++------
+ gst-libs/gst/fft/Makefile.am        |  4 ++--
+ gst-libs/gst/pbutils/Makefile.am    | 12 ++++++------
+ gst-libs/gst/riff/Makefile.am       |  8 ++++----
+ gst-libs/gst/rtp/Makefile.am        |  8 ++++----
+ gst-libs/gst/rtsp/Makefile.am       |  4 ++--
+ gst-libs/gst/sdp/Makefile.am        |  4 ++--
+ gst-libs/gst/tag/Makefile.am        |  8 ++++----
+ gst-libs/gst/video/Makefile.am      |  8 ++++----
+ 11 files changed, 38 insertions(+), 38 deletions(-)
+
+diff --git a/gst-libs/gst/allocators/Makefile.am b/gst-libs/gst/allocators/Makefile.am
+index bc7f53a..0ef5f86 100644
+--- a/gst-libs/gst/allocators/Makefile.am
++++ b/gst-libs/gst/allocators/Makefile.am
+@@ -35,7 +35,7 @@ GstAllocators-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstallocators-@
+ 		--c-include "gst/allocators/allocators.h" \
+ 		-I$(top_srcdir)/gst-libs \
+ 		-I$(top_builddir)/gst-libs \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+ 		--library=libgstallocators-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--libtool="$(LIBTOOL)" \
+@@ -59,7 +59,7 @@ typelibs_DATA = $(BUILT_GIRSOURCES:.gir=.typelib)
+ 		$(INTROSPECTION_COMPILER) \
+ 		--includedir=$(srcdir) \
+ 		--includedir=$(builddir) \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+ 		$(INTROSPECTION_COMPILER_OPTS) $< -o $(@F)
+ 
+ CLEANFILES = $(BUILT_GIRSOURCES) $(typelibs_DATA)
+diff --git a/gst-libs/gst/app/Makefile.am b/gst-libs/gst/app/Makefile.am
+index dcc2fe0..dc076cb 100644
+--- a/gst-libs/gst/app/Makefile.am
++++ b/gst-libs/gst/app/Makefile.am
+@@ -48,8 +48,8 @@ GstApp-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstapp-@GST_API_VERSIO
+ 		--c-include "gst/app/app.h" \
+ 		-I$(top_srcdir)/gst-libs \
+ 		-I$(top_builddir)/gst-libs \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ 		--library=libgstapp-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstBase-@GST_API_VERSION@ \
+diff --git a/gst-libs/gst/audio/Makefile.am b/gst-libs/gst/audio/Makefile.am
+index 2374196..295eb42 100644
+--- a/gst-libs/gst/audio/Makefile.am
++++ b/gst-libs/gst/audio/Makefile.am
+@@ -106,12 +106,12 @@ GstAudio-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstaudio-@GST_API_VE
+ 		-I$(top_srcdir)/gst-libs \
+ 		-I$(top_builddir)/gst-libs \
+ 		--c-include "gst/audio/audio.h" \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ 		--add-include-path="$(top_builddir)/gst-libs/gst/tag/" \
+ 		--library=libgstaudio-@GST_API_VERSION@.la \
+-		--library-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=libdir gstreamer-@GST_API_VERSION@` \
+-		--library-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=libdir gstreamer-base-@GST_API_VERSION@` \
++		--library-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=libdir gstreamer-@GST_API_VERSION@` \
++		--library-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=libdir gstreamer-base-@GST_API_VERSION@` \
+ 		--library-path="$(top_builddir)/gst-libs/gst/tag/" \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstBase-@GST_API_VERSION@ \
+@@ -140,8 +140,8 @@ typelibs_DATA = $(BUILT_GIRSOURCES:.gir=.typelib)
+ 		--includedir=$(srcdir) \
+ 		--includedir=$(builddir) \
+ 		--includedir="$(top_builddir)/gst-libs/gst/tag/" \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+ 		$(INTROSPECTION_COMPILER_OPTS) $< -o $(@F)
+ 
+ CLEANFILES += $(BUILT_GIRSOURCES) $(typelibs_DATA)
+diff --git a/gst-libs/gst/fft/Makefile.am b/gst-libs/gst/fft/Makefile.am
+index f545354..1bb6243 100644
+--- a/gst-libs/gst/fft/Makefile.am
++++ b/gst-libs/gst/fft/Makefile.am
+@@ -62,7 +62,7 @@ GstFft-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstfft-@GST_API_VERSIO
+ 		--c-include "gst/fft/fft.h" \
+ 		-I$(top_srcdir)/gst-libs \
+ 		-I$(top_builddir)/gst-libs \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+ 		--library=libgstfft-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--libtool="$(LIBTOOL)" \
+@@ -86,7 +86,7 @@ typelibs_DATA = $(BUILT_GIRSOURCES:.gir=.typelib)
+ 		$(INTROSPECTION_COMPILER) \
+ 		--includedir=$(srcdir) \
+ 		--includedir=$(builddir) \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+ 		$(INTROSPECTION_COMPILER_OPTS) $< -o $(@F)
+ 
+ CLEANFILES = $(BUILT_GIRSOURCES) $(typelibs_DATA)
+diff --git a/gst-libs/gst/pbutils/Makefile.am b/gst-libs/gst/pbutils/Makefile.am
+index 91dc214..dc8e1d3 100644
+--- a/gst-libs/gst/pbutils/Makefile.am
++++ b/gst-libs/gst/pbutils/Makefile.am
+@@ -84,14 +84,14 @@ GstPbutils-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstpbutils-@GST_AP
+ 		--c-include "gst/pbutils/pbutils.h" \
+ 		-I$(top_srcdir)/gst-libs \
+ 		-I$(top_builddir)/gst-libs \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ 		--add-include-path="$(top_builddir)/gst-libs/gst/tag/" \
+ 		--add-include-path="$(top_builddir)/gst-libs/gst/video/" \
+ 		--add-include-path="$(top_builddir)/gst-libs/gst/audio/" \
+ 		--library=libgstpbutils-@GST_API_VERSION@.la \
+-		--library-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=libdir gstreamer-@GST_API_VERSION@` \
+-		--library-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=libdir gstreamer-base-@GST_API_VERSION@` \
++		--library-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=libdir gstreamer-@GST_API_VERSION@` \
++		--library-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=libdir gstreamer-base-@GST_API_VERSION@` \
+ 		--library-path="$(top_builddir)/gst-libs/gst/tag/" \
+ 		--library-path="$(top_builddir)/gst-libs/gst/video/" \
+ 		--library-path="$(top_builddir)/gst-libs/gst/audio/" \
+@@ -124,8 +124,8 @@ typelibs_DATA = $(BUILT_GIRSOURCES:.gir=.typelib)
+ 		$(INTROSPECTION_COMPILER) \
+ 		--includedir=$(srcdir) \
+ 		--includedir=$(builddir) \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ 		--includedir="$(top_builddir)/gst-libs/gst/tag/" \
+ 		--includedir="$(top_builddir)/gst-libs/gst/video/" \
+ 		--includedir="$(top_builddir)/gst-libs/gst/audio/" \
+diff --git a/gst-libs/gst/riff/Makefile.am b/gst-libs/gst/riff/Makefile.am
+index 3bd8fc0..0a115cc 100644
+--- a/gst-libs/gst/riff/Makefile.am
++++ b/gst-libs/gst/riff/Makefile.am
+@@ -41,8 +41,8 @@ libgstriff_@GST_API_VERSION@_la_LDFLAGS = $(GST_LIB_LDFLAGS) $(GST_ALL_LDFLAGS)
+ #		--c-include "gst/riff/riff.h" \
+ #		--add-include-path=$(builddir)/../tag \
+ #		--add-include-path=$(builddir)/../audio \
+-#		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-#		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++#		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++#		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ #		--library=libgstriff-@GST_API_VERSION@.la \
+ #		--include=GstAudio-@GST_API_VERSION@ \
+ #		--include=GstTag-@GST_API_VERSION@ \
+@@ -73,8 +73,8 @@ libgstriff_@GST_API_VERSION@_la_LDFLAGS = $(GST_LIB_LDFLAGS) $(GST_ALL_LDFLAGS)
+ #		--includedir=$(builddir) \
+ #		--includedir=$(builddir)/../tag \
+ #		--includedir=$(builddir)/../audio \
+-#		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-#		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++#		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++#		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ #		$(INTROSPECTION_COMPILER_OPTS) $< -o $(@F)
+ #
+ #CLEANFILES = $(BUILT_GIRSOURCES) $(typelibs_DATA)
+diff --git a/gst-libs/gst/rtp/Makefile.am b/gst-libs/gst/rtp/Makefile.am
+index f5445c1..527c0b4 100644
+--- a/gst-libs/gst/rtp/Makefile.am
++++ b/gst-libs/gst/rtp/Makefile.am
+@@ -60,8 +60,8 @@ GstRtp-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstrtp-@GST_API_VERSIO
+ 		--c-include "gst/rtp/rtp.h" \
+ 		-I$(top_builddir)/gst-libs \
+ 		-I$(top_srcdir)/gst-libs \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ 		--library=libgstrtp-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstBase-@GST_API_VERSION@ \
+@@ -88,8 +88,8 @@ typelibs_DATA = $(BUILT_GIRSOURCES:.gir=.typelib)
+ 		$(INTROSPECTION_COMPILER) \
+ 		--includedir=$(srcdir) \
+ 		--includedir=$(builddir) \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ 		$(INTROSPECTION_COMPILER_OPTS) $< -o $(@F)
+ 
+ CLEANFILES += $(BUILT_GIRSOURCES) $(typelibs_DATA)
+diff --git a/gst-libs/gst/rtsp/Makefile.am b/gst-libs/gst/rtsp/Makefile.am
+index 9b0b258..4f6d9f8 100644
+--- a/gst-libs/gst/rtsp/Makefile.am
++++ b/gst-libs/gst/rtsp/Makefile.am
+@@ -67,7 +67,7 @@ GstRtsp-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstrtsp-@GST_API_VERS
+ 		-I$(top_builddir)/gst-libs \
+ 		-I$(top_srcdir)/gst-libs \
+ 		--add-include-path=$(builddir)/../sdp \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+ 		--library=libgstrtsp-@GST_API_VERSION@.la \
+ 		--include=Gio-2.0 \
+ 		--include=Gst-@GST_API_VERSION@ \
+@@ -97,7 +97,7 @@ typelibs_DATA = $(BUILT_GIRSOURCES:.gir=.typelib)
+ 		--includedir=$(srcdir) \
+ 		--includedir=$(builddir) \
+ 		--includedir=$(builddir)/../sdp \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+ 		$(INTROSPECTION_COMPILER_OPTS) $< -o $(@F)
+ 
+ CLEANFILES += $(BUILT_GIRSOURCES) $(typelibs_DATA)
+diff --git a/gst-libs/gst/sdp/Makefile.am b/gst-libs/gst/sdp/Makefile.am
+index 0e149b8..9aa0512 100644
+--- a/gst-libs/gst/sdp/Makefile.am
++++ b/gst-libs/gst/sdp/Makefile.am
+@@ -29,7 +29,7 @@ GstSdp-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstsdp-@GST_API_VERSIO
+ 		--warn-all \
+ 		--c-include "gst/sdp/sdp.h" \
+ 		-I$(top_srcdir)/gst-libs \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+ 		--library=libgstsdp-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--libtool="$(LIBTOOL)" \
+@@ -53,7 +53,7 @@ typelibs_DATA = $(BUILT_GIRSOURCES:.gir=.typelib)
+ 		$(INTROSPECTION_COMPILER) \
+ 		--includedir=$(srcdir) \
+ 		--includedir=$(builddir) \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+ 		$(INTROSPECTION_COMPILER_OPTS) $< -o $(@F)
+ 
+ CLEANFILES = $(BUILT_GIRSOURCES) $(typelibs_DATA)
+diff --git a/gst-libs/gst/tag/Makefile.am b/gst-libs/gst/tag/Makefile.am
+index cafafd3..ba99279 100644
+--- a/gst-libs/gst/tag/Makefile.am
++++ b/gst-libs/gst/tag/Makefile.am
+@@ -40,8 +40,8 @@ GstTag-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgsttag-@GST_API_VERSIO
+ 		--c-include "gst/tag/tag.h" \
+ 		-I$(top_srcdir)/gst-libs \
+ 		-I$(top_builddir)/gst-libs \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ 		--library=libgsttag-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstBase-@GST_API_VERSION@ \
+@@ -68,8 +68,8 @@ typelibs_DATA = $(BUILT_GIRSOURCES:.gir=.typelib)
+ 		$(INTROSPECTION_COMPILER) \
+ 		--includedir=$(srcdir) \
+ 		--includedir=$(builddir) \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ 		$(INTROSPECTION_COMPILER_OPTS) $< -o $(@F)
+ 
+ CLEANFILES = $(BUILT_GIRSOURCES) $(typelibs_DATA)
+diff --git a/gst-libs/gst/video/Makefile.am b/gst-libs/gst/video/Makefile.am
+index ac64eb3..342c8c6 100644
+--- a/gst-libs/gst/video/Makefile.am
++++ b/gst-libs/gst/video/Makefile.am
+@@ -111,8 +111,8 @@ GstVideo-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstvideo-@GST_API_VE
+ 		--c-include "gst/video/video.h" \
+ 		-I$(top_srcdir)/gst-libs \
+ 		-I$(top_builddir)/gst-libs \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ 		--library=libgstvideo-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstBase-@GST_API_VERSION@ \
+@@ -139,8 +139,8 @@ typelibs_DATA = $(BUILT_GIRSOURCES:.gir=.typelib)
+ 		$(INTROSPECTION_COMPILER) \
+ 		--includedir=$(srcdir) \
+ 		--includedir=$(builddir) \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ 		$(INTROSPECTION_COMPILER_OPTS) $< -o $(@F)
+ 
+ CLEANFILES += $(BUILT_GIRSOURCES) $(typelibs_DATA)
+-- 
+2.6.2
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0003-riff-add-missing-include-directories-when-calling-in.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0003-riff-add-missing-include-directories-when-calling-in.patch
@@ -1,0 +1,28 @@
+From 3c2c2d5dd08aa30ed0e8acd8566ec99412bb8209 Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Mon, 26 Oct 2015 17:29:37 +0200
+Subject: [PATCH 3/4] riff: add missing include directories when calling
+ introspection scanner
+
+Upstream-Status: Pending [review on oe-core maillist]
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+---
+ gst-libs/gst/riff/Makefile.am | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/gst-libs/gst/riff/Makefile.am b/gst-libs/gst/riff/Makefile.am
+index 0a115cc..5057a58 100644
+--- a/gst-libs/gst/riff/Makefile.am
++++ b/gst-libs/gst/riff/Makefile.am
+@@ -39,6 +39,8 @@ libgstriff_@GST_API_VERSION@_la_LDFLAGS = $(GST_LIB_LDFLAGS) $(GST_ALL_LDFLAGS)
+ #		--strip-prefix=Gst \
+ #		--warn-all \
+ #		--c-include "gst/riff/riff.h" \
++#               -I$(top_srcdir)/gst-libs \
++#               -I$(top_builddir)/gst-libs \
+ #		--add-include-path=$(builddir)/../tag \
+ #		--add-include-path=$(builddir)/../audio \
+ #		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-- 
+2.6.2
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0003-ssaparse-enhance-SSA-text-lines-parsing.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0003-ssaparse-enhance-SSA-text-lines-parsing.patch
@@ -1,0 +1,225 @@
+From be6163cfa3a255493f9d75bad9541cbfe1723fee Mon Sep 17 00:00:00 2001
+From: Mingke Wang <mingke.wang@freescale.com>
+Date: Thu, 19 Mar 2015 14:17:10 +0800
+Subject: [PATCH 3/4] ssaparse: enhance SSA text lines parsing.
+
+some parser will pass in the original ssa text line which starts with "Dialog:"
+and there's are maybe multiple Dialog lines in one input buffer.
+
+Upstream-Status: Submitted [https://bugzilla.gnome.org/show_bug.cgi?id=747496]
+
+Signed-off-by: Mingke Wang <mingke.wang@freescale.com>
+
+diff --git a/gst/subparse/gstssaparse.c b/gst/subparse/gstssaparse.c
+old mode 100644
+new mode 100755
+index 06ecef9..0ab5dce
+--- a/gst/subparse/gstssaparse.c
++++ b/gst/subparse/gstssaparse.c
+@@ -260,6 +260,7 @@ gst_ssa_parse_remove_override_codes (GstSsaParse * parse, gchar * txt)
+  * gst_ssa_parse_push_line:
+  * @parse: caller element
+  * @txt: text to push
++ * @size: text size need to be parse
+  * @start: timestamp for the buffer
+  * @duration: duration for the buffer
+  *
+@@ -269,27 +270,133 @@ gst_ssa_parse_remove_override_codes (GstSsaParse * parse, gchar * txt)
+  * Returns: result of the push of the created buffer
+  */
+ static GstFlowReturn
+-gst_ssa_parse_push_line (GstSsaParse * parse, gchar * txt,
++gst_ssa_parse_push_line (GstSsaParse * parse, gchar * txt, gint size,
+     GstClockTime start, GstClockTime duration)
+ {
+   GstFlowReturn ret;
+   GstBuffer *buf;
+-  gchar *t, *escaped;
++  gchar *t, *text, *p, *escaped, *p_start, *p_end;
+   gint num, i, len;
++  GstClockTime start_time = G_MAXUINT64, end_time = 0;
+ 
+-  num = atoi (txt);
+-  GST_LOG_OBJECT (parse, "Parsing line #%d at %" GST_TIME_FORMAT,
+-      num, GST_TIME_ARGS (start));
+-
+-  /* skip all non-text fields before the actual text */
++  p = text = g_malloc(size + 1);
++  *p = '\0';
+   t = txt;
+-  for (i = 0; i < 8; ++i) {
+-    t = strchr (t, ',');
++
++  /* there are may have multiple dialogue lines at a time */
++  while (*t) {
++    /* ignore leading white space characters */
++    while (isspace(*t))
++      t++;
++
++    /* ignore Format: and Style: lines */
++    if (strncmp(t, "Format:", 7) == 0 || strncmp(t, "Style:", 6) == 0) {
++      while (*t != '\0' && *t != '\n') {
++        t++;
++      }
++    }
++
++    if (*t == '\0')
++      break;
++
++    /* continue with next line */
++    if (*t == '\n') {
++      t++;
++      continue;
++    }
++
++    if(strncmp(t, "Dialogue:", 9) != 0) {
++      /* not started with "Dialogue:", it must be a line trimmed by demuxer */
++      num = atoi (t);
++      GST_LOG_OBJECT (parse, "Parsing line #%d at %" GST_TIME_FORMAT,
++          num, GST_TIME_ARGS (start));
++
++      /* skip all non-text fields before the actual text */
++      for (i = 0; i < 8; ++i) {
++        t = strchr (t, ',');
++        if (t == NULL)
++          break;
++        ++t;
++      }
++    } else {
++      /* started with "Dialogue:", update timestamp and duration */
++      /* time format are like Dialog:Mark,0:00:01.02,0:00:03.04,xx,xxx,... */
++      guint hour, min, sec, msec, len;
++      GstClockTime tmp;
++      gchar t_str[12] = {0};
++
++      /* find the first ',' */
++      p_start = strchr (t, ',');
++      if (p_start)
++        p_end = strchr (++p_start, ',');
++
++      if (p_start && p_end) {
++        /* copy text between first ',' and second ',' */
++        strncpy(t_str, p_start, p_end - p_start);
++        if (sscanf (t_str, "%u:%u:%u.%u", &hour, &min, &sec, &msec) == 4) {
++          tmp = ((hour*3600) + (min*60) + sec) * GST_SECOND + msec*GST_MSECOND;
++          GST_DEBUG_OBJECT (parse, "Get start time:%02d:%02d:%02d:%03d\n",
++              hour, min, sec, msec);
++          if (start_time > tmp)
++            start_time = tmp;
++        } else {
++          GST_WARNING_OBJECT (parse,
++              "failed to parse ssa start timestamp string :%s", t_str);
++        }
++
++        p_start = p_end;
++        p_end = strchr (++p_start, ',');
++        if (p_end) {
++          /* copy text between second ',' and third ',' */
++          strncpy(t_str, p_start, p_end - p_start);
++          if (sscanf (t_str, "%u:%u:%u.%u", &hour, &min, &sec, &msec) == 4) {
++            tmp = ((hour*3600) + (min*60) + sec)*GST_SECOND + msec*GST_MSECOND;
++            GST_DEBUG_OBJECT(parse, "Get end time:%02d:%02d:%02d:%03d\n",
++                hour, min, sec, msec);
++            if (end_time < tmp)
++              end_time = tmp;
++          } else {
++            GST_WARNING_OBJECT (parse,
++                "failed to parse ssa end timestamp string :%s", t_str);
++          }
++        }
++      }
++
++      /* now skip all non-text fields before the actual text */
++      for (i = 0; i <= 8; ++i) {
++        t = strchr (t, ',');
++        if (t == NULL)
++          break;
++        ++t;
++      }
++    }
++
++    /* line end before expected number of ',', not a Dialogue line */
+     if (t == NULL)
+-      return GST_FLOW_ERROR;
+-    ++t;
++      break;
++
++    /* if not the first line, and the last character of previous line is '\0',
++     * then replace it with '\N' */
++    if (p != text && *p == '\0') {
++      *p++ = '\\';
++      *p++ = 'N';
++    }
++
++    /* copy all actual text of this line */
++    while ((*t != '\0') && (*t != '\n'))
++      *p++ = *t++;
++
++    /* add a terminator at the end */
++    *p = '\0';
++  }
++
++  /* not valid text found in this buffer return OK to let caller unref buffer */
++  if (strlen(text) <= 0) {
++    GST_WARNING_OBJECT (parse, "Not valid text found in this buffer\n");
++    return GST_FLOW_ERROR;
+   }
+ 
++  t = text;
+   GST_LOG_OBJECT (parse, "Text : %s", t);
+ 
+   if (gst_ssa_parse_remove_override_codes (parse, t)) {
+@@ -307,13 +414,22 @@ gst_ssa_parse_push_line (GstSsaParse * parse, gchar * txt,
+   gst_buffer_fill (buf, 0, escaped, len + 1);
+   gst_buffer_set_size (buf, len);
+   g_free (escaped);
++  g_free(t);
++
++  if (start_time != G_MAXUINT64)
++    GST_BUFFER_TIMESTAMP (buf) = start_time;
++  else
++    GST_BUFFER_TIMESTAMP (buf) = start;
+ 
+-  GST_BUFFER_TIMESTAMP (buf) = start;
+-  GST_BUFFER_DURATION (buf) = duration;
++  if (end_time > start_time)
++    GST_BUFFER_DURATION (buf) = end_time - start_time;
++  else
++    GST_BUFFER_DURATION (buf) = duration;
+ 
+   GST_LOG_OBJECT (parse, "Pushing buffer with timestamp %" GST_TIME_FORMAT
+-      " and duration %" GST_TIME_FORMAT, GST_TIME_ARGS (start),
+-      GST_TIME_ARGS (duration));
++      " and duration %" GST_TIME_FORMAT,
++      GST_TIME_ARGS (GST_BUFFER_TIMESTAMP (buf)),
++      GST_TIME_ARGS (GST_BUFFER_DURATION (buf)));
+ 
+   ret = gst_pad_push (parse->srcpad, buf);
+ 
+@@ -333,6 +449,7 @@ gst_ssa_parse_chain (GstPad * sinkpad, GstObject * parent, GstBuffer * buf)
+   GstClockTime ts;
+   gchar *txt;
+   GstMapInfo map;
++  gint size;
+ 
+   if (G_UNLIKELY (!parse->framed))
+     goto not_framed;
+@@ -350,13 +467,14 @@ gst_ssa_parse_chain (GstPad * sinkpad, GstObject * parent, GstBuffer * buf)
+   /* make double-sure it's 0-terminated and all */
+   gst_buffer_map (buf, &map, GST_MAP_READ);
+   txt = g_strndup ((gchar *) map.data, map.size);
++  size = map.size;
+   gst_buffer_unmap (buf, &map);
+ 
+   if (txt == NULL)
+     goto empty_text;
+ 
+   ts = GST_BUFFER_TIMESTAMP (buf);
+-  ret = gst_ssa_parse_push_line (parse, txt, ts, GST_BUFFER_DURATION (buf));
++  ret = gst_ssa_parse_push_line (parse, txt, size, ts, GST_BUFFER_DURATION (buf));
+ 
+   if (ret != GST_FLOW_OK && GST_CLOCK_TIME_IS_VALID (ts)) {
+     GstSegment segment;
+-- 
+1.7.9.5
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0004-rtsp-drop-incorrect-reference-to-gstreamer-sdp-in-Ma.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0004-rtsp-drop-incorrect-reference-to-gstreamer-sdp-in-Ma.patch
@@ -1,0 +1,27 @@
+From 4330915d88dc4dd46eb4c28d756482b767c2747f Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Mon, 26 Oct 2015 17:30:14 +0200
+Subject: [PATCH 4/4] rtsp: drop incorrect reference to gstreamer-sdp in
+ Makefile.am
+
+Upstream-Status: Pending [review on oe-core maillist]
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+---
+ gst-libs/gst/rtsp/Makefile.am | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/gst-libs/gst/rtsp/Makefile.am b/gst-libs/gst/rtsp/Makefile.am
+index 4f6d9f8..0afa370 100644
+--- a/gst-libs/gst/rtsp/Makefile.am
++++ b/gst-libs/gst/rtsp/Makefile.am
+@@ -75,7 +75,6 @@ GstRtsp-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstrtsp-@GST_API_VERS
+ 		--libtool="$(LIBTOOL)" \
+ 		--pkg gio-2.0 \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+-		--pkg gstreamer-sdp-@GST_API_VERSION@ \
+ 		--pkg-export gstreamer-rtsp-@GST_API_VERSION@ \
+ 		--add-init-section="$(INTROSPECTION_INIT)" \
+ 		--output $@ \
+-- 
+2.6.2
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0004-subparse-set-need_segment-after-sink-pad-received-GS.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0004-subparse-set-need_segment-after-sink-pad-received-GS.patch
@@ -1,0 +1,69 @@
+From ed09c8fd2c9c2b5384b72cc70af3728be6694e64 Mon Sep 17 00:00:00 2001
+From: Mingke Wang <mingke.wang@freescale.com>
+Date: Thu, 19 Mar 2015 14:20:26 +0800
+Subject: [PATCH 4/4] subparse: set need_segment after sink pad received
+ GST_EVENT_SEGMENT
+
+subparse works in push mode, chain funciton will be called once
+up stream element finished the seeking and flushing.
+if set need_segment flag in src pad event handler, the segment
+event will be pushed earlier, result in the subtitle text will
+be send out to down stream from the beginning.
+
+Upstream-Status: Submitted [https://bugzilla.gnome.org/show_bug.cgi?id=747498]
+
+Signed-off-by: Mingke Wang <mingke.wang@freescale.com>
+
+diff --git a/gst/subparse/gstsubparse.c b/gst/subparse/gstsubparse.c
+old mode 100644
+new mode 100755
+index b565e93..7741ccc
+--- a/gst/subparse/gstsubparse.c
++++ b/gst/subparse/gstsubparse.c
+@@ -266,22 +266,20 @@ gst_sub_parse_src_event (GstPad * pad, GstObject * parent, GstEvent * event)
+         goto beach;
+       }
+ 
++      /* Apply the seek to our segment */
++      gst_segment_do_seek (&self->segment, rate, format, flags,
++          start_type, start, stop_type, stop, &update);
++
++      GST_DEBUG_OBJECT (self, "segment after seek: %" GST_SEGMENT_FORMAT,
++          &self->segment);
++
+       /* Convert that seek to a seeking in bytes at position 0,
+          FIXME: could use an index */
+       ret = gst_pad_push_event (self->sinkpad,
+           gst_event_new_seek (rate, GST_FORMAT_BYTES, flags,
+               GST_SEEK_TYPE_SET, 0, GST_SEEK_TYPE_NONE, 0));
+ 
+-      if (ret) {
+-        /* Apply the seek to our segment */
+-        gst_segment_do_seek (&self->segment, rate, format, flags,
+-            start_type, start, stop_type, stop, &update);
+-
+-        GST_DEBUG_OBJECT (self, "segment after seek: %" GST_SEGMENT_FORMAT,
+-            &self->segment);
+-
+-        self->need_segment = TRUE;
+-      } else {
++      if (!ret) {
+         GST_WARNING_OBJECT (self, "seek to 0 bytes failed");
+       }
+ 
+@@ -1641,8 +1639,10 @@ gst_sub_parse_sink_event (GstPad * pad, GstObject * parent, GstEvent * event)
+       gst_event_parse_segment (event, &s);
+       if (s->format == GST_FORMAT_TIME)
+         gst_event_copy_segment (event, &self->segment);
+-      GST_DEBUG_OBJECT (self, "newsegment (%s)",
+-          gst_format_get_name (self->segment.format));
++      GST_DEBUG_OBJECT (self, "newsegment (%s) %" GST_SEGMENT_FORMAT,
++          gst_format_get_name (self->segment.format), &self->segment);
++
++      self->need_segment = TRUE;
+ 
+       /* if not time format, we'll either start with a 0 timestamp anyway or
+        * it's following a seek in which case we'll have saved the requested
+-- 
+1.7.9.5
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/encodebin-Need-more-buffers-in-output-queue-for-bett.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/encodebin-Need-more-buffers-in-output-queue-for-bett.patch
@@ -1,0 +1,32 @@
+From 540e02c92c75e08b90326863dc787fa5cadf9da6 Mon Sep 17 00:00:00 2001
+From: Song Bing <b06498@freescale.com>
+Date: Fri, 13 Mar 2015 18:04:31 +0800
+Subject: [PATCH] encodebin: Need more buffers in output queue for better
+ performance
+
+Need more buffers in output queue for better performance
+
+Upstream-Status: Submitted [https://bugzilla.gnome.org/show_bug.cgi?id=744191]
+
+Signed-off-by: Song Bing <b06498@freescale.com>
+---
+ gst/encoding/gstencodebin.c |    3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/gst/encoding/gstencodebin.c b/gst/encoding/gstencodebin.c
+index 6728e58..32daae4 100644
+--- a/gst/encoding/gstencodebin.c
++++ b/gst/encoding/gstencodebin.c
+@@ -1228,8 +1228,7 @@ _create_stream_group (GstEncodeBin * ebin, GstEncodingProfile * sprof,
+    * We only use a 1buffer long queue here, the actual queueing will be done
+    * in the input queue */
+   last = sgroup->outqueue = gst_element_factory_make ("queue", NULL);
+-  g_object_set (sgroup->outqueue, "max-size-buffers", (guint32) 1,
+-      "max-size-bytes", (guint32) 0, "max-size-time", (guint64) 0,
++  g_object_set (sgroup->outqueue, "max-size-time", (guint64) 0,
+       "silent", TRUE, NULL);
+ 
+   gst_bin_add (GST_BIN (ebin), sgroup->outqueue);
+-- 
+1.7.9.5
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/get-caps-from-src-pad-when-query-caps.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/get-caps-from-src-pad-when-query-caps.patch
@@ -1,0 +1,44 @@
+From af0dac26f62aaceb4bf266720911953793e0fc5d Mon Sep 17 00:00:00 2001
+From: zhouming <b42586@freescale.com>
+Date: Wed, 14 May 2014 10:16:20 +0800
+Subject: [PATCH] ENGR00312515: get caps from src pad when query caps
+
+https://bugzilla.gnome.org/show_bug.cgi?id=728312
+
+Upstream-Status: Pending
+
+Signed-off-by: zhouming <b42586@freescale.com>
+---
+ gst-libs/gst/tag/gsttagdemux.c |   13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+ mode change 100644 => 100755 gst-libs/gst/tag/gsttagdemux.c
+
+diff --git a/gst-libs/gst/tag/gsttagdemux.c b/gst-libs/gst/tag/gsttagdemux.c
+old mode 100644
+new mode 100755
+index 9b6c478..ae2294a
+--- a/gst-libs/gst/tag/gsttagdemux.c
++++ b/gst-libs/gst/tag/gsttagdemux.c
+@@ -1769,6 +1769,19 @@ gst_tag_demux_pad_query (GstPad * pad, GstObject * parent, GstQuery * query)
+       }
+       break;
+     }
++    case GST_QUERY_CAPS:
++    {
++
++      /* We can hijack caps query if we typefind already */
++      if (demux->priv->src_caps) {
++        gst_query_set_caps_result (query, demux->priv->src_caps);
++        res = TRUE;
++      } else {
++        res = gst_pad_query_default (pad, parent, query);
++      }
++      break;
++    }
++
+     default:
+       res = gst_pad_query_default (pad, parent, query);
+       break;
+-- 
+1.7.9.5
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/make-gio_unix_2_0-dependency-configurable.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/make-gio_unix_2_0-dependency-configurable.patch
@@ -1,0 +1,47 @@
+From 10d2a977ee1d469f0bf9059bb2d0b55fd2eecbac Mon Sep 17 00:00:00 2001
+From: Andre McCurdy <armccurdy@gmail.com>
+Date: Wed, 20 Jan 2016 13:00:00 -0800
+Subject: [PATCH] make gio_unix_2_0 dependency configurable
+
+Prior to 1.7.1, gst-plugins-base accepted a configure option to
+disable gio_unix_2_0, however it was implemented incorrectly using
+AG_GST_CHECK_FEATURE. That was fixed in 1.7.1 by making the
+dependency unconditional.
+
+  http://cgit.freedesktop.org/gstreamer/gst-plugins-base/commit/?id=aadefefba88afe4acbe64454650f24e7ce7c8d70
+
+To make builds deterministic, re-instate support for
+--disable-gio_unix_2_0, but implement it using the AC_ARG_ENABLE
+instead of AG_GST_CHECK_FEATURE.
+
+Upstream-Status: Pending
+
+Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
+---
+ configure.ac | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/configure.ac b/configure.ac
+index 9c52aeb..26cacd6 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -752,9 +752,16 @@ AC_SUBST(FT2_CFLAGS)
+ fi dnl of EXT plugins
+ 
+ dnl *** gio-unix-2.0 for tests/check/pipelines/tcp.c ***
++AC_ARG_ENABLE([gio_unix_2_0],
++  [AS_HELP_STRING([--disable-gio_unix_2_0],[disable use of gio_unix_2_0])],
++  [],
++  [enable_gio_unix_2_0=yes])
++
++if test "x${enable_gio_unix_2_0}" != "xno"; then
+ PKG_CHECK_MODULES(GIO_UNIX_2_0, gio-unix-2.0 >= 2.24,
+     HAVE_GIO_UNIX_2_0="yes",
+     HAVE_GIO_UNIX_2_0="no")
++fi
+ AM_CONDITIONAL(USE_GIO_UNIX_2_0, test "x$HAVE_GIO_UNIX_2_0" = "xyes")
+ 
+ dnl *** finalize CFLAGS, LDFLAGS, LIBS
+-- 
+1.9.1
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_%.bbappend
@@ -1,3 +1,4 @@
-PACKAGECONFIG[gl] = "-Dgl=enabled,,"
-PACKAGECONFIG_append = " gl opus"
+PACKAGECONFIG_dunfell[gl] = "-Dgl=enabled,,"
+PACKAGECONFIG_append_dunfell = " gl"
+PACKAGECONFIG_append = " opus"
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_%.bbappend
@@ -1,4 +1,4 @@
-PACKAGECONFIG_dunfell[gl] = "-Dgl=enabled,,"
-PACKAGECONFIG_append_dunfell = " gl"
+PACKAGECONFIG[gl] = "-Dgl=enabled,,"
+PACKAGECONFIG_append = " ${@oe.utils.ifelse(d.getVar('DISTRO_CODENAME', True) == 'dunfell', 'gl', '')}"
 PACKAGECONFIG_append = " opus"
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_%.bbappend
@@ -1,4 +1,4 @@
-PACKAGECONFIG[gl] = "-Dgl=enabled,,"
+PACKAGECONFIG[gl] = "-Dgl=enabled ,,"
 PACKAGECONFIG_append = " ${@oe.utils.ifelse(d.getVar('DISTRO_CODENAME', True) == 'dunfell', 'gl', '')}"
 PACKAGECONFIG_append = " opus"
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_%.bbappend
@@ -1,4 +1,4 @@
 PACKAGECONFIG[gl] = "-Dgl=enabled ,,"
-PACKAGECONFIG_append = " ${@oe.utils.ifelse(d.getVar('DISTRO_CODENAME', True) == 'dunfell', 'gl', '')}"
+PACKAGECONFIG_append_dunfell = " gl"
 PACKAGECONFIG_append = " opus"
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.10.4.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.10.4.bb
@@ -1,10 +1,12 @@
 require gstreamer1.0-plugins-base.inc
 
-LIC_FILES_CHKSUM = "file://COPYING;md5=c54ce9345727175ff66d17b67ff51f58 \
-                    file://COPYING.LIB;md5=6762ed442b3822387a51c92d928ead0d \
-                    file://common/coverage/coverage-report.pl;beginline=2;endline=17;md5=a4e1830fce078028c8f0974161272607"
+LIC_FILES_CHKSUM = "\
+    file://COPYING;md5=c54ce9345727175ff66d17b67ff51f58 \
+    file://COPYING.LIB;md5=6762ed442b3822387a51c92d928ead0d \
+    file://common/coverage/coverage-report.pl;beginline=2;endline=17;md5=a4e1830fce078028c8f0974161272607 \
+"
 
-SRC_URI = " \
+SRC_URI = "\
     http://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-base-${PV}.tar.xz \
     file://get-caps-from-src-pad-when-query-caps.patch \
     file://0003-ssaparse-enhance-SSA-text-lines-parsing.patch \

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.10.4.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.10.4.bb
@@ -1,0 +1,21 @@
+require gstreamer1.0-plugins-base.inc
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=c54ce9345727175ff66d17b67ff51f58 \
+                    file://COPYING.LIB;md5=6762ed442b3822387a51c92d928ead0d \
+                    file://common/coverage/coverage-report.pl;beginline=2;endline=17;md5=a4e1830fce078028c8f0974161272607"
+
+SRC_URI = " \
+    http://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-base-${PV}.tar.xz \
+    file://get-caps-from-src-pad-when-query-caps.patch \
+    file://0003-ssaparse-enhance-SSA-text-lines-parsing.patch \
+    file://0004-subparse-set-need_segment-after-sink-pad-received-GS.patch \
+    file://encodebin-Need-more-buffers-in-output-queue-for-bett.patch \
+    file://make-gio_unix_2_0-dependency-configurable.patch \
+    file://0001-introspection.m4-prefix-pkgconfig-paths-with-PKG_CON.patch \
+    file://0001-Revert-uridecodebin-Use-the-correct-caps-name-for-MS.patch \
+    file://0001-decodebin-Manually-sync-element-states-with-parent-a.patch \
+"
+SRC_URI[md5sum] = "f6b46f8fac01eb773d556e3efc369e86"
+SRC_URI[sha256sum] = "f6d245b6b3d4cb733f81ebb021074c525ece83db0c10e932794b339b8d935eb7"
+
+S = "${WORKDIR}/gst-plugins-base-${PV}"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.16%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.16%.bbappend
@@ -2,7 +2,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
 
 PACKAGECONFIG[gl] ?= "-Dgl=enabled -Dgl_winsys=egl,,"
 
-SRC_URI += "\
+SRC_URI_append = "\
     file://0001-meson-add-window-system-egl.patch \
     file://0002-decodebin-Manually-sync-element-states-with-parent-a.patch \
     file://0003-gstglcolorconvert-Reverse-direction-when-asking-for-.patch \

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.16%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.16%.bbappend
@@ -2,7 +2,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
 
 PACKAGECONFIG[gl] ?= "-Dgl=enabled -Dgl_winsys=egl,,"
 
-SRC_URI_append = "\
+SRC_URI_append = " \
     file://0001-meson-add-window-system-egl.patch \
     file://0002-decodebin-Manually-sync-element-states-with-parent-a.patch \
     file://0003-gstglcolorconvert-Reverse-direction-when-asking-for-.patch \

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.16%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.16%.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
 
-PACKAGECONFIG[gl] ?= "-Dgl=enabled -Dgl_winsys=egl,,"
+PACKAGECONFIG_dunfell[gl] ?= "-Dgl=enabled -Dgl_winsys=egl,,"
 
 SRC_URI += "\
     file://0001-meson-add-window-system-egl.patch \

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.16%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.16%.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
 
-PACKAGECONFIG_dunfell[gl] ?= "-Dgl=enabled -Dgl_winsys=egl,,"
+PACKAGECONFIG[gl] ?= "-Dgl=enabled -Dgl_winsys=egl,,"
 
 SRC_URI += "\
     file://0001-meson-add-window-system-egl.patch \

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good-1.10.4/0001-qtdemux-distinguish-TFDT-with-value-0-from-no-TFDT-a.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good-1.10.4/0001-qtdemux-distinguish-TFDT-with-value-0-from-no-TFDT-a.patch
@@ -1,0 +1,53 @@
+From 43510d1b1a1843be4f07d96a303486c30cbcb687 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Enrique=20Oca=C3=B1a=20Gonz=C3=A1lez?= <eocanha@igalia.com>
+Date: Wed, 22 Mar 2017 18:18:40 +0000
+Subject: [PATCH] qtdemux: distinguish TFDT with value 0 from no TFDT at all
+
+TFDTs with time 0 are being ignored since commit 1fc3d42f. They're
+mistaken with the case of not having TFDT, but those two cases
+must be distinguished in some way.
+
+This patch passes an extra boolean flag when the TFDT is present.
+This is now the condition being evaluated, instead of checking for
+0 time.
+
+https://bugzilla.gnome.org/show_bug.cgi?id=780410
+---
+ gst/isomp4/qtdemux.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/gst/isomp4/qtdemux.c b/gst/isomp4/qtdemux.c
+index 8d304bd..87f8f42 100644
+--- a/gst/isomp4/qtdemux.c
++++ b/gst/isomp4/qtdemux.c
+@@ -3039,7 +3039,8 @@ static gboolean
+ qtdemux_parse_trun (GstQTDemux * qtdemux, GstByteReader * trun,
+     QtDemuxStream * stream, guint32 d_sample_duration, guint32 d_sample_size,
+     guint32 d_sample_flags, gint64 moof_offset, gint64 moof_length,
+-    gint64 * base_offset, gint64 * running_offset, gint64 decode_ts)
++    gint64 * base_offset, gint64 * running_offset, gint64 decode_ts,
++    gboolean has_tfdt)
+ {
+   GstClockTime gst_ts = GST_CLOCK_TIME_NONE;
+   guint64 timestamp;
+@@ -3200,7 +3201,7 @@ qtdemux_parse_trun (GstQTDemux * qtdemux, GstByteReader * trun,
+       /* If this is a GST_FORMAT_BYTES stream and there's a significant
+        * difference (1 sec.) between decode_ts and timestamp, prefer the
+        * former */
+-      if (decode_ts != 0 && !qtdemux->upstream_format_is_time
++      if (has_tfdt && !qtdemux->upstream_format_is_time
+           && ABSDIFF (decode_ts, timestamp) >
+           MAX (stream->duration_last_moof / 2,
+               GSTTIME_TO_QTSTREAMTIME (stream, GST_SECOND))) {
+@@ -3919,7 +3920,7 @@ qtdemux_parse_moof (GstQTDemux * qtdemux, const guint8 * buffer, guint length,
+     while (trun_node) {
+       qtdemux_parse_trun (qtdemux, &trun_data, stream,
+           ds_duration, ds_size, ds_flags, moof_offset, length, &base_offset,
+-          &running_offset, decode_time);
++          &running_offset, decode_time, (tfdt_node != NULL));
+       /* iterate all siblings */
+       trun_node = qtdemux_tree_get_sibling_by_type_full (trun_node, FOURCC_trun,
+           &trun_data);
+-- 
+2.1.4
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good-1.10.4/0005-souphttpsrc-cookie-jar-and-context-query-support.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good-1.10.4/0005-souphttpsrc-cookie-jar-and-context-query-support.patch
@@ -1,0 +1,120 @@
+From 8e03a63fd55f5ae447994579890e8630b27f4a1b Mon Sep 17 00:00:00 2001
+From: Philippe Normand <philn@igalia.com>
+Date: Wed, 28 Oct 2015 12:00:09 +0100
+Subject: [PATCH 2/3] souphttpsrc: cookie jar and context query support
+
+Use a volatile Cookie jar to store cookies and handle the context
+query so that session data can be shared with other elements (like
+adaptivedemux).
+
+https://bugzilla.gnome.org/show_bug.cgi?id=726314
+---
+ ext/soup/gstsouphttpsrc.c | 41 +++++++++++++++++++++++++++++++++++++++--
+ ext/soup/gstsouphttpsrc.h |  1 +
+ 2 files changed, 40 insertions(+), 2 deletions(-)
+
+diff --git a/ext/soup/gstsouphttpsrc.c b/ext/soup/gstsouphttpsrc.c
+index fc7cba7..0d3e886 100644
+--- a/ext/soup/gstsouphttpsrc.c
++++ b/ext/soup/gstsouphttpsrc.c
+@@ -482,6 +482,7 @@ gst_soup_http_src_init (GstSoupHTTPSrc * src)
+   src->cookies = NULL;
+   src->iradio_mode = DEFAULT_IRADIO_MODE;
+   src->session = NULL;
++  src->cookie_jar = NULL;
+   src->msg = NULL;
+   src->timeout = DEFAULT_TIMEOUT;
+   src->log_level = DEFAULT_SOUP_LOG_LEVEL;
+@@ -943,6 +944,9 @@ gst_soup_http_src_session_open (GstSoupHTTPSrc * src)
+     soup_session_remove_feature_by_type (src->session,
+         SOUP_TYPE_CONTENT_DECODER);
+ 
++  src->cookie_jar = soup_cookie_jar_new ();
++  soup_session_add_feature (src->session,
++      SOUP_SESSION_FEATURE (src->cookie_jar));
+   return TRUE;
+ }
+ 
+@@ -958,6 +962,11 @@ gst_soup_http_src_session_close (GstSoupHTTPSrc * src)
+     src->msg = NULL;
+   }
+ 
++  if (src->cookie_jar) {
++    g_object_unref (src->cookie_jar);
++    src->cookie_jar = NULL;
++  }
++
+   if (src->session) {
+     soup_session_abort (src->session);
+     g_object_unref (src->session);
+@@ -1426,11 +1435,12 @@ gst_soup_http_src_build_message (GstSoupHTTPSrc * src, const gchar * method)
+   }
+   if (src->cookies) {
+     gchar **cookie;
++    SoupURI *uri = soup_uri_new (src->location);
+ 
+     for (cookie = src->cookies; *cookie != NULL; cookie++) {
+-      soup_message_headers_append (src->msg->request_headers, "Cookie",
+-          *cookie);
++      soup_cookie_jar_set_cookie (src->cookie_jar, uri, *cookie);
+     }
++    soup_uri_free (uri);
+   }
+ 
+   soup_message_set_flags (src->msg, SOUP_MESSAGE_OVERWRITE_CHUNKS |
+@@ -1910,6 +1920,12 @@ gst_soup_http_src_query (GstBaseSrc * bsrc, GstQuery * query)
+   gboolean ret;
+   GstSchedulingFlags flags;
+   gint minsize, maxsize, align;
++  GstContext *context;
++  GstStructure *context_structure;
++  char *cookie;
++  const gchar *cookies[2];
++  const gchar *context_type;
++  SoupURI *uri;
+ 
+   switch (GST_QUERY_TYPE (query)) {
+     case GST_QUERY_URI:
+@@ -1921,6 +1937,27 @@ gst_soup_http_src_query (GstBaseSrc * bsrc, GstQuery * query)
+       }
+       ret = TRUE;
+       break;
++    case GST_QUERY_CONTEXT:
++      if (gst_query_parse_context_type (query, &context_type)
++          && !g_strcmp0 (context_type, "http-headers")) {
++        uri = soup_uri_new (src->location);
++        cookie = soup_cookie_jar_get_cookies (src->cookie_jar, uri, TRUE);
++        context = gst_context_new ("http-headers", FALSE);
++        gst_context_make_writable (context);
++        context_structure = gst_context_writable_structure (context);
++        if (cookie != NULL) {
++          cookies[0] = cookie;
++          cookies[1] = NULL;
++          gst_structure_set (context_structure, "cookies", G_TYPE_STRV, cookies,
++              NULL);
++          g_free (cookie);
++        }
++        gst_query_set_context (query, context);
++        soup_uri_free (uri);
++        ret = TRUE;
++        break;
++      }
++
+     default:
+       ret = FALSE;
+       break;
+diff --git a/ext/soup/gstsouphttpsrc.h b/ext/soup/gstsouphttpsrc.h
+index dd01656..9c6bb5c 100644
+--- a/ext/soup/gstsouphttpsrc.h
++++ b/ext/soup/gstsouphttpsrc.h
+@@ -60,6 +60,7 @@ struct _GstSoupHTTPSrc {
+   gchar *proxy_pw;             /* Authentication user password for proxy URI. */
+   gchar **cookies;             /* HTTP request cookies. */
+   SoupSession *session;        /* Async context. */
++  SoupCookieJar *cookie_jar;   /* Volatile HTTP cookie storage */
+   SoupMessage *msg;            /* Request message. */
+   GstFlowReturn ret;           /* Return code from callback. */
+   gint retry_count;            /* Number of retries since we received data */
+-- 
+1.8.3.2
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good-1.10.4/0006-qtdemux-add-context-for-a-preferred-protection.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good-1.10.4/0006-qtdemux-add-context-for-a-preferred-protection.patch
@@ -1,0 +1,328 @@
+From 4f3cb1a1b4403d42a60a7257d49b05dd28812eaf Mon Sep 17 00:00:00 2001
+From: Xabier Rodriguez Calvar <calvaris@igalia.com>
+Date: Wed, 21 Jun 2017 17:59:21 +0200
+Subject: [PATCH 6/8] qtdemux: add context for a preferred protection
+
+qtdemux selected the first system corresponding to a working GStreamer
+decryptor. With this change, before selecting that decryptor, qtdemux
+will check if it has context (a preferred decryptor id) and if not, it
+will request it.
+
+The request includes track-id, available key system ids for the
+available decryptors and even the events so that the init data is
+accessible.
+
+[eocanha@igalia.com: select the preferred protection system even if not available]
+
+Test "4. ClearKeyVideo" in YouTube leanback EME conformance tests 2016 for
+H.264[1] uses a media file[2] with cenc encryption which embeds 'pssh' boxes
+with the init data for the Playready and Widevine encryption systems, but not
+for the ClearKey encryption system (as defined by the EMEv0.1b spec[3] and with
+the encryption system id defined in [4]).
+
+Instead, the ClearKey encryption system is manually selected by the web page
+code (even if not originally detected by qtdemux) and the proper decryption key
+is dispatched to the decryptor, which can then decrypt the video successfully.
+
+[1] http://yt-dash-mse-test.commondatastorage.googleapis.com/unit-tests/2016.html?test_type=encryptedmedia-test&webm=false
+[2] http://yt-dash-mse-test.commondatastorage.googleapis.com/unit-tests/media/car_cenc-20120827-86.mp4
+[3] https://dvcs.w3.org/hg/html-media/raw-file/eme-v0.1b/encrypted-media/encrypted-media.html#simple-decryption-clear-key
+[4] https://www.w3.org/Bugs/Public/show_bug.cgi?id=24027#c2
+
+https://bugzilla.gnome.org/show_bug.cgi?id=770107
+---
+ gst/isomp4/qtdemux.c | 200 +++++++++++++++++++++++++++++++++++++++++++++++++--
+ gst/isomp4/qtdemux.h |   1 +
+ 2 files changed, 195 insertions(+), 6 deletions(-)
+
+diff --git a/gst/isomp4/qtdemux.c b/gst/isomp4/qtdemux.c
+index 4cbcaedb2..2091374c6 100644
+--- a/gst/isomp4/qtdemux.c
++++ b/gst/isomp4/qtdemux.c
+@@ -490,6 +490,8 @@ static GstIndex *gst_qtdemux_get_index (GstElement * element);
+ #endif
+ static GstStateChangeReturn gst_qtdemux_change_state (GstElement * element,
+     GstStateChange transition);
++static void gst_qtdemux_set_context (GstElement * element,
++    GstContext * context);
+ static gboolean qtdemux_sink_activate (GstPad * sinkpad, GstObject * parent);
+ static gboolean qtdemux_sink_activate_mode (GstPad * sinkpad,
+     GstObject * parent, GstPadMode mode, gboolean active);
+@@ -576,6 +578,7 @@ gst_qtdemux_class_init (GstQTDemuxClass * klass)
+   gstelement_class->set_index = GST_DEBUG_FUNCPTR (gst_qtdemux_set_index);
+   gstelement_class->get_index = GST_DEBUG_FUNCPTR (gst_qtdemux_get_index);
+ #endif
++  gstelement_class->set_context = GST_DEBUG_FUNCPTR (gst_qtdemux_set_context);
+ 
+   gst_tag_register_musicbrainz_tags ();
+ 
+@@ -634,6 +637,7 @@ gst_qtdemux_init (GstQTDemux * qtdemux)
+   qtdemux->cenc_aux_info_sizes = NULL;
+   qtdemux->cenc_aux_sample_count = 0;
+   qtdemux->protection_system_ids = NULL;
++  qtdemux->preferred_protection_system_id = NULL;
+   g_queue_init (&qtdemux->protection_event_queue);
+   gst_segment_init (&qtdemux->segment, GST_FORMAT_TIME);
+   qtdemux->flowcombiner = gst_flow_combiner_new ();
+@@ -2022,6 +2026,10 @@ gst_qtdemux_reset (GstQTDemux * qtdemux, gboolean hard)
+       g_ptr_array_free (qtdemux->protection_system_ids, TRUE);
+       qtdemux->protection_system_ids = NULL;
+     }
++    if (qtdemux->preferred_protection_system_id) {
++      g_free (qtdemux->preferred_protection_system_id);
++      qtdemux->preferred_protection_system_id = NULL;
++    }
+   } else if (qtdemux->mss_mode) {
+     gst_flow_combiner_reset (qtdemux->flowcombiner);
+     for (n = 0; n < qtdemux->n_streams; n++)
+@@ -2485,6 +2493,28 @@ gst_qtdemux_change_state (GstElement * element, GstStateChange transition)
+ }
+ 
+ static void
++gst_qtdemux_set_context (GstElement * element, GstContext * context)
++{
++  GstQTDemux *qtdemux = GST_QTDEMUX (element);
++
++  g_return_if_fail (GST_IS_CONTEXT (context));
++
++  if (gst_context_has_context_type (context,
++          "drm-preferred-decryption-system-id")) {
++    const GstStructure *s;
++
++    s = gst_context_get_structure (context);
++    g_free (qtdemux->preferred_protection_system_id);
++    qtdemux->preferred_protection_system_id =
++        g_strdup (gst_structure_get_string (s, "decryption-system-id"));
++    GST_DEBUG_OBJECT (element, "set preferred decryption system to %s",
++        qtdemux->preferred_protection_system_id);
++  }
++
++  GST_ELEMENT_CLASS (parent_class)->set_context (element, context);
++}
++
++static void
+ qtdemux_parse_ftyp (GstQTDemux * qtdemux, const guint8 * buffer, gint length)
+ {
+   /* counts as header data */
+@@ -3673,6 +3703,8 @@ qtdemux_parse_pssh (GstQTDemux * qtdemux, GNode * node)
+   event = gst_event_new_protection (sysid_string, pssh,
+       (parent_box_type == FOURCC_moov) ? "isobmff/moov" : "isobmff/moof");
+   for (i = 0; i < qtdemux->n_streams; ++i) {
++    GST_TRACE_OBJECT (qtdemux,
++        "adding protection event for stream %d and system %s", i, sysid_string);
+     g_queue_push_tail (&qtdemux->streams[i]->protection_scheme_event_queue,
+         gst_event_ref (event));
+   }
+@@ -5380,6 +5412,8 @@ gst_qtdemux_decorate_and_push_buffer (GstQTDemux * qtdemux,
+     GstEvent *event;
+ 
+     while ((event = g_queue_pop_head (&stream->protection_scheme_event_queue))) {
++      GST_TRACE_OBJECT (stream->pad, "pushing protection event: %"
++          GST_PTR_FORMAT, event);
+       gst_pad_push_event (stream->pad, event);
+     }
+ 
+@@ -7475,11 +7509,141 @@ qtdemux_do_allocation (GstQTDemux * qtdemux, QtDemuxStream * stream)
+ }
+ 
+ static gboolean
++pad_query (const GValue * item, GValue * value, gpointer user_data)
++{
++  GstPad *pad = g_value_get_object (item);
++  GstQuery *query = user_data;
++  gboolean res;
++
++  res = gst_pad_peer_query (pad, query);
++
++  if (res) {
++    g_value_set_boolean (value, TRUE);
++    return FALSE;
++  }
++
++  GST_INFO_OBJECT (pad, "pad peer query failed");
++  return TRUE;
++}
++
++static gboolean
++gst_qtdemux_run_query (GstElement * element, GstQuery * query,
++    GstPadDirection direction)
++{
++  GstIterator *it;
++  GstIteratorFoldFunction func = pad_query;
++  GValue res = { 0, };
++
++  g_value_init (&res, G_TYPE_BOOLEAN);
++  g_value_set_boolean (&res, FALSE);
++
++  /* Ask neighbor */
++  if (direction == GST_PAD_SRC)
++    it = gst_element_iterate_src_pads (element);
++  else
++    it = gst_element_iterate_sink_pads (element);
++
++  while (gst_iterator_fold (it, func, &res, query) == GST_ITERATOR_RESYNC)
++    gst_iterator_resync (it);
++
++  gst_iterator_free (it);
++
++  return g_value_get_boolean (&res);
++}
++
++static void
++gst_qtdemux_request_protection_context (GstQTDemux * qtdemux,
++    QtDemuxStream * stream)
++{
++  GstQuery *query;
++  GstContext *ctxt;
++  GstElement *element = GST_ELEMENT (qtdemux);
++  GstStructure *st;
++  gchar **filtered_sys_ids;
++  GValue event_list = G_VALUE_INIT;
++  GList *walk;
++
++  /* 1. Check if we already have the context. */
++  if (qtdemux->preferred_protection_system_id != NULL) {
++    GST_LOG_OBJECT (element,
++        "already have the protection context, no need to request it again");
++    return;
++  }
++
++  g_ptr_array_add (qtdemux->protection_system_ids, NULL);
++  filtered_sys_ids = gst_protection_filter_systems_by_available_decryptors (
++      (const gchar **) qtdemux->protection_system_ids->pdata);
++  g_ptr_array_remove_index (qtdemux->protection_system_ids,
++      qtdemux->protection_system_ids->len - 1);
++  GST_TRACE_OBJECT (qtdemux, "detected %u protection systems, we have "
++      "decryptors for %u of them, running context request",
++      qtdemux->protection_system_ids->len, g_strv_length (filtered_sys_ids));
++
++  if (stream->protection_scheme_event_queue.length) {
++    GST_TRACE_OBJECT (qtdemux, "using stream event queue, length %u",
++        stream->protection_scheme_event_queue.length);
++    walk = stream->protection_scheme_event_queue.tail;
++  } else {
++    GST_TRACE_OBJECT (qtdemux, "using demuxer event queue, length %u",
++        qtdemux->protection_event_queue.length);
++    walk = qtdemux->protection_event_queue.tail;
++  }
++
++  g_value_init (&event_list, GST_TYPE_LIST);
++  for (; walk; walk = g_list_previous (walk)) {
++    GValue *event_value = g_new0 (GValue, 1);
++    g_value_init (event_value, GST_TYPE_EVENT);
++    g_value_set_boxed (event_value, walk->data);
++    gst_value_list_append_and_take_value (&event_list, event_value);
++  }
++
++  /*  2a) Query downstream with GST_QUERY_CONTEXT for the context and
++   *      check if downstream already has a context of the specific type
++   *  2b) Query upstream as above.
++   */
++  query = gst_query_new_context ("drm-preferred-decryption-system-id");
++  st = gst_query_writable_structure (query);
++  gst_structure_set (st, "track-id", G_TYPE_UINT, stream->track_id,
++      "stream-encryption-systems", G_TYPE_STRV, filtered_sys_ids, NULL);
++  gst_structure_set_value (st, "stream-encryption-events", &event_list);
++  if (gst_qtdemux_run_query (element, query, GST_PAD_SRC)) {
++    gst_query_parse_context (query, &ctxt);
++    GST_INFO_OBJECT (element, "found context (%p) in downstream query", ctxt);
++    gst_element_set_context (element, ctxt);
++  } else if (gst_qtdemux_run_query (element, query, GST_PAD_SINK)) {
++    gst_query_parse_context (query, &ctxt);
++    GST_INFO_OBJECT (element, "found context (%p) in upstream query", ctxt);
++    gst_element_set_context (element, ctxt);
++  } else {
++    /* 3) Post a GST_MESSAGE_NEED_CONTEXT message on the bus with
++     *    the required context type and afterwards check if a
++     *    usable context was set now as in 1). The message could
++     *    be handled by the parent bins of the element and the
++     *    application.
++     */
++    GstMessage *msg;
++
++    GST_INFO_OBJECT (element, "posting need context message");
++    msg = gst_message_new_need_context (GST_OBJECT_CAST (element),
++        "drm-preferred-decryption-system-id");
++    st = (GstStructure *) gst_message_get_structure (msg);
++    gst_structure_set (st, "track-id", G_TYPE_UINT, stream->track_id,
++        "stream-encryption-systems", G_TYPE_STRV, filtered_sys_ids, NULL);
++    gst_structure_set_value (st, "stream-encryption-events", &event_list);
++    gst_element_post_message (element, msg);
++  }
++
++  g_strfreev (filtered_sys_ids);
++  g_value_unset (&event_list);
++  gst_query_unref (query);
++}
++
++static gboolean
+ gst_qtdemux_configure_protected_caps (GstQTDemux * qtdemux,
+     QtDemuxStream * stream)
+ {
+   GstStructure *s;
+-  const gchar *selected_system;
++  const gchar *selected_system = NULL;
+ 
+   g_return_val_if_fail (qtdemux != NULL, FALSE);
+   g_return_val_if_fail (stream != NULL, FALSE);
+@@ -7494,17 +7658,41 @@ gst_qtdemux_configure_protected_caps (GstQTDemux * qtdemux,
+         "cenc protection system information has been found");
+     return FALSE;
+   }
+-  g_ptr_array_add (qtdemux->protection_system_ids, NULL);
+-  selected_system = gst_protection_select_system ((const gchar **)
+-      qtdemux->protection_system_ids->pdata);
+-  g_ptr_array_remove_index (qtdemux->protection_system_ids,
+-      qtdemux->protection_system_ids->len - 1);
++
++  gst_qtdemux_request_protection_context (qtdemux, stream);
++  if (qtdemux->preferred_protection_system_id != NULL) {
++    const gchar *preferred_system_array[] =
++        { qtdemux->preferred_protection_system_id, NULL };
++
++    selected_system = gst_protection_select_system (preferred_system_array);
++
++    if (selected_system) {
++      GST_TRACE_OBJECT (qtdemux, "selected preferred system %s",
++          qtdemux->preferred_protection_system_id);
++    } else {
++      GST_WARNING_OBJECT (qtdemux, "could not select preferred system %s "
++          "because there is no available decryptor",
++          qtdemux->preferred_protection_system_id);
++    }
++  }
++
++  if (!selected_system) {
++    g_ptr_array_add (qtdemux->protection_system_ids, NULL);
++    selected_system = gst_protection_select_system ((const gchar **)
++        qtdemux->protection_system_ids->pdata);
++    g_ptr_array_remove_index (qtdemux->protection_system_ids,
++        qtdemux->protection_system_ids->len - 1);
++  }
++
+   if (!selected_system) {
+     GST_ERROR_OBJECT (qtdemux, "stream is protected, but no "
+         "suitable decryptor element has been found");
+     return FALSE;
+   }
+ 
++  GST_DEBUG_OBJECT (qtdemux, "selected protection system is %s",
++      selected_system);
++
+   s = gst_caps_get_structure (stream->caps, 0);
+   if (!gst_structure_has_name (s, "application/x-cenc")) {
+     gst_structure_set (s,
+diff --git a/gst/isomp4/qtdemux.h b/gst/isomp4/qtdemux.h
+index 771ddcc5b..ba5f70cb2 100644
+--- a/gst/isomp4/qtdemux.h
++++ b/gst/isomp4/qtdemux.h
+@@ -154,6 +154,7 @@ struct _GstQTDemux {
+   guint64 cenc_aux_info_offset;
+   guint8 *cenc_aux_info_sizes;
+   guint32 cenc_aux_sample_count;
++  gchar *preferred_protection_system_id;
+ 
+ 
+   /*
+-- 
+2.11.0

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good-1.10.4/0007-qtdemux-dont-check-pushbased-edts.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good-1.10.4/0007-qtdemux-dont-check-pushbased-edts.patch
@@ -1,0 +1,11 @@
+--- a/gst/isomp4/qtdemux.c
++++ b/gst/isomp4/qtdemux.c
+@@ -8975,7 +8975,7 @@
+ 
+   /* push based does not handle segments, so act accordingly here,
+    * and warn if applicable */
+-  if (!qtdemux->pullbased && !allow_pushbased_edts) {
++  if (!qtdemux->pullbased /* && !allow_pushbased_edts */) {
+     GST_WARNING_OBJECT (qtdemux, "streaming; discarding edit list segments");
+     /* remove and use default one below, we stream like it anyway */
+     g_free (stream->segments);

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good-1.10.4/0008-qtdemux-also-push-buffers-without-encryption-info-in.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good-1.10.4/0008-qtdemux-also-push-buffers-without-encryption-info-in.patch
@@ -1,0 +1,50 @@
+From 78559bc5db3495f12b0284e4be5fc8bfcd7041e2 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Enrique=20Oca=C3=B1a=20Gonz=C3=A1lez?= <eocanha@igalia.com>
+Date: Mon, 24 Apr 2017 17:22:02 +0000
+Subject: [PATCH] qtdemux: also push buffers without encryption info instead of
+ dropping them
+
+---
+ gst/isomp4/qtdemux.c | 26 ++++++++++++--------------
+ 1 file changed, 12 insertions(+), 14 deletions(-)
+
+diff --git a/gst/isomp4/qtdemux.c b/gst/isomp4/qtdemux.c
+index 6b0c820..7b71237 100644
+--- a/gst/isomp4/qtdemux.c
++++ b/gst/isomp4/qtdemux.c
+@@ -5421,20 +5421,18 @@ gst_qtdemux_decorate_and_push_buffer (GstQTDemux * qtdemux,
+         gst_pad_push_event (stream->pad, event);
+     }
+ 
+-    if (info->crypto_info == NULL) {
+-      GST_DEBUG_OBJECT (qtdemux, "cenc metadata hasn't been parsed yet");
+-      gst_buffer_unref (buf);
+-      goto exit;
+-    }
+-
+-    index = stream->sample_index - (stream->n_samples - info->crypto_info->len);
+-    if (G_LIKELY (index >= 0 && index < info->crypto_info->len)) {
+-      /* steal structure from array */
+-      crypto_info = g_ptr_array_index (info->crypto_info, index);
+-      g_ptr_array_index (info->crypto_info, index) = NULL;
+-      GST_LOG_OBJECT (qtdemux, "attaching cenc metadata [%u]", index);
+-      if (!crypto_info || !gst_buffer_add_protection_meta (buf, crypto_info))
+-        GST_ERROR_OBJECT (qtdemux, "failed to attach cenc metadata to buffer");
++    if (info->crypto_info == NULL)
++      GST_DEBUG_OBJECT (qtdemux, "cenc metadata hasn't been parsed yet, pushing buffer as if it wasn't encrypted");
++    else {
++      index = stream->sample_index - (stream->n_samples - info->crypto_info->len);
++      if (G_LIKELY (index >= 0 && index < info->crypto_info->len)) {
++        /* steal structure from array */
++        crypto_info = g_ptr_array_index (info->crypto_info, index);
++        g_ptr_array_index (info->crypto_info, index) = NULL;
++        GST_LOG_OBJECT (qtdemux, "attaching cenc metadata [%u]", index);
++        if (!crypto_info || !gst_buffer_add_protection_meta (buf, crypto_info))
++          GST_ERROR_OBJECT (qtdemux, "failed to attach cenc metadata to buffer");
++      }
+     }
+   }
+ 
+-- 
+1.8.3.2
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good-1.10.4/0009-qtdemux-fix-assert-when-moof-contains-one-sample.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good-1.10.4/0009-qtdemux-fix-assert-when-moof-contains-one-sample.patch
@@ -1,0 +1,27 @@
+From e667ac33dcc039698ee311c22d7b37bedf48df3c Mon Sep 17 00:00:00 2001
+From: Nael Ouedraogo <nael.ouedraogo@crf.canon.fr>
+Date: Fri, 22 Sep 2017 18:41:52 +0200
+Subject: [PATCH] qtdemux: fix assert when moof contains one sample
+
+Avoid computing frame rate when a stream contain moof with only one
+sample, to avoid an assert. The moof is considered as still picture.
+---
+ gst/isomp4/qtdemux.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/gst/isomp4/qtdemux.c b/gst/isomp4/qtdemux.c
+index 5f4de422e..f839d82f6 100644
+--- a/gst/isomp4/qtdemux.c
++++ b/gst/isomp4/qtdemux.c
+@@ -7531,7 +7531,8 @@ gst_qtdemux_configure_stream (GstQTDemux * qtdemux, QtDemuxStream * stream)
+      * qt does not have a fixed framerate. */
+     gboolean fps_available = TRUE;
+ 
+-    if ((stream->n_samples == 1) && (stream->first_duration == 0)) {
++    if ((stream->n_samples == 1 && stream->first_duration == 0)
++        || (qtdemux->fragmented && stream->n_samples_moof == 1)) {
+       /* still frame */
+       stream->fps_n = 0;
+       stream->fps_d = 1;
+-- 
+2.14.1

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good-1.10.4/0010-matroskademux-Allow-Matroska-headers-to-be-read-more.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good-1.10.4/0010-matroskademux-Allow-Matroska-headers-to-be-read-more.patch
@@ -1,0 +1,43 @@
+From a45aa9ddbdf441ad9d9c347a1bad98414fc6de6a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alicia=20Boya=20Garc=C3=ADa?= <ntrrgc@gmail.com>
+Date: Thu, 30 Nov 2017 20:44:23 +0100
+Subject: [PATCH 1/2] matroskademux: Allow Matroska headers to be read more
+ than once
+
+This is necessary for MSE, where a new MSE initialization segment may be
+appended at any point. These MSE initialization segments consist of an
+entire WebM file until the first Cluster element (not included). [1]
+
+Note that track definitions are ignored on successive headers, they must
+match, but this is not checked by matroskademux (look for
+`(!demux->tracks_parsed)` in the code).
+
+Source pads are not altered when the new headers are read.
+
+This patch has been splitted from the original patch from eocanha in [2].
+
+[1] https://www.w3.org/TR/mse-byte-stream-format-webm/
+[2] https://bug334082.bugzilla-attachments.gnome.org/attachment.cgi?id=362212
+---
+ gst/matroska/matroska-demux.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/gst/matroska/matroska-demux.c b/gst/matroska/matroska-demux.c
+index e419a70..79903d1 100644
+--- a/gst/matroska/matroska-demux.c
++++ b/gst/matroska/matroska-demux.c
+@@ -4391,6 +4391,11 @@ gst_matroska_demux_parse_id (GstMatroskaDemux * demux, guint32 id,
+     case GST_MATROSKA_READ_STATE_DATA:
+     case GST_MATROSKA_READ_STATE_SEEK:
+       switch (id) {
++        case GST_EBML_ID_HEADER:
++          GST_READ_CHECK (gst_matroska_demux_flush (demux, read));
++          demux->common.state = GST_MATROSKA_READ_STATE_SEGMENT;
++          gst_matroska_demux_check_seekability (demux);
++          break;
+         case GST_MATROSKA_ID_SEGMENTINFO:
+           if (!demux->common.segmentinfo_parsed) {
+             GST_READ_CHECK (gst_matroska_demux_take (demux, read, &ebml));
+-- 
+1.8.3.2
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good-1.10.4/0011-matroskademux-Start-stream-time-at-zero.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good-1.10.4/0011-matroskademux-Start-stream-time-at-zero.patch
@@ -1,0 +1,28 @@
+From 78afbe5ac21067497536499c1d7439a595b918c6 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alicia=20Boya=20Garc=C3=ADa?= <aboya@igalia.com>
+Date: Wed, 22 Nov 2017 19:25:45 +0100
+Subject: [PATCH 2/2] matroskademux: Start stream time at zero
+
+---
+ gst/matroska/matroska-demux.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/gst/matroska/matroska-demux.c b/gst/matroska/matroska-demux.c
+index 79903d1..00020e5 100644
+--- a/gst/matroska/matroska-demux.c
++++ b/gst/matroska/matroska-demux.c
+@@ -3517,9 +3517,9 @@ gst_matroska_demux_parse_blockgroup_or_simpleblock (GstMatroskaDemux * demux,
+         clace_time = demux->common.segment.position + demux->stream_start_time;
+         segment->position = GST_CLOCK_TIME_NONE;
+       }
+-      segment->start = clace_time;
++      segment->start = 0;
+       segment->stop = GST_CLOCK_TIME_NONE;
+-      segment->time = segment->start - demux->stream_start_time;
++      segment->time = 0;
+       segment->position = segment->start - demux->stream_start_time;
+       GST_DEBUG_OBJECT (demux,
+           "generated segment starting at %" GST_TIME_FORMAT ": %"
+-- 
+1.8.3.2
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good-1.10.4/0012-matroskademux-emit-no-more-pads-when-the-Tracks-elem.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good-1.10.4/0012-matroskademux-emit-no-more-pads-when-the-Tracks-elem.patch
@@ -1,0 +1,51 @@
+From 35318132d2b4f25fe924b55171b09fb655721937 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alicia=20Boya=20Garc=C3=ADa?= <ntrrgc@gmail.com>
+Date: Thu, 14 Dec 2017 18:57:56 +0100
+Subject: [PATCH] matroskademux: emit no-more-pads when the Tracks element is
+ completely read
+
+---
+ gst/matroska/matroska-demux.c | 19 +++++++++----------
+ 1 file changed, 9 insertions(+), 10 deletions(-)
+
+diff --git a/gst/matroska/matroska-demux.c b/gst/matroska/matroska-demux.c
+index 00020e5..cac3fcb 100644
+--- a/gst/matroska/matroska-demux.c
++++ b/gst/matroska/matroska-demux.c
+@@ -2529,6 +2529,14 @@ gst_matroska_demux_parse_tracks (GstMatroskaDemux * demux, GstEbmlRead * ebml)
+ 
+   demux->tracks_parsed = TRUE;
+ 
++  demux->common.state = GST_MATROSKA_READ_STATE_DATA;
++  GST_DEBUG_OBJECT (demux, "signaling no more pads");
++  gst_element_no_more_pads (GST_ELEMENT (demux));
++  /* send initial segment - we wait till we know the first
++     incoming timestamp, so we can properly set the start of
++     the segment. */
++  demux->need_segment = TRUE;
++
+   return ret;
+ }
+ 
+@@ -4426,17 +4434,8 @@ gst_matroska_demux_parse_id (GstMatroskaDemux * demux, guint32 id,
+                 goto no_tracks;
+             }
+           }
+-          if (G_UNLIKELY (demux->common.state
+-                  == GST_MATROSKA_READ_STATE_HEADER)) {
+-            demux->common.state = GST_MATROSKA_READ_STATE_DATA;
++          if (demux->first_cluster_offset == 0)
+             demux->first_cluster_offset = demux->common.offset;
+-            GST_DEBUG_OBJECT (demux, "signaling no more pads");
+-            gst_element_no_more_pads (GST_ELEMENT (demux));
+-            /* send initial segment - we wait till we know the first
+-               incoming timestamp, so we can properly set the start of
+-               the segment. */
+-            demux->need_segment = TRUE;
+-          }
+           demux->cluster_time = GST_CLOCK_TIME_NONE;
+           demux->cluster_offset = demux->common.offset;
+           if (G_UNLIKELY (!demux->seek_first && demux->seek_block)) {
+-- 
+1.8.3.2
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good-1.10.4/0013-qtdemux-Don-t-push-GAP-event-if-first-buffer-is-with.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good-1.10.4/0013-qtdemux-Don-t-push-GAP-event-if-first-buffer-is-with.patch
@@ -1,0 +1,38 @@
+From 2e45926a96ec5298c6ef29bf912e5e6a06dc3e0e Mon Sep 17 00:00:00 2001
+From: Edward Hervey <edward@centricular.com>
+Date: Wed, 13 Dec 2017 11:35:37 +0100
+Subject: [PATCH] qtdemux: Don't push GAP event if first buffer is within 1s
+
+If we saw empty segments, we previously unconditionally pushed a
+GAP event downstream regardless of the duration of that empty
+segment.
+
+In order to avoid issues with initial negotiation of downstream elements
+(which would negotiate to something before receiving any data due to
+that initial GAP event), check if there's at least a second of difference
+(like we do for other GAP-related checks in qtdemux) before
+deciding to push a GAP event downstream.
+---
+ gst/isomp4/qtdemux.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/gst/isomp4/qtdemux.c b/gst/isomp4/qtdemux.c
+index b38e88ecf..91a22dc9e 100644
+--- a/gst/isomp4/qtdemux.c
++++ b/gst/isomp4/qtdemux.c
+@@ -5811,8 +5811,10 @@ gst_qtdemux_loop_state_movie (GstQTDemux * qtdemux)
+       GST_TIME_ARGS (dts), GST_TIME_ARGS (pts), GST_TIME_ARGS (duration));
+ 
+   if (G_UNLIKELY (empty)) {
+-    /* empty segment, push a gap and move to the next one */
+-    gst_pad_push_event (stream->pad, gst_event_new_gap (pts, duration));
++    /* empty segment, push a gap if there's more than a second
++     * difference and move to the next one */
++    if ((pts + duration - stream->segment.position) > GST_SECOND)
++      gst_pad_push_event (stream->pad, gst_event_new_gap (pts, duration));
+     stream->segment.position = pts + duration;
+     goto next;
+   }
+-- 
+2.14.3
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good-1.10.4/0014-qtdemux-default-key-ids.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good-1.10.4/0014-qtdemux-default-key-ids.patch
@@ -1,0 +1,134 @@
+From 15f68f30b47fa510b73dc6fa96f4dadd929b384e Mon Sep 17 00:00:00 2001
+From: Charlie Turner <chturne@gmail.com>
+Date: Fri, 25 May 2018 14:08:17 +0100
+Subject: [PATCH] [qtdemux] Check if an upstream demuxer provided a default
+ kid.
+
+Smooth streaming demuxers do not send boxes containing metadata about
+the stream. They have to send metadata "out-of-band".
+
+For piff encoded streams, if no box has been found containing a default
+kid for the sample, check if an upstream demuxer has provided one via a
+protection event, and use this as a fallback.
+---
+ gst/isomp4/qtdemux.c | 55 ++++++++++++++++++++++++++++++++++++++++----
+ 1 file changed, 51 insertions(+), 4 deletions(-)
+
+diff --git a/gst/isomp4/qtdemux.c b/gst/isomp4/qtdemux.c
+index bad9ca759..d033f98fd 100644
+--- a/gst/isomp4/qtdemux.c
++++ b/gst/isomp4/qtdemux.c
+@@ -407,6 +407,9 @@ struct _QtDemuxStream
+   guint32 protection_scheme_type;
+   guint32 protection_scheme_version;
+   gpointer protection_scheme_info;      /* specific to the protection scheme */
++
++  GstBuffer *default_kid;
++
+   GQueue protection_scheme_event_queue;
+ };
+ 
+@@ -1854,6 +1857,7 @@ _create_stream (void)
+   stream->alignment = 1;
+   stream->duration_last_moof = 0;
+   g_queue_init (&stream->protection_scheme_event_queue);
++  stream->default_kid = NULL;
+   return stream;
+ }
+ 
+@@ -2284,6 +2288,32 @@ gst_qtdemux_handle_sink_event (GstPad * sinkpad, GstObject * parent,
+     case GST_EVENT_PROTECTION:
+     {
+       const gchar *system_id = NULL;
++      GstBuffer *default_key_id = NULL;
++      const GstStructure *structure;
++      QtDemuxStream *stream = NULL;
++      GstMapInfo map;
++
++      structure = gst_event_get_structure (event);
++      if (gst_structure_has_field_typed (structure, "key_id", GST_TYPE_BUFFER)) {
++        gst_structure_get (structure, "key_id", GST_TYPE_BUFFER,
++            &default_key_id, NULL);
++        GST_DEBUG_OBJECT (demux,
++            "received a default key id of size %" G_GSIZE_FORMAT,
++            gst_buffer_get_size (default_key_id));
++
++        if (gst_debug_category_get_threshold (GST_CAT_DEFAULT) >=
++            GST_LEVEL_MEMDUMP) {
++          gst_buffer_map (default_key_id, &map, GST_MAP_READ);
++          GST_MEMDUMP_OBJECT (demux, "default key id", (guint8 *) map.data,
++              map.size);
++          gst_buffer_unmap (default_key_id, &map);
++        }
++
++        if (demux->n_streams) {
++          stream = demux->streams[0];
++          stream->default_kid = default_key_id;
++        }
++      }
+ 
+       gst_event_parse_protection (event, &system_id, NULL, NULL);
+       GST_DEBUG_OBJECT (demux, "Received protection event for system ID %s",
+@@ -2436,6 +2466,8 @@ gst_qtdemux_stream_clear (GstQTDemux * qtdemux, QtDemuxStream * stream)
+   g_queue_foreach (&stream->protection_scheme_event_queue,
+       (GFunc) gst_event_unref, NULL);
+   g_queue_clear (&stream->protection_scheme_event_queue);
++  if (stream->default_kid)
++    gst_buffer_unref (stream->default_kid);
+   gst_qtdemux_stream_flush_segments_data (qtdemux, stream);
+   gst_qtdemux_stream_flush_samples_data (qtdemux, stream);
+ }
+@@ -2663,6 +2695,18 @@ qtdemux_parse_piff (GstQTDemux * qtdemux, const guint8 * buffer, gint length,
+   } else if ((flags & 0x000002)) {
+     uses_sub_sample_encryption = TRUE;
+   }
++  // In the case of smooth streaming, we never get moov boxes and their
++  // default encryption metadata. Instead, the demuxer has to parse this
++  // information out of the playready specific payloads and make it availble
++  // somehow to us.
++  if (!gst_structure_has_field (ss_info->default_properties, "kid")) {
++    if (!stream->default_kid) {
++      GST_WARNING_OBJECT (qtdemux, "No available key id for sample");
++    } else {
++      gst_structure_set (ss_info->default_properties, "kid", GST_TYPE_BUFFER,
++          stream->default_kid, NULL);
++    }
++  }
+ 
+   if (!gst_byte_reader_get_uint32_be (&br, &qtdemux->cenc_aux_sample_count)) {
+     GST_ERROR_OBJECT (qtdemux, "Error getting box's sample count field");
+@@ -5418,16 +5462,19 @@ gst_qtdemux_decorate_and_push_buffer (GstQTDemux * qtdemux,
+     }
+ 
+     if (info->crypto_info == NULL)
+-      GST_DEBUG_OBJECT (qtdemux, "cenc metadata hasn't been parsed yet, pushing buffer as if it wasn't encrypted");
++      GST_DEBUG_OBJECT (qtdemux,
++          "cenc metadata hasn't been parsed yet, pushing buffer as if it wasn't encrypted");
+     else {
+-      index = stream->sample_index - (stream->n_samples - info->crypto_info->len);
++      index =
++          stream->sample_index - (stream->n_samples - info->crypto_info->len);
+       if (G_LIKELY (index >= 0 && index < info->crypto_info->len)) {
+         /* steal structure from array */
+         crypto_info = g_ptr_array_index (info->crypto_info, index);
+         g_ptr_array_index (info->crypto_info, index) = NULL;
+         GST_LOG_OBJECT (qtdemux, "attaching cenc metadata [%u]", index);
+         if (!crypto_info || !gst_buffer_add_protection_meta (buf, crypto_info))
+-          GST_ERROR_OBJECT (qtdemux, "failed to attach cenc metadata to buffer");
++          GST_ERROR_OBJECT (qtdemux,
++              "failed to attach cenc metadata to buffer");
+       }
+     }
+   }
+@@ -8968,7 +9015,7 @@ done:
+ 
+   /* push based does not handle segments, so act accordingly here,
+    * and warn if applicable */
+-  if (!qtdemux->pullbased /* && !allow_pushbased_edts */) {
++  if (!qtdemux->pullbased /* && !allow_pushbased_edts */ ) {
+     GST_WARNING_OBJECT (qtdemux, "streaming; discarding edit list segments");
+     /* remove and use default one below, we stream like it anyway */
+     g_free (stream->segments);
+-- 
+2.17.1
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good-1.10.4/0015-qtdemux-Keep-sample-data-from-the-current-fragment-o.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good-1.10.4/0015-qtdemux-Keep-sample-data-from-the-current-fragment-o.patch
@@ -1,0 +1,41 @@
+From bfa666506313715af71141c22ba301eec6f059a0 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alicia=20Boya=20Garc=C3=ADa?= <aboya@igalia.com>
+Date: Tue, 31 Jul 2018 12:52:36 +0200
+Subject: [PATCH] qtdemux: Keep sample data from the current fragment only
+ (push mode)
+
+This patch clears the sample table whenever the demuxing of a new
+fragment begins. This avoids increasing memory usage for long videos.
+This behavior was already present when upstream_format_is_time; this
+patch extends it to all push mode operation (e.g. Media Source
+Extensions).
+---
+ gst/isomp4/qtdemux.c | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/gst/isomp4/qtdemux.c b/gst/isomp4/qtdemux.c
+index d033f98fd..7bc79388d 100644
+--- a/gst/isomp4/qtdemux.c
++++ b/gst/isomp4/qtdemux.c
+@@ -3889,8 +3889,17 @@ qtdemux_parse_moof (GstQTDemux * qtdemux, const guint8 * buffer, guint length,
+     if (G_UNLIKELY (base_offset < -1))
+       goto lost_offset;
+ 
+-    if (qtdemux->upstream_format_is_time)
++    if (!qtdemux->pullbased) {
++      /* Sample tables can grow enough to be problematic if the system memory
++       * is very low (e.g. embedded devices) and the videos very long
++       * (~8 MiB/hour for 25-30 fps video + typical AAC audio frames).
++       * Fortunately, we can easily discard them for each new fragment when
++       * we know qtdemux will not receive seeks outside of the current fragment.
++       * adaptivedemux honors this assumption.
++       * This optimization is also useful for applications that use qtdemux as
++       * a push-based simple demuxer, like Media Source Extensions. */
+       gst_qtdemux_stream_flush_samples_data (qtdemux, stream);
++    }
+ 
+     /* initialise moof sample data */
+     stream->n_samples_moof = 0;
+-- 
+2.17.0
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good-1.10.4/0016-matroska-Add-the-WebM-encrypted-content-support-in-m.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good-1.10.4/0016-matroska-Add-the-WebM-encrypted-content-support-in-m.patch
@@ -1,0 +1,844 @@
+From 3019a75d6b70c2865bad5c43fb8b4e75bfd13a6e Mon Sep 17 00:00:00 2001
+From: Yacine Bandou <yacine.bandou@softathome.com>
+Date: Sun, 30 Sep 2018 19:28:07 +0200
+Subject: [PATCH 16/17] matroska: Add the WebM encrypted content support in
+ matroskademux
+
+This commit:
+
+1. Reads the WebM and Matroska ContentEncryption subelements.
+
+2. Creates a GST_PROTECTION event for each ContentEncryption, which
+   will be sent before pushing the first source buffer.
+   The DRM system id field in this event is set to GST_PROTECTION_UNSPECIFIED_SYSTEM_ID,
+   because it isn't specified neither by Matroska nor by the WebM spec.
+
+3. Reads the protection information of encrypted Block/SimpleBlock and
+   extracts the IV and the partitioning format (subsamples).
+
+4. Creates the metadata protection for each encrypted Block/SimpleBlock,
+   with those informations: KeyID (extracted from ContentEncryption element),
+   IV and partitioning format.
+
+5. Adds a new caps for WebM encrypted content named "application/x-webm-enc",
+   with the following new fields:
+
+   "encryption-algorithm": The encryption algorithm used.
+                           values: "None", "DES", "3DES", "Twofish", "Blowfish", "AES".
+
+   "encoding-scope": The field that describes which Elements have been modified.
+                     Values: "frame", "codec-data", "next-content".
+
+   "cipher-mode": The cipher mode used in the encryption.
+                  Values: "None", "CTR".
+
+https://bugzilla.gnome.org/show_bug.cgi?id=765275
+
+Signed-off-by: Xabier Rodriguez Calvar <calvaris@igalia.com>
+---
+ gst/matroska/matroska-demux.c       | 122 +++++++++-
+ gst/matroska/matroska-ids.c         |  73 ++++++
+ gst/matroska/matroska-ids.h         |  53 +++++
+ gst/matroska/matroska-read-common.c | 354 +++++++++++++++++++++++++++-
+ gst/matroska/matroska-read-common.h |   3 +
+ 5 files changed, 586 insertions(+), 19 deletions(-)
+
+diff --git a/gst/matroska/matroska-demux.c b/gst/matroska/matroska-demux.c
+index cac3fcbf2..c298e940c 100644
+--- a/gst/matroska/matroska-demux.c
++++ b/gst/matroska/matroska-demux.c
+@@ -168,6 +168,9 @@ static GstCaps *gst_matroska_demux_audio_caps (GstMatroskaTrackAudioContext
+ static GstCaps
+     * gst_matroska_demux_subtitle_caps (GstMatroskaTrackSubtitleContext *
+     subtitlecontext, const gchar * codec_id, gpointer data, guint size);
++static const gchar *gst_matroska_track_encryption_algorithm_name (gint val);
++static const gchar *gst_matroska_track_encryption_cipher_mode_name (gint val);
++static const gchar *gst_matroska_track_encoding_scope_name (gint val);
+ 
+ /* stream methods */
+ static void gst_matroska_demux_reset (GstElement * element);
+@@ -339,12 +342,13 @@ gst_matroska_decode_buffer (GstMatroskaTrackContext * context, GstBuffer * buf)
+   GstMapInfo map;
+   gpointer data;
+   gsize size;
++  GstBuffer *out_buf = buf;
+ 
+   g_return_val_if_fail (GST_IS_BUFFER (buf), NULL);
+ 
+   GST_DEBUG ("decoding buffer %p", buf);
+ 
+-  gst_buffer_map (buf, &map, GST_MAP_READ);
++  gst_buffer_map (out_buf, &map, GST_MAP_READ);
+   data = map.data;
+   size = map.size;
+ 
+@@ -352,15 +356,53 @@ gst_matroska_decode_buffer (GstMatroskaTrackContext * context, GstBuffer * buf)
+ 
+   if (gst_matroska_decode_data (context->encodings, &data, &size,
+           GST_MATROSKA_TRACK_ENCODING_SCOPE_FRAME, FALSE)) {
+-    gst_buffer_unmap (buf, &map);
+-    gst_buffer_unref (buf);
+-    return gst_buffer_new_wrapped (data, size);
++    gst_buffer_unmap (out_buf, &map);
++    if (data != map.data) {
++      gst_buffer_unref (out_buf);
++      out_buf = gst_buffer_new_wrapped (data, size);
++    }
+   } else {
+     GST_DEBUG ("decode data failed");
+-    gst_buffer_unmap (buf, &map);
+-    gst_buffer_unref (buf);
++    gst_buffer_unmap (out_buf, &map);
++    gst_buffer_unref (out_buf);
+     return NULL;
+   }
++  /* Encrypted stream */
++  if (context->protection_info) {
++
++    GstStructure *info_protect = gst_structure_copy (context->protection_info);
++    gboolean encrypted = FALSE;
++
++    gst_buffer_map (out_buf, &map, GST_MAP_READ);
++    data = map.data;
++    size = map.size;
++
++    if (gst_matroska_parse_protection_meta (&data, &size, info_protect,
++            &encrypted)) {
++      gst_buffer_unmap (out_buf, &map);
++      if (data != map.data) {
++        GstBuffer *tmp_buf = out_buf;
++        out_buf =
++            gst_buffer_copy_region (tmp_buf, GST_BUFFER_COPY_ALL,
++            gst_buffer_get_size (tmp_buf) - size, size);
++        gst_buffer_unref (tmp_buf);
++        if (encrypted)
++          gst_buffer_add_protection_meta (out_buf, info_protect);
++        else
++          gst_structure_free (info_protect);
++      } else {
++        gst_structure_free (info_protect);
++      }
++    } else {
++      GST_WARNING ("Adding protection metadata failed");
++      gst_buffer_unmap (out_buf, &map);
++      gst_buffer_unref (out_buf);
++      gst_structure_free (info_protect);
++      return NULL;
++    }
++  }
++
++  return out_buf;
+ }
+ 
+ static void
+@@ -436,6 +478,8 @@ gst_matroska_demux_add_stream (GstMatroskaDemux * demux, GstEbmlRead * ebml)
+   context->tags = gst_tag_list_new_empty ();
+   demux->common.num_streams++;
+   g_assert (demux->common.src->len == demux->common.num_streams);
++  g_queue_init (&context->protection_event_queue);
++  context->protection_info = NULL;
+ 
+   GST_DEBUG_OBJECT (demux, "Stream number %d", context->index);
+ 
+@@ -1275,6 +1319,31 @@ gst_matroska_demux_add_stream (GstMatroskaDemux * demux, GstEbmlRead * ebml)
+         context->stream_headers, caps);
+   }
+ 
++  if (context->encodings) {
++    GstMatroskaTrackEncoding *enc;
++    guint i;
++
++    for (i = 0; i < context->encodings->len; i++) {
++      enc = &g_array_index (context->encodings, GstMatroskaTrackEncoding, i);
++      if (enc->type == GST_MATROSKA_ENCODING_ENCRYPTION /* encryption */ ) {
++        GstStructure *s = gst_caps_get_structure (caps, 0);
++        if (!gst_structure_has_name (s, "application/x-webm-enc")) {
++          gst_structure_set (s, "original-media-type", G_TYPE_STRING,
++              gst_structure_get_name (s), NULL);
++          gst_structure_set (s, "encryption-algorithm", G_TYPE_STRING,
++              gst_matroska_track_encryption_algorithm_name (enc->enc_algo),
++              NULL);
++          gst_structure_set (s, "encoding-scope", G_TYPE_STRING,
++              gst_matroska_track_encoding_scope_name (enc->scope), NULL);
++          gst_structure_set (s, "cipher-mode", G_TYPE_STRING,
++              gst_matroska_track_encryption_cipher_mode_name
++              (enc->enc_cipher_mode), NULL);
++          gst_structure_set_name (s, "application/x-webm-enc");
++        }
++      }
++    }
++  }
++
+   /* the pad in here */
+   context->pad = gst_pad_new_from_template (templ, padname);
+   context->caps = caps;
+@@ -3484,6 +3553,7 @@ gst_matroska_demux_parse_blockgroup_or_simpleblock (GstMatroskaDemux * demux,
+     gboolean delta_unit = FALSE;
+     guint64 duration = 0;
+     gint64 lace_time = 0;
++    GstEvent *protect_event;
+ 
+     stream = g_ptr_array_index (demux->common.src, stream_num);
+ 
+@@ -3503,6 +3573,12 @@ gst_matroska_demux_parse_blockgroup_or_simpleblock (GstMatroskaDemux * demux,
+     } else {
+       lace_time = GST_CLOCK_TIME_NONE;
+     }
++    /* Send the GST_PROTECTION event */
++    while ((protect_event = g_queue_pop_head (&stream->protection_event_queue))) {
++      GST_TRACE_OBJECT (demux, "pushing protection event for stream %d:%s",
++          stream->index, GST_STR_NULL (stream->name));
++      gst_pad_push_event (stream->pad, protect_event);
++    }
+ 
+     /* need to refresh segment info ASAP */
+     if (GST_CLOCK_TIME_IS_VALID (lace_time) && demux->need_segment) {
+@@ -4566,6 +4642,9 @@ gst_matroska_demux_parse_id (GstMatroskaDemux * demux, guint32 id,
+         case GST_MATROSKA_ID_POSITION:
+         case GST_MATROSKA_ID_PREVSIZE:
+         case GST_MATROSKA_ID_ENCRYPTEDBLOCK:
++          /* The WebM doesn't support the EncryptedBlock element.
++           * The Matroska spec doesn't give us more detail, how to parse this element,
++           * for example the field TransformID isn't specified yet.*/
+         case GST_MATROSKA_ID_SILENTTRACKS:
+           GST_DEBUG_OBJECT (demux,
+               "Skipping Cluster subelement 0x%x - ignoring", id);
+@@ -6062,6 +6141,37 @@ gst_matroska_demux_get_property (GObject * object,
+   }
+ }
+ 
++static const gchar *
++gst_matroska_track_encryption_algorithm_name (gint val)
++{
++  GEnumValue *en;
++  GEnumClass *enum_class =
++      g_type_class_ref (MATROSKA_TRACK_ENCRYPTION_ALGORITHM_TYPE);
++  en = g_enum_get_value (G_ENUM_CLASS (enum_class), val);
++  return en ? en->value_nick : NULL;
++}
++
++static const gchar *
++gst_matroska_track_encryption_cipher_mode_name (gint val)
++{
++  GEnumValue *en;
++  GEnumClass *enum_class =
++      g_type_class_ref (MATROSKA_TRACK_ENCRYPTION_CIPHER_MODE_TYPE);
++  en = g_enum_get_value (G_ENUM_CLASS (enum_class), val);
++  return en ? en->value_nick : NULL;
++}
++
++static const gchar *
++gst_matroska_track_encoding_scope_name (gint val)
++{
++  GEnumValue *en;
++  GEnumClass *enum_class =
++      g_type_class_ref (MATROSKA_TRACK_ENCODING_SCOPE_TYPE);
++
++  en = g_enum_get_value (G_ENUM_CLASS (enum_class), val);
++  return en ? en->value_nick : NULL;
++}
++
+ gboolean
+ gst_matroska_demux_plugin_init (GstPlugin * plugin)
+ {
+diff --git a/gst/matroska/matroska-ids.c b/gst/matroska/matroska-ids.c
+index 1ef3e2630..d8734a495 100644
+--- a/gst/matroska/matroska-ids.c
++++ b/gst/matroska/matroska-ids.c
+@@ -346,5 +346,78 @@ gst_matroska_track_free (GstMatroskaTrackContext * track)
+   if (track->stream_headers)
+     gst_buffer_list_unref (track->stream_headers);
+ 
++  g_queue_foreach (&track->protection_event_queue, (GFunc) gst_event_unref,
++      NULL);
++  g_queue_clear (&track->protection_event_queue);
++
++  if (track->protection_info)
++    gst_structure_free (track->protection_info);
++
+   g_free (track);
+ }
++
++GType
++matroska_track_encryption_algorithm_get_type (void)
++{
++  static GType type = 0;
++
++  static const GEnumValue types[] = {
++    {GST_MATROSKA_TRACK_ENCRYPTION_ALGORITHM_NONE, "Not encrypted",
++        "None"},
++    {GST_MATROSKA_TRACK_ENCRYPTION_ALGORITHM_DES, "DES encryption algorithm",
++        "DES"},
++    {GST_MATROSKA_TRACK_ENCRYPTION_ALGORITHM_3DES, "3DES encryption algorithm",
++        "3DES"},
++    {GST_MATROSKA_TRACK_ENCRYPTION_ALGORITHM_TWOFISH,
++        "TwoFish encryption algorithm", "TwoFish"},
++    {GST_MATROSKA_TRACK_ENCRYPTION_ALGORITHM_BLOWFISH,
++        "BlowFish encryption algorithm", "BlowFish"},
++    {GST_MATROSKA_TRACK_ENCRYPTION_ALGORITHM_AES, "AES encryption algorithm",
++        "AES"},
++    {0, NULL, NULL}
++  };
++
++  if (!type) {
++    type = g_enum_register_static ("MatroskaTrackEncryptionAlgorithm", types);
++  }
++  return type;
++}
++
++GType
++matroska_track_encryption_cipher_mode_get_type (void)
++{
++  static GType type = 0;
++
++  static const GEnumValue types[] = {
++    {GST_MATROSKA_TRACK_ENCRYPTION_CIPHER_MODE_NONE, "Not defined",
++        "None"},
++    {GST_MATROSKA_TRACK_ENCRYPTION_CIPHER_MODE_CTR, "CTR encryption mode",
++        "CTR"},
++    {0, NULL, NULL}
++  };
++
++  if (!type) {
++    type = g_enum_register_static ("MatroskaTrackEncryptionCipherMode", types);
++  }
++  return type;
++}
++
++GType
++matroska_track_encoding_scope_get_type (void)
++{
++  static GType type = 0;
++
++  static const GEnumValue types[] = {
++    {GST_MATROSKA_TRACK_ENCODING_SCOPE_FRAME, "Encoding scope frame", "frame"},
++    {GST_MATROSKA_TRACK_ENCODING_SCOPE_CODEC_DATA, "Encoding scope codec data",
++        "codec-data"},
++    {GST_MATROSKA_TRACK_ENCODING_SCOPE_NEXT_CONTENT_ENCODING,
++        "Encoding scope next content", "next-content"},
++    {0, NULL, NULL}
++  };
++
++  if (!type) {
++    type = g_enum_register_static ("MatroskaTrackEncodingScope", types);
++  }
++  return type;
++}
+diff --git a/gst/matroska/matroska-ids.h b/gst/matroska/matroska-ids.h
+index a2171b37c..ffcf5d9a1 100644
+--- a/gst/matroska/matroska-ids.h
++++ b/gst/matroska/matroska-ids.h
+@@ -168,6 +168,9 @@
+ #define GST_MATROSKA_ID_CONTENTSIGKEYID            0x47E4
+ #define GST_MATROSKA_ID_CONTENTSIGALGO             0x47E5
+ #define GST_MATROSKA_ID_CONTENTSIGHASHALGO         0x47E6
++/* Added in WebM spec */
++#define GST_MATROSKA_ID_CONTENTENCAESSETTINGS      0x47E7
++#define GST_MATROSKA_ID_AESSETTINGSCIPHERMODE      0x47E8
+ 
+ /* ID in the CUEs master */
+ #define GST_MATROSKA_ID_POINTENTRY                 0xBB
+@@ -505,6 +508,17 @@ typedef enum {
+   GST_MATROSKA_STEREO_MODE_FBF_RL      = 0xE
+ } GstMatroskaStereoMode;
+ 
++typedef enum {
++  GST_MATROSKA_ENCODING_COMPRESSION = 0x00,
++  GST_MATROSKA_ENCODING_ENCRYPTION  = 0x01
++} GstMatroskaEncodingType;
++
++/* WebM spec */
++typedef enum {
++  GST_MATROSKA_BLOCK_ENCRYPTED   = 0x01,
++  GST_MATROSKA_BLOCK_PARTITIONED = 0x02
++} GstMatroskaEncryptedBlockFlags;
++
+ typedef struct _GstMatroskaTrackContext GstMatroskaTrackContext;
+ 
+ /* TODO: check if all fields are used */
+@@ -538,6 +552,11 @@ struct _GstMatroskaTrackContext {
+ 
+   gboolean      set_discont; /* TRUE = set DISCONT flag on next buffer */
+ 
++  /* Queue to save the GST_PROTECTION events which will be sent before the first source buffer */
++  GQueue         protection_event_queue;
++  /* Protection information structure which will be added in protection metadata for each encrypted buffer */
++  GstStructure * protection_info;
++
+   /* Stream header buffer, to put into caps and send before any other buffers */
+   GstBufferList * stream_headers;
+   gboolean        send_stream_headers;
+@@ -640,6 +659,9 @@ typedef enum {
+   GST_MATROSKA_TRACK_ENCODING_SCOPE_NEXT_CONTENT_ENCODING = (1<<2)
+ } GstMatroskaTrackEncodingScope;
+ 
++#define MATROSKA_TRACK_ENCODING_SCOPE_TYPE (matroska_track_encoding_scope_get_type())
++GType matroska_track_encoding_scope_get_type (void);
++
+ typedef enum {
+   GST_MATROSKA_TRACK_COMPRESSION_ALGORITHM_ZLIB = 0,
+   GST_MATROSKA_TRACK_COMPRESSION_ALGORITHM_BZLIB = 1,
+@@ -647,6 +669,35 @@ typedef enum {
+   GST_MATROSKA_TRACK_COMPRESSION_ALGORITHM_HEADERSTRIP = 3
+ } GstMatroskaTrackCompressionAlgorithm;
+ 
++/* The encryption algorithm used. The value '0' means that the contents
++ * have not been encrypted but only signed.
++ * Predefined values: 1 - DES; 2 - 3DES; 3 - Twofish; 4 - Blowfish; 5 - AES.
++ * WebM only supports a value of 5 (AES).
++ */
++typedef enum {
++  GST_MATROSKA_TRACK_ENCRYPTION_ALGORITHM_NONE     = 0,
++  GST_MATROSKA_TRACK_ENCRYPTION_ALGORITHM_DES      = 1,
++  GST_MATROSKA_TRACK_ENCRYPTION_ALGORITHM_3DES     = 2,
++  GST_MATROSKA_TRACK_ENCRYPTION_ALGORITHM_TWOFISH  = 3,
++  GST_MATROSKA_TRACK_ENCRYPTION_ALGORITHM_BLOWFISH = 4,
++  GST_MATROSKA_TRACK_ENCRYPTION_ALGORITHM_AES      = 5
++} GstMatroskaTrackEncryptionAlgorithm;
++
++#define MATROSKA_TRACK_ENCRYPTION_ALGORITHM_TYPE (matroska_track_encryption_algorithm_get_type())
++GType matroska_track_encryption_algorithm_get_type (void);
++
++/* Defined only in WebM spec.
++ * The cipher mode used in the encryption. Predefined values: 1 - CTR
++ */
++typedef enum {
++  GST_MATROSKA_TRACK_ENCRYPTION_CIPHER_MODE_NONE    = 0,
++  GST_MATROSKA_TRACK_ENCRYPTION_CIPHER_MODE_CTR     = 1
++} GstMatroskaTrackEncryptionCipherMode;
++
++#define MATROSKA_TRACK_ENCRYPTION_CIPHER_MODE_TYPE (matroska_track_encryption_cipher_mode_get_type())
++GType matroska_track_encryption_cipher_mode_get_type (void);
++
++
+ typedef struct _GstMatroskaTrackEncoding {
+   guint   order;
+   guint   scope     : 3;
+@@ -654,6 +705,8 @@ typedef struct _GstMatroskaTrackEncoding {
+   guint   comp_algo : 2;
+   guint8 *comp_settings;
+   guint   comp_settings_length;
++  guint   enc_algo  : 3;
++  guint   enc_cipher_mode : 2;
+ } GstMatroskaTrackEncoding;
+ 
+ gboolean gst_matroska_track_init_video_context    (GstMatroskaTrackContext ** p_context);
+diff --git a/gst/matroska/matroska-read-common.c b/gst/matroska/matroska-read-common.c
+index 4b3512919..68462ad52 100644
+--- a/gst/matroska/matroska-read-common.c
++++ b/gst/matroska/matroska-read-common.c
+@@ -39,6 +39,7 @@
+ 
+ #include <gst/tag/tag.h>
+ #include <gst/base/gsttypefindhelper.h>
++#include <gst/base/gstbytewriter.h>
+ 
+ #include "lzo.h"
+ 
+@@ -262,9 +263,9 @@ gst_matroska_decode_content_encodings (GArray * encodings)
+         == 0)
+       continue;
+ 
+-    /* Encryption not supported yet */
+-    if (enc->type != 0)
+-      return GST_FLOW_ERROR;
++    /* Other than ENCODING_COMPRESSION not handled here */
++    if (enc->type != GST_MATROSKA_ENCODING_COMPRESSION)
++      continue;
+ 
+     if (i + 1 >= encodings->len)
+       return GST_FLOW_ERROR;
+@@ -312,9 +313,9 @@ gst_matroska_decode_data (GArray * encodings, gpointer * data_out,
+     if ((enc->scope & scope) == 0)
+       continue;
+ 
+-    /* Encryption not supported yet */
+-    if (enc->type != 0) {
+-      ret = FALSE;
++    /* Encryption not handled here */
++    if (enc->type != GST_MATROSKA_ENCODING_COMPRESSION) {
++      ret = TRUE;
+       break;
+     }
+ 
+@@ -349,6 +350,211 @@ gst_matroska_decode_data (GArray * encodings, gpointer * data_out,
+   return ret;
+ }
+ 
++/* This function parses the protection info of Block/SimpleBlock and extracts the
++ * IV and partitioning format (subsample) information.
++ * Set those parsed information into protection info structure @info_protect which
++ * will be added in protection metadata of the Gstbuffer.
++ * The subsamples format follows the same pssh box format in Common Encryption spec:
++ * subsample number + clear subsample size (16bit bigendian) | encrypted subsample size (32bit bigendian) | ...
++ * @encrypted is an output argument: TRUE if the current Block/SimpleBlock is encrypted else FALSE
++ */
++gboolean
++gst_matroska_parse_protection_meta (gpointer * data_out, gsize * size_out,
++    GstStructure * info_protect, gboolean * encrypted)
++{
++  guint8 *data;
++  GstBuffer *buf_iv;
++  guint8 *data_iv;
++  guint8 *subsamples;
++  guint8 signal_byte;
++  gint i;
++  GstByteReader reader;
++
++  g_return_val_if_fail (data_out != NULL && *data_out != NULL, FALSE);
++  g_return_val_if_fail (size_out != NULL, FALSE);
++  g_return_val_if_fail (info_protect != NULL, FALSE);
++  g_return_val_if_fail (encrypted != NULL, FALSE);
++
++  *encrypted = FALSE;
++  data = *data_out;
++  gst_byte_reader_init (&reader, data, *size_out);
++
++  /* WebM spec:
++   * 4.7 Signal Byte Format
++   *  0 1 2 3 4 5 6 7
++   * +-+-+-+-+-+-+-+-+
++   * |X|   RSV   |P|E|
++   * +-+-+-+-+-+-+-+-+
++   *
++   * Extension bit (X)
++   * If set, another signal byte will follow this byte. Reserved for future expansion (currently MUST be set to 0).
++   * RSV bits (RSV)
++   * Bits reserved for future use. MUST be set to 0 and MUST be ignored.
++   * Encrypted bit (E)
++   * If set, the Block MUST contain an IV immediately followed by an encrypted frame. If not set, the Block MUST NOT include an IV and the frame MUST be unencrypted. The unencrypted frame MUST immediately follow the Signal Byte.
++   * Partitioned bit (P)
++   * Used to indicate that the sample has subsample partitions. If set, the IV will be followed by a num_partitions byte, and num_partitions * 32-bit partition offsets. This bit can only be set if the E bit is also set.
++   */
++  if (!gst_byte_reader_get_uint8 (&reader, &signal_byte)) {
++    GST_ERROR ("Error reading the signal byte");
++    return FALSE;
++  }
++
++  /* Unencrypted buffer */
++  if (!(signal_byte & GST_MATROSKA_BLOCK_ENCRYPTED)) {
++    return TRUE;
++  }
++
++  /* Encrypted buffer */
++  *encrypted = TRUE;
++  /* Create IV buffer */
++  if (!gst_byte_reader_dup_data (&reader, sizeof (guint64), &data_iv)) {
++    GST_ERROR ("Error reading the IV data");
++    return FALSE;
++  }
++  buf_iv = gst_buffer_new_wrapped ((gpointer) data_iv, sizeof (guint64));
++  gst_structure_set (info_protect, "iv", GST_TYPE_BUFFER, buf_iv, NULL);
++  gst_buffer_unref (buf_iv);
++
++  /* Partitioned in subsample */
++  if (signal_byte & GST_MATROSKA_BLOCK_PARTITIONED) {
++    guint nb_subsample;
++    guint32 offset = 0;
++    guint32 offset_prev;
++    guint32 encrypted_bytes = 0;
++    guint16 clear_bytes = 0;
++    GstBuffer *buf_sub_sample;
++    guint8 nb_part;
++    GstByteWriter writer;
++
++    /* Read the number of partitions (1 byte) */
++    if (!gst_byte_reader_get_uint8 (&reader, &nb_part)) {
++      GST_ERROR ("Error reading the partition number");
++      return FALSE;
++    }
++
++    if (nb_part == 0) {
++      GST_ERROR ("Partitioned, but the subsample number equal to zero");
++      return FALSE;
++    }
++
++    nb_subsample = (nb_part + 2) >> 1;
++
++    gst_structure_set (info_protect, "subsample_count", G_TYPE_UINT,
++        nb_subsample, NULL);
++
++    /* WebM Spec:
++     *
++     * 4.6 Subsample Encrypted Block Format
++     *
++     * The Subsample Encrypted Block format extends the Full-sample format by setting a "partitioned" (P) bit in the Signal Byte.
++     * If this bit is set, the EncryptedBlock header shall include an
++     * 8-bit integer indicating the number of sample partitions (dividers between clear/encrypted sections),
++     * and a series of 32-bit integers in big-endian encoding indicating the byte offsets of such partitions.
++     *
++     *  0                   1                   2                   3
++     *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++     * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
++     * |  Signal Byte  |                                               |
++     * +-+-+-+-+-+-+-+-+             IV                                |
++     * |                                                               |
++     * |               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
++     * |               | num_partition |     Partition 0 offset ->     |
++     * |-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-|
++     * |     -> Partition 0 offset     |              ...              |
++     * |-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-|
++     * |             ...               |     Partition n-1 offset ->   |
++     * |-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-|
++     * |     -> Partition n-1 offset   |                               |
++     * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+                               |
++     * |                    Clear/encrypted sample data                |
++     * |                                                               |
++     * |                                                               |
++     * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
++     *
++     * 4.6.1 SAMPLE PARTITIONS
++     *
++     * The samples shall be partitioned into alternating clear and encrypted sections,
++     * always starting with a clear section.
++     * Generally for n clear/encrypted sections there shall be n-1 partition offsets.
++     * However, if it is required that the first section be encrypted, then the first partition shall be at byte offset 0
++     * (indicating a zero-size clear section), and there shall be n partition offsets.
++     * Please refer to the "Sample Encryption" description of the "Common Encryption"
++     * section of the VP Codec ISO Media File Format Binding Specification for more
++     * detail on how subsample encryption is implemented.
++     */
++    subsamples =
++        g_malloc (nb_subsample * (sizeof (guint16) + sizeof (guint32)));
++
++    gst_byte_writer_init_with_data (&writer, subsamples,
++        nb_subsample * (sizeof (guint16) + sizeof (guint32)), FALSE);
++
++    for (i = 0; i <= nb_part; i++) {
++      offset_prev = offset;
++      if (i == nb_part) {
++        offset = gst_byte_reader_get_remaining (&reader);
++      } else {
++        if (!gst_byte_reader_get_uint32_be (&reader, &offset)) {
++          GST_ERROR ("Error reading the partition offset");
++          goto release_err;
++        }
++      }
++
++      if (offset < offset_prev) {
++        GST_ERROR ("Partition offsets should not decrease");
++        goto release_err;
++      }
++
++      if (i % 2 == 0) {
++        if ((offset - offset_prev) & 0xFFFF0000) {
++          GST_ERROR
++              ("The Clear Partition exceed 64KB in encrypted subsample format");
++          goto release_err;
++        }
++        /* We set the Clear partition size in 16 bits, in order to
++         * follow the same format of the box PSSH in CENC spec */
++        clear_bytes = offset - offset_prev;
++        if (i == nb_part)
++          encrypted_bytes = 0;
++      } else {
++        encrypted_bytes = offset - offset_prev;
++      }
++
++      if ((i % 2 == 1) || (i == nb_part)) {
++        if (clear_bytes == 0 && encrypted_bytes == 0) {
++          GST_ERROR ("Found 2 partitions with the same offsets.");
++          goto release_err;
++        }
++        if (!gst_byte_writer_put_uint16_be (&writer, clear_bytes)) {
++          GST_ERROR ("Error writing the number of clear bytes");
++          goto release_err;
++        }
++        if (!gst_byte_writer_put_uint32_be (&writer, encrypted_bytes)) {
++          GST_ERROR ("Error writing the number of encrypted bytes");
++          goto release_err;
++        }
++      }
++    }
++
++    buf_sub_sample =
++        gst_buffer_new_wrapped (subsamples,
++        nb_subsample * (sizeof (guint16) + sizeof (guint32)));
++    gst_structure_set (info_protect, "subsamples", GST_TYPE_BUFFER,
++        buf_sub_sample, NULL);
++    gst_buffer_unref (buf_sub_sample);
++  } else {
++    gst_structure_set (info_protect, "subsample_count", G_TYPE_UINT, 0, NULL);
++  }
++
++  gst_byte_reader_get_data (&reader, 0, (const guint8 **) data_out);
++  *size_out = gst_byte_reader_get_remaining (&reader);
++  return TRUE;
++
++release_err:
++  g_free (subsamples);
++  return FALSE;
++}
++
+ static gint
+ gst_matroska_index_compare (GstMatroskaIndex * i1, GstMatroskaIndex * i2)
+ {
+@@ -2705,9 +2911,11 @@ gst_matroska_read_common_read_track_encoding (GstMatroskaReadCommon * common,
+               G_GUINT64_FORMAT, num);
+           ret = GST_FLOW_ERROR;
+           break;
+-        } else if (num != 0) {
++        }
++
++        if ((!common->is_webm) && (num == GST_MATROSKA_ENCODING_ENCRYPTION)) {
+           GST_ERROR_OBJECT (common->sinkpad,
+-              "Encrypted tracks are not supported yet");
++              "Encrypted tracks are supported only in WebM");
+           ret = GST_FLOW_ERROR;
+           break;
+         }
+@@ -2773,12 +2981,132 @@ gst_matroska_read_common_read_track_encoding (GstMatroskaReadCommon * common,
+         break;
+       }
+ 
+-      case GST_MATROSKA_ID_CONTENTENCRYPTION:
+-        GST_ERROR_OBJECT (common->sinkpad,
+-            "Encrypted tracks not yet supported");
+-        gst_ebml_read_skip (ebml);
+-        ret = GST_FLOW_ERROR;
++      case GST_MATROSKA_ID_CONTENTENCRYPTION:{
++
++        DEBUG_ELEMENT_START (common, ebml, "ContentEncryption");
++
++        if (enc.type != GST_MATROSKA_ENCODING_ENCRYPTION) {
++          GST_WARNING_OBJECT (common->sinkpad,
++              "Unexpected to have Content Encryption because it isn't encryption type");
++          ret = GST_FLOW_ERROR;
++          break;
++        }
++
++        if ((ret = gst_ebml_read_master (ebml, &id)) != GST_FLOW_OK)
++          break;
++
++        while (ret == GST_FLOW_OK &&
++            gst_ebml_read_has_remaining (ebml, 1, TRUE)) {
++          if ((ret = gst_ebml_peek_id (ebml, &id)) != GST_FLOW_OK)
++            break;
++
++          switch (id) {
++            case GST_MATROSKA_ID_CONTENTENCALGO:{
++              guint64 num;
++
++              if ((ret = gst_ebml_read_uint (ebml, &id, &num)) != GST_FLOW_OK) {
++                break;
++              }
++
++              if (num > GST_MATROSKA_TRACK_ENCRYPTION_ALGORITHM_AES) {
++                GST_ERROR_OBJECT (common->sinkpad, "Invalid ContentEncAlgo %"
++                    G_GUINT64_FORMAT, num);
++                ret = GST_FLOW_ERROR;
++                break;
++              }
++              GST_DEBUG_OBJECT (common->sinkpad,
++                  "ContentEncAlgo: %" G_GUINT64_FORMAT, num);
++              enc.enc_algo = num;
++
++              break;
++            }
++            case GST_MATROSKA_ID_CONTENTENCAESSETTINGS:{
++
++              DEBUG_ELEMENT_START (common, ebml, "ContentEncAESSettings");
++
++              if ((ret = gst_ebml_read_master (ebml, &id)) != GST_FLOW_OK)
++                break;
++
++              while (ret == GST_FLOW_OK &&
++                  gst_ebml_read_has_remaining (ebml, 1, TRUE)) {
++                if ((ret = gst_ebml_peek_id (ebml, &id)) != GST_FLOW_OK)
++                  break;
++
++                switch (id) {
++                  case GST_MATROSKA_ID_AESSETTINGSCIPHERMODE:{
++                    guint64 num;
++
++                    if ((ret =
++                            gst_ebml_read_uint (ebml, &id,
++                                &num)) != GST_FLOW_OK) {
++                      break;
++                    }
++                    if (num > 3) {
++                      GST_ERROR_OBJECT (common->sinkpad, "Invalid Cipher Mode %"
++                          G_GUINT64_FORMAT, num);
++                      ret = GST_FLOW_ERROR;
++                      break;
++                    }
++                    GST_DEBUG_OBJECT (common->sinkpad,
++                        "ContentEncAESSettings: %" G_GUINT64_FORMAT, num);
++                    enc.enc_cipher_mode = num;
++                    break;
++                  }
++                  default:
++                    GST_WARNING_OBJECT (common->sinkpad,
++                        "Unknown ContentEncAESSettings subelement 0x%x - ignoring",
++                        id);
++                    ret = gst_ebml_read_skip (ebml);
++                    break;
++                }
++              }
++              DEBUG_ELEMENT_STOP (common, ebml, "ContentEncAESSettings", ret);
++              break;
++            }
++
++            case GST_MATROSKA_ID_CONTENTENCKEYID:{
++              guint8 *data;
++              guint64 size;
++              GstBuffer *keyId_buf;
++              GstEvent *event;
++
++              if ((ret =
++                      gst_ebml_read_binary (ebml, &id, &data,
++                          &size)) != GST_FLOW_OK) {
++                break;
++              }
++              GST_DEBUG_OBJECT (common->sinkpad,
++                  "ContentEncrypt KeyID length : %" G_GUINT64_FORMAT, size);
++              keyId_buf = gst_buffer_new_wrapped (data, size);
++
++              /* Push an event containing the Key ID into the queues of all streams. */
++              /* system_id field is set to GST_PROTECTION_UNSPECIFIED_SYSTEM_ID because it isn't specified neither in WebM nor in Matroska spec. */
++              event =
++                  gst_event_new_protection
++                  (GST_PROTECTION_UNSPECIFIED_SYSTEM_ID, keyId_buf,
++                  "matroskademux");
++              GST_TRACE_OBJECT (common->sinkpad,
++                  "adding protection event for stream %d", context->index);
++              g_queue_push_tail (&context->protection_event_queue, event);
++
++              context->protection_info =
++                  gst_structure_new ("application/x-cenc", "iv_size",
++                  G_TYPE_UINT, 8, "encrypted", G_TYPE_BOOLEAN, TRUE, "kid",
++                  GST_TYPE_BUFFER, keyId_buf, NULL);
++
++              gst_buffer_unref (keyId_buf);
++              break;
++            }
++            default:
++              GST_WARNING_OBJECT (common->sinkpad,
++                  "Unknown ContentEncryption subelement 0x%x - ignoring", id);
++              ret = gst_ebml_read_skip (ebml);
++              break;
++          }
++        }
++        DEBUG_ELEMENT_STOP (common, ebml, "ContentEncryption", ret);
+         break;
++      }
+       default:
+         GST_WARNING_OBJECT (common->sinkpad,
+             "Unknown ContentEncoding subelement 0x%x - ignoring", id);
+diff --git a/gst/matroska/matroska-read-common.h b/gst/matroska/matroska-read-common.h
+index ed01e1fad..1993a7453 100644
+--- a/gst/matroska/matroska-read-common.h
++++ b/gst/matroska/matroska-read-common.h
+@@ -111,6 +111,9 @@ typedef struct _GstMatroskaReadCommon {
+ GstFlowReturn gst_matroska_decode_content_encodings (GArray * encodings);
+ gboolean gst_matroska_decode_data (GArray * encodings, gpointer * data_out,
+     gsize * size_out, GstMatroskaTrackEncodingScope scope, gboolean free);
++gboolean
++gst_matroska_parse_protection_meta (gpointer * data_out, gsize * size_out,
++    GstStructure * info_protect, gboolean * encrypted);
+ gint gst_matroska_index_seek_find (GstMatroskaIndex * i1, GstClockTime * time,
+     gpointer user_data);
+ GstMatroskaIndex * gst_matroska_read_common_do_index_seek (
+-- 
+2.20.1
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good-1.10.4/0017-matroskdemux-do-not-use-MapInfo.data-after-unmapping.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good-1.10.4/0017-matroskdemux-do-not-use-MapInfo.data-after-unmapping.patch
@@ -1,0 +1,108 @@
+From 3cdc6c4fc9e318aa05d83605ef624fea2464fa94 Mon Sep 17 00:00:00 2001
+From: Thibault Saunier <tsaunier@igalia.com>
+Date: Wed, 3 Oct 2018 17:34:49 +0200
+Subject: [PATCH 17/17] matroskdemux: do not use MapInfo.data after unmapping
+
+And minor gst-indenting
+---
+ gst/matroska/matroska-demux.c       | 22 +++++++++++++---------
+ gst/matroska/matroska-read-common.c |  6 ++++++
+ 2 files changed, 19 insertions(+), 9 deletions(-)
+
+diff --git a/gst/matroska/matroska-demux.c b/gst/matroska/matroska-demux.c
+index c298e940c..6972a41af 100644
+--- a/gst/matroska/matroska-demux.c
++++ b/gst/matroska/matroska-demux.c
+@@ -356,10 +356,12 @@ gst_matroska_decode_buffer (GstMatroskaTrackContext * context, GstBuffer * buf)
+ 
+   if (gst_matroska_decode_data (context->encodings, &data, &size,
+           GST_MATROSKA_TRACK_ENCODING_SCOPE_FRAME, FALSE)) {
+-    gst_buffer_unmap (out_buf, &map);
+     if (data != map.data) {
++      gst_buffer_unmap (out_buf, &map);
+       gst_buffer_unref (out_buf);
+       out_buf = gst_buffer_new_wrapped (data, size);
++    } else {
++      gst_buffer_unmap (out_buf, &map);
+     }
+   } else {
+     GST_DEBUG ("decode data failed");
+@@ -379,11 +381,12 @@ gst_matroska_decode_buffer (GstMatroskaTrackContext * context, GstBuffer * buf)
+ 
+     if (gst_matroska_parse_protection_meta (&data, &size, info_protect,
+             &encrypted)) {
+-      gst_buffer_unmap (out_buf, &map);
+       if (data != map.data) {
+-        GstBuffer *tmp_buf = out_buf;
+-        out_buf =
+-            gst_buffer_copy_region (tmp_buf, GST_BUFFER_COPY_ALL,
++        GstBuffer *tmp_buf;
++
++        gst_buffer_unmap (out_buf, &map);
++        tmp_buf = out_buf;
++        out_buf = gst_buffer_copy_region (tmp_buf, GST_BUFFER_COPY_ALL,
+             gst_buffer_get_size (tmp_buf) - size, size);
+         gst_buffer_unref (tmp_buf);
+         if (encrypted)
+@@ -391,6 +394,7 @@ gst_matroska_decode_buffer (GstMatroskaTrackContext * context, GstBuffer * buf)
+         else
+           gst_structure_free (info_protect);
+       } else {
++        gst_buffer_unmap (out_buf, &map);
+         gst_structure_free (info_protect);
+       }
+     } else {
+@@ -2136,10 +2140,10 @@ gst_matroska_demux_handle_seek_event (GstMatroskaDemux * demux,
+    * would be determined again when parsing, but anyway ... */
+   seeksegment.duration = demux->common.segment.duration;
+ 
+-  flush = ! !(flags & GST_SEEK_FLAG_FLUSH);
+-  keyunit = ! !(flags & GST_SEEK_FLAG_KEY_UNIT);
+-  after = ! !(flags & GST_SEEK_FLAG_SNAP_AFTER);
+-  before = ! !(flags & GST_SEEK_FLAG_SNAP_BEFORE);
++  flush = !!(flags & GST_SEEK_FLAG_FLUSH);
++  keyunit = !!(flags & GST_SEEK_FLAG_KEY_UNIT);
++  after = !!(flags & GST_SEEK_FLAG_SNAP_AFTER);
++  before = !!(flags & GST_SEEK_FLAG_SNAP_BEFORE);
+ 
+   /* always do full update if flushing,
+    * otherwise problems might arise downstream with missing keyframes etc */
+diff --git a/gst/matroska/matroska-read-common.c b/gst/matroska/matroska-read-common.c
+index 68462ad52..5083be17d 100644
+--- a/gst/matroska/matroska-read-common.c
++++ b/gst/matroska/matroska-read-common.c
+@@ -2006,6 +2006,8 @@ gst_matroska_read_common_parse_metadata_id_simple_tag (GstMatroskaReadCommon *
+     const gchar *matroska_tagname;
+     const gchar *gstreamer_tagname;
+   }
++
++  /* *INDENT-OFF* */
+   tag_conv[] = {
+     {
+       /* The following list has the _same_ order as the one in Matroska spec. Please, don't mess it up. */
+@@ -2140,11 +2142,14 @@ gst_matroska_read_common_parse_metadata_id_simple_tag (GstMatroskaReadCommon *
+     GST_MATROSKA_TAG_ID_LICENSE, GST_TAG_LICENSE}, {    /* The license applied to the content (like Creative Commons variants). */
+     GST_MATROSKA_TAG_ID_TERMS_OF_USE, GST_TAG_LICENSE}
+   };
++  /* *INDENT-ON* */
+   static const struct
+   {
+     const gchar *matroska_tagname;
+     const gchar *gstreamer_tagname;
+   }
++
++  /* *INDENT-OFF* */
+   child_tag_conv[] = {
+     {
+     "TITLE/SORT_WITH=", GST_TAG_TITLE_SORTNAME}, {
+@@ -2161,6 +2166,7 @@ gst_matroska_read_common_parse_metadata_id_simple_tag (GstMatroskaReadCommon *
+     "LICENSE/URL=", GST_TAG_LICENSE_URI}, {
+     "LICENSE/URL=", GST_TAG_LICENSE_URI}
+   };
++  /* *INDENT-ON* */
+   GstFlowReturn ret;
+   guint32 id;
+   gchar *value = NULL;
+-- 
+2.20.1
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good-1.10.4/0018-matroskademux-Parse-successive-Tracks-elements.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good-1.10.4/0018-matroskademux-Parse-successive-Tracks-elements.patch
@@ -1,0 +1,148 @@
+From d008e2135f8fe4e71730d399733217422abbf0aa Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alicia=20Boya=20Garc=C3=ADa?= <aboya@igalia.com>
+Date: Fri, 21 Sep 2018 20:38:02 +0200
+Subject: [PATCH] matroskademux: Parse successive Tracks elements
+
+This patch allows matroskademux to parse a second Tracks element,
+erroring out if the tracks are not compatible (different number, type or
+codec) and emitting new caps and tag events should they have changed.
+
+https://bugzilla.gnome.org/show_bug.cgi?id=793333
+---
+ gst/matroska/matroska-demux.c | 111 +++++++++++++++++++++++++++++++++-
+ 1 file changed, 109 insertions(+), 2 deletions(-)
+
+diff --git a/gst/matroska/matroska-demux.c b/gst/matroska/matroska-demux.c
+index 0236cb004..005793b8a 100644
+--- a/gst/matroska/matroska-demux.c
++++ b/gst/matroska/matroska-demux.c
+@@ -3136,6 +3136,113 @@ gst_matroska_demux_parse_tracks (GstMatroskaDemux * demux, GstEbmlRead * ebml)
+   return ret;
+ }
+ 
++static GstFlowReturn
++gst_matroska_demux_update_tracks (GstMatroskaDemux * demux, GstEbmlRead * ebml)
++{
++  GstFlowReturn ret = GST_FLOW_OK;
++  guint num_tracks_found = 0;
++  guint32 id;
++
++  GST_INFO_OBJECT (demux, "Reparsing Tracks element");
++
++  DEBUG_ELEMENT_START (demux, ebml, "Tracks");
++
++  if ((ret = gst_ebml_read_master (ebml, &id)) != GST_FLOW_OK) {
++    DEBUG_ELEMENT_STOP (demux, ebml, "Tracks", ret);
++    return ret;
++  }
++
++  while (ret == GST_FLOW_OK && gst_ebml_read_has_remaining (ebml, 1, TRUE)) {
++    if ((ret = gst_ebml_peek_id (ebml, &id)) != GST_FLOW_OK)
++      break;
++
++    switch (id) {
++        /* one track within the "all-tracks" header */
++      case GST_MATROSKA_ID_TRACKENTRY:{
++        GstMatroskaTrackContext *new_track;
++        gint old_track_index;
++        GstMatroskaTrackContext *old_track;
++        ret = gst_matroska_demux_parse_stream (demux, ebml, &new_track);
++        if (new_track == NULL)
++          break;
++        num_tracks_found++;
++
++        if (gst_matroska_read_common_tracknumber_unique (&demux->common,
++                new_track->num)) {
++          GST_ERROR_OBJECT (demux,
++              "Unexpected new TrackNumber: %" G_GUINT64_FORMAT, new_track->num);
++          goto track_mismatch_error;
++        }
++
++        old_track_index =
++            gst_matroska_read_common_stream_from_num (&demux->common,
++            new_track->num);
++        g_assert (old_track_index != -1);
++        old_track = g_ptr_array_index (demux->common.src, old_track_index);
++
++        if (old_track->type != new_track->type) {
++          GST_ERROR_OBJECT (demux,
++              "Mismatch reparsing track %" G_GUINT64_FORMAT
++              " on track type. Expected %d, found %d", new_track->num,
++              old_track->type, new_track->type);
++          goto track_mismatch_error;
++        }
++
++        if (g_strcmp0 (old_track->codec_id, new_track->codec_id) != 0) {
++          GST_ERROR_OBJECT (demux,
++              "Mismatch reparsing track %" G_GUINT64_FORMAT
++              " on codec id. Expected '%s', found '%s'", new_track->num,
++              old_track->codec_id, new_track->codec_id);
++          goto track_mismatch_error;
++        }
++
++        /* The new track matches the old track. No problems on our side.
++         * Let's make it replace the old track. */
++        new_track->pad = old_track->pad;
++        new_track->index = old_track->index;
++        new_track->pos = old_track->pos;
++        g_ptr_array_index (demux->common.src, old_track_index) = new_track;
++        gst_pad_set_element_private (new_track->pad, new_track);
++
++        if (!gst_caps_is_equal (old_track->caps, new_track->caps)) {
++          gst_pad_set_caps (new_track->pad, new_track->caps);
++        }
++
++        if (!gst_tag_list_is_equal (old_track->tags, new_track->tags)) {
++          GST_DEBUG_OBJECT (old_track->pad, "Sending tags %p: %"
++              GST_PTR_FORMAT, new_track->tags, new_track->tags);
++          gst_pad_push_event (new_track->pad,
++              gst_event_new_tag (gst_tag_list_copy (new_track->tags)));
++        }
++
++        gst_matroska_track_free (old_track);
++        break;
++
++      track_mismatch_error:
++        gst_matroska_track_free (new_track);
++        new_track = NULL;
++        ret = GST_FLOW_ERROR;
++        break;
++      }
++
++      default:
++        ret = gst_matroska_read_common_parse_skip (&demux->common, ebml,
++            "Track", id);
++        break;
++    }
++  }
++  DEBUG_ELEMENT_STOP (demux, ebml, "Tracks", ret);
++
++  if (ret != GST_FLOW_ERROR && demux->common.num_streams != num_tracks_found) {
++    GST_ERROR_OBJECT (demux,
++        "Mismatch on the number of tracks. Expected %du tracks, found %du",
++        demux->common.num_streams, num_tracks_found);
++    ret = GST_FLOW_ERROR;
++  }
++
++  return ret;
++}
++
+ /*
+  * Read signed/unsigned "EBML" numbers.
+  * Return: number of bytes processed.
+@@ -5035,11 +5142,11 @@ gst_matroska_demux_parse_id (GstMatroskaDemux * demux, guint32 id,
+           }
+           break;
+         case GST_MATROSKA_ID_TRACKS:
++          GST_READ_CHECK (gst_matroska_demux_take (demux, read, &ebml));
+           if (!demux->tracks_parsed) {
+-            GST_READ_CHECK (gst_matroska_demux_take (demux, read, &ebml));
+             ret = gst_matroska_demux_parse_tracks (demux, &ebml);
+           } else {
+-            GST_READ_CHECK (gst_matroska_demux_flush (demux, read));
++            ret = gst_matroska_demux_update_tracks (demux, &ebml);
+           }
+           break;
+         case GST_MATROSKA_ID_CLUSTER:
+-- 
+2.17.1

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good-1.10.4/0019-matroskademux-Refactor-track-parsing-out-from-adding-tracks.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good-1.10.4/0019-matroskademux-Refactor-track-parsing-out-from-adding-tracks.patch
@@ -1,0 +1,247 @@
+diff --git a/gst/matroska/matroska-demux.c b/gst/matroska/matroska-demux.c
+index 8b2c3d8..761bc24 100644
+--- a/gst/matroska/matroska-demux.c
++++ b/gst/matroska/matroska-demux.c
+@@ -435,21 +435,16 @@ gst_matroska_demux_add_stream_headers_to_caps (GstMatroskaDemux * demux,
+ }
+ 
+ static GstFlowReturn
+-gst_matroska_demux_add_stream (GstMatroskaDemux * demux, GstEbmlRead * ebml)
++gst_matroska_demux_parse_stream (GstMatroskaDemux * demux, GstEbmlRead * ebml,
++    GstMatroskaTrackContext ** dest_context)
+ {
+-  GstElementClass *klass = GST_ELEMENT_GET_CLASS (demux);
+   GstMatroskaTrackContext *context;
+-  GstPadTemplate *templ = NULL;
+-  GstStreamFlags stream_flags;
+   GstCaps *caps = NULL;
+   GstTagList *cached_taglist;
+-  gchar *padname = NULL;
+   GstFlowReturn ret;
+   guint32 id, riff_fourcc = 0;
+   guint16 riff_audio_fmt = 0;
+-  GstEvent *stream_start;
+   gchar *codec = NULL;
+-  gchar *stream_id;
+ 
+   DEBUG_ELEMENT_START (demux, ebml, "TrackEntry");
+ 
+@@ -462,8 +457,6 @@ gst_matroska_demux_add_stream (GstMatroskaDemux * demux, GstEbmlRead * ebml)
+   /* allocate generic... if we know the type, we'll g_renew()
+    * with the precise type */
+   context = g_new0 (GstMatroskaTrackContext, 1);
+-  g_ptr_array_add (demux->common.src, context);
+-  context->index = demux->common.num_streams;
+   context->index_writer_id = -1;
+   context->type = 0;            /* no type yet */
+   context->default_duration = 0;
+@@ -480,12 +473,11 @@ gst_matroska_demux_add_stream (GstMatroskaDemux * demux, GstEbmlRead * ebml)
+   context->dts_only = FALSE;
+   context->intra_only = FALSE;
+   context->tags = gst_tag_list_new_empty ();
+-  demux->common.num_streams++;
+-  g_assert (demux->common.src->len == demux->common.num_streams);
+   g_queue_init (&context->protection_event_queue);
+   context->protection_info = NULL;
+ 
+-  GST_DEBUG_OBJECT (demux, "Stream number %d", context->index);
++  GST_DEBUG_OBJECT (demux, "Parsing a TrackEntry (%d tracks parsed so far)",
++        demux->common.num_streams);
+ 
+   /* try reading the trackentry headers */
+   while (ret == GST_FLOW_OK && gst_ebml_read_has_remaining (ebml, 1, TRUE)) {
+@@ -504,12 +496,6 @@ gst_matroska_demux_add_stream (GstMatroskaDemux * demux, GstEbmlRead * ebml)
+           GST_ERROR_OBJECT (demux, "Invalid TrackNumber 0");
+           ret = GST_FLOW_ERROR;
+           break;
+-        } else if (!gst_matroska_read_common_tracknumber_unique (&demux->common,
+-                num)) {
+-          GST_ERROR_OBJECT (demux, "TrackNumber %" G_GUINT64_FORMAT
+-              " is not unique", num);
+-          ret = GST_FLOW_ERROR;
+-          break;
+         }
+ 
+         GST_DEBUG_OBJECT (demux, "TrackNumber: %" G_GUINT64_FORMAT, num);
+@@ -576,8 +562,6 @@ gst_matroska_demux_add_stream (GstMatroskaDemux * demux, GstEbmlRead * ebml)
+             context->type = 0;
+             break;
+         }
+-        g_ptr_array_index (demux->common.src, demux->common.num_streams - 1)
+-            = context;
+         break;
+       }
+ 
+@@ -596,8 +580,6 @@ gst_matroska_demux_add_stream (GstMatroskaDemux * demux, GstEbmlRead * ebml)
+           break;
+         }
+         videocontext = (GstMatroskaTrackVideoContext *) context;
+-        g_ptr_array_index (demux->common.src, demux->common.num_streams - 1)
+-            = context;
+ 
+         while (ret == GST_FLOW_OK &&
+             gst_ebml_read_has_remaining (ebml, 1, TRUE)) {
+@@ -866,8 +848,6 @@ gst_matroska_demux_add_stream (GstMatroskaDemux * demux, GstEbmlRead * ebml)
+           break;
+ 
+         audiocontext = (GstMatroskaTrackAudioContext *) context;
+-        g_ptr_array_index (demux->common.src, demux->common.num_streams - 1)
+-            = context;
+ 
+         while (ret == GST_FLOW_OK &&
+             gst_ebml_read_has_remaining (ebml, 1, TRUE)) {
+@@ -1196,11 +1176,9 @@ gst_matroska_demux_add_stream (GstMatroskaDemux * demux, GstEbmlRead * ebml)
+     if (ret == GST_FLOW_OK || ret == GST_FLOW_EOS)
+       GST_WARNING_OBJECT (ebml, "Unknown stream/codec in track entry header");
+ 
+-    demux->common.num_streams--;
+-    g_ptr_array_remove_index (demux->common.src, demux->common.num_streams);
+-    g_assert (demux->common.src->len == demux->common.num_streams);
+     gst_matroska_track_free (context);
+-
++    context = NULL;
++    *dest_context = NULL;
+     return ret;
+   }
+ 
+@@ -1211,14 +1189,12 @@ gst_matroska_demux_add_stream (GstMatroskaDemux * demux, GstEbmlRead * ebml)
+   if (cached_taglist)
+     gst_tag_list_insert (context->tags, cached_taglist, GST_TAG_MERGE_APPEND);
+ 
+-  /* now create the GStreamer connectivity */
++  /* compute caps */
+   switch (context->type) {
+     case GST_MATROSKA_TRACK_TYPE_VIDEO:{
+       GstMatroskaTrackVideoContext *videocontext =
+           (GstMatroskaTrackVideoContext *) context;
+ 
+-      padname = g_strdup_printf ("video_%u", demux->num_v_streams++);
+-      templ = gst_element_class_get_pad_template (klass, "video_%u");
+       caps = gst_matroska_demux_video_caps (videocontext,
+           context->codec_id, context->codec_priv,
+           context->codec_priv_size, &codec, &riff_fourcc);
+@@ -1236,8 +1212,6 @@ gst_matroska_demux_add_stream (GstMatroskaDemux * demux, GstEbmlRead * ebml)
+       GstMatroskaTrackAudioContext *audiocontext =
+           (GstMatroskaTrackAudioContext *) context;
+ 
+-      padname = g_strdup_printf ("audio_%u", demux->num_a_streams++);
+-      templ = gst_element_class_get_pad_template (klass, "audio_%u");
+       caps = gst_matroska_demux_audio_caps (audiocontext,
+           context->codec_id, context->codec_priv, context->codec_priv_size,
+           &codec, &riff_audio_fmt);
+@@ -1255,8 +1229,6 @@ gst_matroska_demux_add_stream (GstMatroskaDemux * demux, GstEbmlRead * ebml)
+       GstMatroskaTrackSubtitleContext *subtitlecontext =
+           (GstMatroskaTrackSubtitleContext *) context;
+ 
+-      padname = g_strdup_printf ("subtitle_%u", demux->num_t_streams++);
+-      templ = gst_element_class_get_pad_template (klass, "subtitle_%u");
+       caps = gst_matroska_demux_subtitle_caps (subtitlecontext,
+           context->codec_id, context->codec_priv, context->codec_priv_size);
+       break;
+@@ -1348,9 +1320,60 @@ gst_matroska_demux_add_stream (GstMatroskaDemux * demux, GstEbmlRead * ebml)
+     }
+   }
+ 
++  context->caps = caps;
++
++  /* tadaah! */
++  *dest_context = context;
++  return ret;
++}
++
++static void
++gst_matroska_demux_add_stream (GstMatroskaDemux * demux,
++    GstMatroskaTrackContext * context)
++{
++  GstElementClass *klass = GST_ELEMENT_GET_CLASS (demux);
++  gchar *padname = NULL;
++  GstPadTemplate *templ = NULL;
++  GstStreamFlags stream_flags;
++
++  GstEvent *stream_start;
++
++  gchar *stream_id;
++
++  g_ptr_array_add (demux->common.src, context);
++  context->index = demux->common.num_streams++;
++  g_assert (demux->common.src->len == demux->common.num_streams);
++  g_ptr_array_index (demux->common.src, demux->common.num_streams - 1) =
++      context;
++
++  /* now create the GStreamer connectivity */
++  switch (context->type) {
++    case GST_MATROSKA_TRACK_TYPE_VIDEO:
++      padname = g_strdup_printf ("video_%u", demux->num_v_streams++);
++      templ = gst_element_class_get_pad_template (klass, "video_%u");
++      break;
++
++    case GST_MATROSKA_TRACK_TYPE_AUDIO:
++      padname = g_strdup_printf ("audio_%u", demux->num_a_streams++);
++      templ = gst_element_class_get_pad_template (klass, "audio_%u");
++      break;
++
++    case GST_MATROSKA_TRACK_TYPE_SUBTITLE:
++      padname = g_strdup_printf ("subtitle_%u", demux->num_t_streams++);
++      templ = gst_element_class_get_pad_template (klass, "subtitle_%u");
++      break;
++
++    case GST_MATROSKA_TRACK_TYPE_COMPLEX:
++    case GST_MATROSKA_TRACK_TYPE_LOGO:
++    case GST_MATROSKA_TRACK_TYPE_BUTTONS:
++    case GST_MATROSKA_TRACK_TYPE_CONTROL:
++    default:
++      /* we should already have quit by now */
++      g_assert_not_reached ();
++  }
++
+   /* the pad in here */
+   context->pad = gst_pad_new_from_template (templ, padname);
+-  context->caps = caps;
+ 
+   gst_pad_set_event_function (context->pad,
+       GST_DEBUG_FUNCPTR (gst_matroska_demux_handle_src_event));
+@@ -1358,7 +1381,7 @@ gst_matroska_demux_add_stream (GstMatroskaDemux * demux, GstEbmlRead * ebml)
+       GST_DEBUG_FUNCPTR (gst_matroska_demux_handle_src_query));
+ 
+   GST_INFO_OBJECT (demux, "Adding pad '%s' with caps %" GST_PTR_FORMAT,
+-      padname, caps);
++      padname, context->caps);
+ 
+   gst_pad_set_element_private (context->pad, context);
+ 
+@@ -1423,9 +1446,6 @@ gst_matroska_demux_add_stream (GstMatroskaDemux * demux, GstEbmlRead * ebml)
+   gst_flow_combiner_add_pad (demux->flowcombiner, context->pad);
+ 
+   g_free (padname);
+-
+-  /* tadaah! */
+-  return ret;
+ }
+ 
+ static gboolean
+@@ -2588,9 +2608,23 @@ gst_matroska_demux_parse_tracks (GstMatroskaDemux * demux, GstEbmlRead * ebml)
+ 
+     switch (id) {
+         /* one track within the "all-tracks" header */
+-      case GST_MATROSKA_ID_TRACKENTRY:
+-        ret = gst_matroska_demux_add_stream (demux, ebml);
++      case GST_MATROSKA_ID_TRACKENTRY:{
++        GstMatroskaTrackContext *track;
++        ret = gst_matroska_demux_parse_stream (demux, ebml, &track);
++        if (track != NULL) {
++          if (gst_matroska_read_common_tracknumber_unique (&demux->common,
++                  track->num)) {
++            gst_matroska_demux_add_stream (demux, track);
++          } else {
++            GST_ERROR_OBJECT (demux,
++                "TrackNumber %" G_GUINT64_FORMAT " is not unique", track->num);
++            ret = GST_FLOW_ERROR;
++            gst_matroska_track_free (track);
++            track = NULL;
++          }
++        }
+         break;
++      }
+ 
+       default:
+         ret = gst_matroska_read_common_parse_skip (&demux->common, ebml,

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good.inc
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good.inc
@@ -1,0 +1,57 @@
+require gstreamer1.0-plugins.inc
+
+LICENSE = "GPLv2+ & LGPLv2.1+"
+
+DEPENDS += "gstreamer1.0-plugins-base libcap zlib bzip2"
+
+inherit gettext
+
+PACKAGECONFIG ??= " \
+    ${GSTREAMER_ORC} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'pulseaudio', 'pulseaudio', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'x11', '', d)} \
+    cairo flac gdk-pixbuf gudev jpeg id3demux icydemux libpng matroska soup speex taglib udp v4l2 \
+"
+
+X11DEPENDS = "virtual/libx11 libsm libxrender libxfixes libxdamage"
+
+PACKAGECONFIG[cairo]      = "--enable-cairo,--disable-cairo,cairo"
+PACKAGECONFIG[dv1394]     = "--enable-dv1394,--disable-dv1394,libiec61883 libavc1394 libraw1394"
+PACKAGECONFIG[flac]       = "--enable-flac,--disable-flac,flac"
+PACKAGECONFIG[gdk-pixbuf] = "--enable-gdk_pixbuf,--disable-gdk_pixbuf,gdk-pixbuf"
+PACKAGECONFIG[gudev]      = "--with-gudev,--without-gudev,libgudev"
+PACKAGECONFIG[id3demux]   = "--enable-id3demux,--disable-id3demux,"
+PACKAGECONFIG[icydemux]   = "--enable-icydemux,--disable-icydemux,"
+PACKAGECONFIG[jack]       = "--enable-jack,--disable-jack,jack"
+PACKAGECONFIG[jpeg]       = "--enable-jpeg,--disable-jpeg,jpeg"
+PACKAGECONFIG[libpng]     = "--enable-libpng,--disable-libpng,libpng"
+PACKAGECONFIG[libv4l2]    = "--with-libv4l2,--without-libv4l2,v4l-utils"
+PACKAGECONFIG[matroska]   = "--enable-matroska,--disable-matroska,"
+PACKAGECONFIG[pulseaudio] = "--enable-pulse,--disable-pulse,pulseaudio"
+PACKAGECONFIG[soup]       = "--enable-soup,--disable-soup,libsoup-2.4"
+PACKAGECONFIG[speex]      = "--enable-speex,--disable-speex,speex"
+PACKAGECONFIG[taglib]     = "--enable-taglib,--disable-taglib,taglib"
+PACKAGECONFIG[udp]        = "--enable-udp,--disable-udp"
+PACKAGECONFIG[v4l2]       = "--enable-gst_v4l2 --enable-v4l2-probe,--disable-gst_v4l2"
+PACKAGECONFIG[vpx]        = "--enable-vpx,--disable-vpx,libvpx"
+PACKAGECONFIG[wavpack]    = "--enable-wavpack,--disable-wavpack,wavpack"
+PACKAGECONFIG[x11]        = "--enable-x,--disable-x,${X11DEPENDS}"
+
+EXTRA_OECONF += " \
+    --enable-bz2 \
+    --enable-oss \
+    --enable-zlib \
+    --disable-aalib \
+    --disable-aalibtest \
+    --disable-directsound \
+    --disable-libcaca \
+    --disable-libdv \
+    --disable-oss4 \
+    --disable-osx_audio \
+    --disable-osx_video \
+    --disable-shout2 \
+    --disable-sunaudio \
+    --disable-waveform \
+"
+
+FILES_${PN}-equalizer += "${datadir}/gstreamer-1.0/presets/*.prs"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good.inc
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good.inc
@@ -2,7 +2,7 @@ require gstreamer1.0-plugins.inc
 
 LICENSE = "GPLv2+ & LGPLv2.1+"
 
-DEPENDS += "gstreamer1.0-plugins-base libcap zlib bzip2"
+DEPENDS_append = " gstreamer1.0-plugins-base libcap zlib bzip2"
 
 inherit gettext
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good/0001-gstrtpmp4gpay-set-dafault-value-for-MPEG4-without-co.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good/0001-gstrtpmp4gpay-set-dafault-value-for-MPEG4-without-co.patch
@@ -1,0 +1,62 @@
+From c782a30482908a4b4dd9cd4abff9f9bc4016698f Mon Sep 17 00:00:00 2001
+From: Song Bing <b06498@freescale.com>
+Date: Tue, 5 Aug 2014 14:40:46 +0800
+Subject: [PATCH] gstrtpmp4gpay: set dafault value for MPEG4 without codec
+ data in caps.
+
+https://bugzilla.gnome.org/show_bug.cgi?id=734263
+
+Upstream-Status: Submitted
+
+Signed-off-by: Song Bing <b06498@freescale.com>
+---
+ gst/rtp/gstrtpmp4gpay.c |   19 ++++++++++++++++++-
+ 1 file changed, 18 insertions(+), 1 deletion(-)
+
+diff --git a/gst/rtp/gstrtpmp4gpay.c b/gst/rtp/gstrtpmp4gpay.c
+index 7913d9a..1749d39 100644
+--- a/gst/rtp/gstrtpmp4gpay.c
++++ b/gst/rtp/gstrtpmp4gpay.c
+@@ -391,6 +391,7 @@ gst_rtp_mp4g_pay_setcaps (GstRTPBasePayload * payload, GstCaps * caps)
+   const GValue *codec_data;
+   const gchar *media_type = NULL;
+   gboolean res;
++  const gchar *name;
+ 
+   rtpmp4gpay = GST_RTP_MP4G_PAY (payload);
+ 
+@@ -401,7 +402,6 @@ gst_rtp_mp4g_pay_setcaps (GstRTPBasePayload * payload, GstCaps * caps)
+     GST_LOG_OBJECT (rtpmp4gpay, "got codec_data");
+     if (G_VALUE_TYPE (codec_data) == GST_TYPE_BUFFER) {
+       GstBuffer *buffer;
+-      const gchar *name;
+ 
+       buffer = gst_value_get_buffer (codec_data);
+       GST_LOG_OBJECT (rtpmp4gpay, "configuring codec_data");
+@@ -427,6 +427,23 @@ gst_rtp_mp4g_pay_setcaps (GstRTPBasePayload * payload, GstCaps * caps)
+ 
+       rtpmp4gpay->config = gst_buffer_copy (buffer);
+     }
++  } else {
++    name = gst_structure_get_name (structure);
++
++    if (!strcmp (name, "video/mpeg")) {
++      rtpmp4gpay->profile = g_strdup ("1");
++
++      /* fixed rate */
++      rtpmp4gpay->rate = 90000;
++      /* video stream type */
++      rtpmp4gpay->streamtype = "4";
++      /* no params for video */
++      rtpmp4gpay->params = NULL;
++      /* mode */
++      rtpmp4gpay->mode = "generic";
++
++      media_type = "video";
++    }
+   }
+   if (media_type == NULL)
+     goto config_failed;
+-- 
+1.7.9.5
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good/0001-v4l2object-Also-add-videometa-if-there-is-padding-to.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good/0001-v4l2object-Also-add-videometa-if-there-is-padding-to.patch
@@ -1,0 +1,35 @@
+From 22be02612adc757f6a43cefc6ee65ecaef68f0d9 Mon Sep 17 00:00:00 2001
+From: Carlos Rafael Giani <dv@pseudoterminal.org>
+Date: Thu, 23 Mar 2017 22:13:05 +0100
+Subject: [PATCH] v4l2object: Also add videometa if there is padding to the
+ right and bottom
+
+https://bugzilla.gnome.org/show_bug.cgi?id=780478
+
+Upstream-Status: Backport [1.10.5]
+
+Signed-off-by: Carlos Rafael Giani <dv@pseudoterminal.org>
+---
+ sys/v4l2/gstv4l2object.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/sys/v4l2/gstv4l2object.c b/sys/v4l2/gstv4l2object.c
+index 91c8ff0..ed4654e 100644
+--- a/sys/v4l2/gstv4l2object.c
++++ b/sys/v4l2/gstv4l2object.c
+@@ -3070,9 +3070,10 @@ store_info:
+   GST_DEBUG_OBJECT (v4l2object->element, "Got sizeimage %" G_GSIZE_FORMAT,
+       info->size);
+ 
+-  /* to avoid copies we need video meta if top or left padding */
++  /* to avoid copies we need video meta if there is padding */
+   v4l2object->need_video_meta =
+-      ((align->padding_top + align->padding_left) != 0);
++      ((align->padding_top + align->padding_left + align->padding_right +
++          align->padding_bottom) != 0);
+ 
+   /* ... or if stride is non "standard" */
+   if (!standard_stride)
+-- 
+2.7.4
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good/avoid-including-sys-poll.h-directly.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good/avoid-including-sys-poll.h-directly.patch
@@ -1,0 +1,44 @@
+From 4bfe2c8570a4a7080ec662504882969054d8a072 Mon Sep 17 00:00:00 2001
+From: Andre McCurdy <armccurdy@gmail.com>
+Date: Wed, 3 Feb 2016 18:12:38 -0800
+Subject: [PATCH] avoid including <sys/poll.h> directly
+
+musl libc generates warnings if <sys/poll.h> is included directly.
+
+Upstream-Status: Pending
+
+Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
+---
+ ext/raw1394/gstdv1394src.c  | 2 +-
+ ext/raw1394/gsthdv1394src.c | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/ext/raw1394/gstdv1394src.c b/ext/raw1394/gstdv1394src.c
+index dbc7607..3c42b41 100644
+--- a/ext/raw1394/gstdv1394src.c
++++ b/ext/raw1394/gstdv1394src.c
+@@ -37,7 +37,7 @@
+ #include "config.h"
+ #endif
+ #include <unistd.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ #include <sys/socket.h>
+ #include <errno.h>
+ #include <fcntl.h>
+diff --git a/ext/raw1394/gsthdv1394src.c b/ext/raw1394/gsthdv1394src.c
+index 0b07a37..9785a15 100644
+--- a/ext/raw1394/gsthdv1394src.c
++++ b/ext/raw1394/gsthdv1394src.c
+@@ -36,7 +36,7 @@
+ #include "config.h"
+ #endif
+ #include <unistd.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ #include <sys/socket.h>
+ #include <errno.h>
+ #include <fcntl.h>
+-- 
+1.9.1
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good/ensure-valid-sentinel-for-gst_structure_get.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good/ensure-valid-sentinel-for-gst_structure_get.patch
@@ -1,0 +1,40 @@
+From 2169f2205c0205a220d826d7573e5a863bd36e0a Mon Sep 17 00:00:00 2001
+From: Andre McCurdy <armccurdy@gmail.com>
+Date: Tue, 9 Feb 2016 14:00:00 -0800
+Subject: [PATCH] ensure valid sentinal for gst_structure_get()
+
+gst_structure_get() is declared with G_GNUC_NULL_TERMINATED, ie
+__attribute__((__sentinel__)), which means gcc will generate a
+warning if the last parameter passed to the function is not NULL
+(where a valid NULL in this context is defined as zero with any
+pointer type).
+
+The C code callers to gst_structure_get() within gst-plugins-good
+use the C NULL definition (ie ((void*)0)), which is a valid sentinel.
+
+However gstid3v2mux.cc uses the C++ NULL definition (ie 0L), which
+is not a valid sentinel without an explicit cast to a pointer type.
+
+Upstream-Status: Pending
+
+Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
+---
+ ext/taglib/gstid3v2mux.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ext/taglib/gstid3v2mux.cc b/ext/taglib/gstid3v2mux.cc
+index 8651e77..a87234f 100644
+--- a/ext/taglib/gstid3v2mux.cc
++++ b/ext/taglib/gstid3v2mux.cc
+@@ -465,7 +465,7 @@ add_image_tag (ID3v2::Tag * id3v2tag, const GstTagList * list,
+ 
+           if (info_struct) {
+             if (gst_structure_get (info_struct, "image-type",
+-                    GST_TYPE_TAG_IMAGE_TYPE, &image_type, NULL)) {
++                    GST_TYPE_TAG_IMAGE_TYPE, &image_type, (void *) NULL)) {
+               if (image_type > 0 && image_type <= 18) {
+                 image_type += 2;
+               } else {
+-- 
+1.9.1
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_%.bbappend
@@ -1,4 +1,2 @@
-PACKAGECONFIG[matroska] = "-Dmatroska=enabled,,"
-PACKAGECONFIG_append = " ${@oe.utils.ifelse(d.getVar('DISTRO_CODENAME', True) == 'dunfell', 'matroska', '')}"
-PACKAGECONFIG_append = " mpg123"
+PACKAGECONFIG_append = " matroska mpg123"
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_%.bbappend
@@ -1,3 +1,4 @@
-PACKAGECONFIG_append = " matroska mpg123"
-PACKAGECONFIG[matroska] = "-Dmatroska=enabled,-Dmatroska=disabled,"
+PACKAGECONFIG_dunfell[matroska] = "-Dmatroska=enabled,-Dmatroska=disabled,"
+PACKAGECONFIG_append_dunfell = " matroska"
+PACKAGECONFIG_append = " mpg123"
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_%.bbappend
@@ -1,4 +1,4 @@
-PACKAGECONFIG_dunfell[matroska] = "-Dmatroska=enabled,-Dmatroska=disabled,"
-PACKAGECONFIG_append_dunfell = " matroska"
+PACKAGECONFIG[matroska] = "-Dmatroska=enabled,,"
+PACKAGECONFIG_append = " ${@oe.utils.ifelse(d.getVar('DISTRO_CODENAME', True) == 'dunfell', 'matroska', '')}"
 PACKAGECONFIG_append = " mpg123"
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.10.4.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.10.4.bb
@@ -1,0 +1,35 @@
+require gstreamer1.0-plugins-good.inc
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=a6f89e2100d9b6cdffcea4f398e37343 \
+                    file://common/coverage/coverage-report.pl;beginline=2;endline=17;md5=a4e1830fce078028c8f0974161272607 \
+                    file://gst/replaygain/rganalysis.c;beginline=1;endline=23;md5=b60ebefd5b2f5a8e0cab6bfee391a5fe"
+
+SRC_URI = " \
+    http://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-good-${PV}.tar.xz \
+    file://0001-gstrtpmp4gpay-set-dafault-value-for-MPEG4-without-co.patch \
+    file://avoid-including-sys-poll.h-directly.patch \
+    file://ensure-valid-sentinel-for-gst_structure_get.patch \
+    file://0001-introspection.m4-prefix-pkgconfig-paths-with-PKG_CON.patch \
+    file://0001-v4l2object-Also-add-videometa-if-there-is-padding-to.patch \
+    file://0001-qtdemux-distinguish-TFDT-with-value-0-from-no-TFDT-a.patch \
+    file://0005-souphttpsrc-cookie-jar-and-context-query-support.patch \
+    file://0006-qtdemux-add-context-for-a-preferred-protection.patch \
+    file://0007-qtdemux-dont-check-pushbased-edts.patch \
+    file://0008-qtdemux-also-push-buffers-without-encryption-info-in.patch \
+    file://0009-qtdemux-fix-assert-when-moof-contains-one-sample.patch \
+    file://0010-matroskademux-Allow-Matroska-headers-to-be-read-more.patch \
+    file://0011-matroskademux-Start-stream-time-at-zero.patch \
+    file://0012-matroskademux-emit-no-more-pads-when-the-Tracks-elem.patch \
+    file://0013-qtdemux-Don-t-push-GAP-event-if-first-buffer-is-with.patch \
+    file://0014-qtdemux-default-key-ids.patch \
+    file://0015-qtdemux-Keep-sample-data-from-the-current-fragment-o.patch \
+    file://0016-matroska-Add-the-WebM-encrypted-content-support-in-m.patch \
+    file://0017-matroskdemux-do-not-use-MapInfo.data-after-unmapping.patch \
+    file://0018-matroskademux-Parse-successive-Tracks-elements.patch \
+    file://0019-matroskademux-Refactor-track-parsing-out-from-adding-tracks.patch \
+"
+
+SRC_URI[md5sum] = "cc0cc13cdb07d4237600b6886b81f31d"
+SRC_URI[sha256sum] = "8a86c61434a8c44665365bd0b3557a040937d1f44bf69caee4e9ea816ce74d7e"
+
+S = "${WORKDIR}/gst-plugins-good-${PV}"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.10.4.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.10.4.bb
@@ -1,10 +1,12 @@
 require gstreamer1.0-plugins-good.inc
 
-LIC_FILES_CHKSUM = "file://COPYING;md5=a6f89e2100d9b6cdffcea4f398e37343 \
-                    file://common/coverage/coverage-report.pl;beginline=2;endline=17;md5=a4e1830fce078028c8f0974161272607 \
-                    file://gst/replaygain/rganalysis.c;beginline=1;endline=23;md5=b60ebefd5b2f5a8e0cab6bfee391a5fe"
+LIC_FILES_CHKSUM = "\
+    file://COPYING;md5=a6f89e2100d9b6cdffcea4f398e37343 \
+    file://common/coverage/coverage-report.pl;beginline=2;endline=17;md5=a4e1830fce078028c8f0974161272607 \
+    file://gst/replaygain/rganalysis.c;beginline=1;endline=23;md5=b60ebefd5b2f5a8e0cab6bfee391a5fe \
+"
 
-SRC_URI = " \
+SRC_URI = "\
     http://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-good-${PV}.tar.xz \
     file://0001-gstrtpmp4gpay-set-dafault-value-for-MPEG4-without-co.patch \
     file://avoid-including-sys-poll.h-directly.patch \

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.16.%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.16.%.bbappend
@@ -2,7 +2,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
 
 PACKAGECONFIG_remove = "gtk"
 
-SRC_URI_append = "\
+SRC_URI_append = " \
     file://0001-souphttpsrc-cookie-jar-and-context-query-support.patch \
     file://0002-0007-qtdemux-dont-check-pushbased-edts.patch.patch \
     file://0003-matroskademux-Start-stream-time-at-zero.patch \

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.16.%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.16.%.bbappend
@@ -2,7 +2,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
 
 PACKAGECONFIG_remove = "gtk"
 
-SRC_URI += "\
+SRC_URI_append = "\
     file://0001-souphttpsrc-cookie-jar-and-context-query-support.patch \
     file://0002-0007-qtdemux-dont-check-pushbased-edts.patch.patch \
     file://0003-matroskademux-Start-stream-time-at-zero.patch \

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.16.%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.16.%.bbappend
@@ -14,3 +14,4 @@ SRC_URI += "\
     file://0009-qtdemux-added-support-for-cbcs-encryption-scheme.patch \
 "
 
+PACKAGECONFIG[matroska] = "-Dmatroska=enabled,-Dmatroska=disabled,"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly.inc
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly.inc
@@ -3,7 +3,7 @@ require gstreamer1.0-plugins.inc
 LICENSE = "GPLv2+ & LGPLv2.1+ & LGPLv2+"
 LICENSE_FLAGS = "commercial"
 
-DEPENDS += "gstreamer1.0-plugins-base libid3tag"
+DEPENDS_append = " gstreamer1.0-plugins-base libid3tag"
 
 inherit gettext
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly.inc
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly.inc
@@ -1,0 +1,34 @@
+require gstreamer1.0-plugins.inc
+
+LICENSE = "GPLv2+ & LGPLv2.1+ & LGPLv2+"
+LICENSE_FLAGS = "commercial"
+
+DEPENDS += "gstreamer1.0-plugins-base libid3tag"
+
+inherit gettext
+
+PACKAGECONFIG ??= " \
+    ${GSTREAMER_ORC} \
+    a52dec lame mpg123 mpeg2dec \
+"
+
+PACKAGECONFIG_remove = "a52dec lame mad mpeg2dec"
+
+PACKAGECONFIG[a52dec]   = "--enable-a52dec,--disable-a52dec,liba52"
+PACKAGECONFIG[amrnb]    = "--enable-amrnb,--disable-amrnb,opencore-amr"
+PACKAGECONFIG[amrwb]    = "--enable-amrwb,--disable-amrwb,opencore-amr"
+PACKAGECONFIG[cdio]     = "--enable-cdio,--disable-cdio,libcdio"
+PACKAGECONFIG[dvdread]  = "--enable-dvdread,--disable-dvdread,libdvdread"
+PACKAGECONFIG[lame]     = "--enable-lame,--disable-lame,lame"
+PACKAGECONFIG[mad]      = "--enable-mad,--disable-mad,libmad"
+PACKAGECONFIG[mpeg2dec] = "--enable-mpeg2dec,--disable-mpeg2dec,mpeg2dec"
+PACKAGECONFIG[mpg123]   = "--enable-mpg123,--disable-mpg123,mpg123"
+PACKAGECONFIG[x264]     = "--enable-x264,--disable-x264,x264"
+
+EXTRA_OECONF += " \
+    --disable-sidplay \
+    --disable-twolame \
+"
+
+FILES_${PN}-amrnb += "${datadir}/gstreamer-1.0/presets/GstAmrnbEnc.prs"
+FILES_${PN}-x264 += "${datadir}/gstreamer-1.0/presets/GstX264Enc.prs"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.10.4.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.10.4.bb
@@ -1,0 +1,13 @@
+require gstreamer1.0-plugins-ugly.inc
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=a6f89e2100d9b6cdffcea4f398e37343 \
+                    file://tests/check/elements/xingmux.c;beginline=1;endline=21;md5=4c771b8af188724855cb99cadd390068"
+
+SRC_URI = " \
+    http://gstreamer.freedesktop.org/src/gst-plugins-ugly/gst-plugins-ugly-${PV}.tar.xz \
+    file://0001-introspection.m4-prefix-pkgconfig-paths-with-PKG_CON.patch \
+"
+SRC_URI[md5sum] = "c68d0509c9980b0b70a4b836ff73fff1"
+SRC_URI[sha256sum] = "6386c77ca8459cba431ed0b63da780c7062c7cc48055d222024d8eaf198ffa59"
+
+S = "${WORKDIR}/gst-plugins-ugly-${PV}"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.10.4.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.10.4.bb
@@ -1,9 +1,11 @@
 require gstreamer1.0-plugins-ugly.inc
 
-LIC_FILES_CHKSUM = "file://COPYING;md5=a6f89e2100d9b6cdffcea4f398e37343 \
-                    file://tests/check/elements/xingmux.c;beginline=1;endline=21;md5=4c771b8af188724855cb99cadd390068"
+LIC_FILES_CHKSUM = "\
+    file://COPYING;md5=a6f89e2100d9b6cdffcea4f398e37343 \
+    file://tests/check/elements/xingmux.c;beginline=1;endline=21;md5=4c771b8af188724855cb99cadd390068 \
+"
 
-SRC_URI = " \
+SRC_URI = "\
     http://gstreamer.freedesktop.org/src/gst-plugins-ugly/gst-plugins-ugly-${PV}.tar.xz \
     file://0001-introspection.m4-prefix-pkgconfig-paths-with-PKG_CON.patch \
 "

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins.inc
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins.inc
@@ -1,0 +1,51 @@
+SUMMARY = "Plugins for the GStreamer multimedia framework 1.x"
+HOMEPAGE = "http://gstreamer.freedesktop.org/"
+BUGTRACKER = "https://bugzilla.gnome.org/enter_bug.cgi?product=Gstreamer"
+SECTION = "multimedia"
+
+DEPENDS = "gstreamer1.0 glib-2.0-native"
+
+inherit autotools pkgconfig upstream-version-is-even gobject-introspection gtk-doc
+
+acpaths = "-I ${S}/common/m4 -I ${S}/m4"
+
+LIBV = "1.0"
+require gst-plugins-package.inc
+
+# Orc enables runtime JIT compilation of data processing routines from Orc
+# bytecode to SIMD instructions for various architectures (currently SSE, MMX,
+# MIPS, Altivec and NEON are supported).
+
+GSTREAMER_ORC ?= "orc"
+
+PACKAGECONFIG[debug] = "--enable-debug,--disable-debug"
+PACKAGECONFIG[orc] = "--enable-orc,--disable-orc,orc orc-native"
+PACKAGECONFIG[valgrind] = "--enable-valgrind,--disable-valgrind,valgrind"
+
+export ORCC = "${STAGING_DIR_NATIVE}${bindir}/orcc"
+
+EXTRA_OECONF = " \
+    --disable-examples \
+"
+
+delete_pkg_m4_file() {
+	# This m4 file is out of date and is missing PKG_CONFIG_SYSROOT_PATH tweaks which we need for introspection
+	rm "${S}/common/m4/pkg.m4" || true
+	rm -f "${S}/common/m4/gtk-doc.m4"
+}
+
+# gstreamer is not using system-wide makefiles (which we patch in gtkdoc recipe,
+# but its own custom ones, which we have to patch here
+patch_gtk_doc_makefiles() {
+        # Patch the gtk-doc makefiles so that the qemu wrapper is used to run transient binaries
+        # instead of libtool wrapper or running them directly
+        # Also substitute a bogus plugin scanner, as trying to run the real one is causing issues during build on x86_64.
+        sed -i \
+           -e "s|GTKDOC_RUN =.*|GTKDOC_RUN = \$(top_builddir)/gtkdoc-qemuwrapper|" \
+           -e "s|\$(GTKDOC_EXTRA_ENVIRONMENT)|\$(GTKDOC_EXTRA_ENVIRONMENT) GST_PLUGIN_SCANNER_1_0=\$(top_builddir)/libs/gst/helpers/gst-plugin-scanner-dummy|" \
+           ${S}/common/gtk-doc*mak
+}
+
+do_configure[prefuncs] += " delete_pkg_m4_file patch_gtk_doc_makefiles"
+
+PACKAGES_DYNAMIC = "^${PN}-.*"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins.inc
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins.inc
@@ -1,6 +1,6 @@
 SUMMARY = "Plugins for the GStreamer multimedia framework 1.x"
 DESCRIPTION = "GStreamer is a multimedia framework for encoding and decoding video and sound. \
-It supports a wide range of formats including mp3, ogg, avi, mpeg and quicktime."
+    It supports a wide range of formats including mp3, ogg, avi, mpeg and quicktime."
 HOMEPAGE = "http://gstreamer.freedesktop.org/"
 BUGTRACKER = "https://bugzilla.gnome.org/enter_bug.cgi?product=Gstreamer"
 SECTION = "multimedia"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins.inc
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins.inc
@@ -1,9 +1,11 @@
 SUMMARY = "Plugins for the GStreamer multimedia framework 1.x"
+DESCRIPTION = "GStreamer is a multimedia framework for encoding and decoding video and sound. \
+It supports a wide range of formats including mp3, ogg, avi, mpeg and quicktime."
 HOMEPAGE = "http://gstreamer.freedesktop.org/"
 BUGTRACKER = "https://bugzilla.gnome.org/enter_bug.cgi?product=Gstreamer"
 SECTION = "multimedia"
 
-DEPENDS = "gstreamer1.0 glib-2.0-native"
+DEPENDS_append = " gstreamer1.0 glib-2.0-native"
 
 inherit autotools pkgconfig upstream-version-is-even gobject-introspection gtk-doc
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0.inc
+++ b/recipes-multimedia/gstreamer/gstreamer1.0.inc
@@ -1,0 +1,71 @@
+SUMMARY = "GStreamer 1.0 multimedia framework"
+DESCRIPTION = "GStreamer is a multimedia framework for encoding and decoding video and sound. \
+It supports a wide range of formats including mp3, ogg, avi, mpeg and quicktime."
+HOMEPAGE = "http://gstreamer.freedesktop.org/"
+BUGTRACKER = "https://bugzilla.gnome.org/enter_bug.cgi?product=Gstreamer"
+SECTION = "multimedia"
+LICENSE = "LGPLv2+"
+
+DEPENDS = "glib-2.0 glib-2.0-native libcap libxml2 bison-native flex-native"
+
+inherit autotools pkgconfig gettext upstream-version-is-even gobject-introspection gtk-doc
+
+# This way common/m4/introspection.m4 will come first
+# (it has a custom INTROSPECTION_INIT macro, and so must be used instead of our common introspection.m4 file)
+acpaths = "-I ${S}/common/m4 -I ${S}/m4"
+
+SRC_URI_append = " \
+    file://0001-introspection.m4-prefix-pkgconfig-paths-with-PKG_CON.patch \
+"
+
+PACKAGECONFIG ??= ""
+
+PACKAGECONFIG[debug] = "--enable-debug,--disable-debug"
+PACKAGECONFIG[tests] = "--enable-tests,--disable-tests"
+PACKAGECONFIG[valgrind] = "--enable-valgrind,--disable-valgrind,valgrind,"
+PACKAGECONFIG[gst-tracer-hooks] = "--enable-gst-tracer-hooks,--disable-gst-tracer-hooks,"
+PACKAGECONFIG[unwind] = "--with-unwind,--without-unwind,libunwind"
+
+EXTRA_OECONF = " \
+    --disable-dependency-tracking \
+    --disable-docbook \
+    --disable-examples \
+"
+
+CACHED_CONFIGUREVARS += "ac_cv_header_valgrind_valgrind_h=no"
+
+# musl libc generates warnings if <sys/poll.h> is included directly
+CACHED_CONFIGUREVARS += "ac_cv_header_sys_poll_h=no"
+
+PACKAGES += "${PN}-bash-completion"
+
+FILES_${PN} += "${libdir}/gstreamer-1.0/*.so"
+FILES_${PN}-dev += "${libdir}/gstreamer-1.0/*.la ${libdir}/gstreamer-1.0/*.a ${libdir}/gstreamer-1.0/include"
+FILES_${PN}-bash-completion += "${datadir}/bash-completion/completions/ ${datadir}/bash-completion/helpers/gst*"
+
+RRECOMMENDS_${PN}_qemux86 += "kernel-module-snd-ens1370 kernel-module-snd-rawmidi"
+RRECOMMENDS_${PN}_qemux86-64 += "kernel-module-snd-ens1370 kernel-module-snd-rawmidi"
+
+delete_pkg_m4_file() {
+        # This m4 file is out of date and is missing PKG_CONFIG_SYSROOT_PATH tweaks which we need for introspection
+        rm "${S}/common/m4/pkg.m4" || true
+        rm -f "${S}/common/m4/gtk-doc.m4"
+}
+
+# gstreamer is not using system-wide makefiles (which we patch in gtkdoc recipe,
+# but its own custom ones, which we have to patch here
+patch_gtk_doc_makefiles() {
+        # Patch the gtk-doc makefiles so that the qemu wrapper is used to run transient binaries
+        # instead of libtool wrapper or running them directly
+        # Also substitute a bogus plugin scanner, as trying to run the real one is causing issues during build on x86_64.
+        sed -i \
+           -e "s|GTKDOC_RUN =.*|GTKDOC_RUN = \$(top_builddir)/gtkdoc-qemuwrapper|" \
+           -e "s|\$(GTKDOC_EXTRA_ENVIRONMENT)|\$(GTKDOC_EXTRA_ENVIRONMENT) GST_PLUGIN_SCANNER_1_0=\$(top_builddir)/libs/gst/helpers/gst-plugin-scanner-dummy|" \
+           ${S}/common/gtk-doc*mak
+}
+
+do_configure[prefuncs] += " delete_pkg_m4_file patch_gtk_doc_makefiles"
+
+do_compile_prepend() {
+        export GIR_EXTRA_LIBS_PATH="${B}/gst/.libs:${B}/libs/gst/base/.libs"
+}

--- a/recipes-multimedia/gstreamer/gstreamer1.0/deterministic-unwind.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0/deterministic-unwind.patch
@@ -1,0 +1,24 @@
+Make the detection of libunwind deterministic.
+
+Upstream-Status: Pending
+Signed-off-by: Ross Burton <ross.burton@intel.com>
+
+diff --git a/configure.ac b/configure.ac
+index ac88fb2..182c19a 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -829,3 +828,0 @@ AM_CONDITIONAL(HAVE_GTK, test "x$HAVE_GTK" = "xyes")
+-dnl libunwind is optionally used by the leaks tracer
+-PKG_CHECK_MODULES(UNWIND, libunwind, HAVE_UNWIND=yes, HAVE_UNWIND=no)
+-
+@@ -839,3 +836,7 @@ AC_CHECK_FUNC(backtrace, [
+-if test "x$HAVE_UNWIND" = "xyes"; then
+-  AC_DEFINE(HAVE_UNWIND, 1, [libunwind available])
+-fi
++dnl libunwind is optionally used by the leaks tracer
++AC_ARG_WITH([unwind],[AS_HELP_STRING([--with-unwind],[use libunwind])],
++            [], [with_unwind=yes])
++AS_IF([test "$with_unwind" = yes],
++      [PKG_CHECK_MODULES(UNWIND, libunwind)
++       AC_DEFINE(HAVE_UNWIND, 1, [libunwind available])]
++)

--- a/recipes-multimedia/gstreamer/gstreamer1.0_1.10.4.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0_1.10.4.bb
@@ -1,9 +1,11 @@
 require gstreamer1.0.inc
 
-LIC_FILES_CHKSUM = "file://COPYING;md5=6762ed442b3822387a51c92d928ead0d \
-                    file://gst/gst.h;beginline=1;endline=21;md5=e059138481205ee2c6fc1c079c016d0d"
+LIC_FILES_CHKSUM = "\
+    file://COPYING;md5=6762ed442b3822387a51c92d928ead0d \
+    file://gst/gst.h;beginline=1;endline=21;md5=e059138481205ee2c6fc1c079c016d0d \
+"
 
-SRC_URI = " \
+SRC_URI = "\
     http://gstreamer.freedesktop.org/src/gstreamer/gstreamer-${PV}.tar.xz \
     file://deterministic-unwind.patch \
     file://0001-typefind-min-1k.patch \

--- a/recipes-multimedia/gstreamer/gstreamer1.0_1.10.4.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0_1.10.4.bb
@@ -1,0 +1,18 @@
+require gstreamer1.0.inc
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=6762ed442b3822387a51c92d928ead0d \
+                    file://gst/gst.h;beginline=1;endline=21;md5=e059138481205ee2c6fc1c079c016d0d"
+
+SRC_URI = " \
+    http://gstreamer.freedesktop.org/src/gstreamer/gstreamer-${PV}.tar.xz \
+    file://deterministic-unwind.patch \
+    file://0001-typefind-min-1k.patch \
+    file://0002-small-robustness-fixes.patch \
+    file://0003-protection-added-function-to-filter-system-ids.patch \
+    file://0004-protection-Add-a-new-definition-for-unspecified-syst.patch \
+    file://0005-protection-Fix-the-string-to-define-unspecified-syst.patch \
+"
+SRC_URI[md5sum] = "7c91a97e4a2dc81eafd59d0a2f8b0d6e"
+SRC_URI[sha256sum] = "50c2f5af50a6cc6c0a3f3ed43bdd8b5e2bff00bacfb766d4be139ec06d8b5218"
+
+S = "${WORKDIR}/gstreamer-${PV}"

--- a/recipes-multimedia/gstreamer/gstreamer1.0_1.16.%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0_1.16.%.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
 
-SRC_URI_append = "\
+SRC_URI_append = " \
     file://0001-typefind-min-1k.patch \
     file://0002-Small-robustness-fixes.patch \
 "

--- a/recipes-multimedia/gstreamer/gstreamer1.0_1.16.%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0_1.16.%.bbappend
@@ -1,5 +1,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
 
-SRC_URI += "file://0001-typefind-min-1k.patch \
-    file://0002-Small-robustness-fixes.patch"
+SRC_URI_append = "\
+    file://0001-typefind-min-1k.patch \
+    file://0002-Small-robustness-fixes.patch \
+"
 

--- a/recipes-support/libsoup/libsoup-2.4_%.bbappend
+++ b/recipes-support/libsoup/libsoup-2.4_%.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
-SRC_URI += "file://0001-soup-cookie-jar-add-API-to-set-a-limit-of-cookies-in.patch"
+SRC_URI_append = " file://0001-soup-cookie-jar-add-API-to-set-a-limit-of-cookies-in.patch"
 
 EXTRA_OECONF += "\
     --disable-gtk-doc \

--- a/recipes-support/libsoup/libsoup-2.4_2.58.1.bbappend
+++ b/recipes-support/libsoup/libsoup-2.4_2.58.1.bbappend
@@ -1,2 +1,1 @@
-SRC_URI_remove_dunfell = "file://0001-soup-cookie-jar-add-API-to-set-a-limit-of-cookies-in.patch"
-
+SRC_URI_remove = "${@oe.utils.ifelse(d.getVar('DISTRO_CODENAME', True) == 'dunfell', 'file://0001-soup-cookie-jar-add-API-to-set-a-limit-of-cookies-in.patch', '')}"

--- a/recipes-support/libsoup/libsoup-2.4_2.58.1.bbappend
+++ b/recipes-support/libsoup/libsoup-2.4_2.58.1.bbappend
@@ -1,1 +1,1 @@
-SRC_URI_remove = "${@oe.utils.ifelse(d.getVar('DISTRO_CODENAME', True) == 'dunfell', 'file://0001-soup-cookie-jar-add-API-to-set-a-limit-of-cookies-in.patch', '')}"
+SRC_URI_remove_dunfell = "file://0001-soup-cookie-jar-add-API-to-set-a-limit-of-cookies-in.patch"

--- a/recipes-wpe/wpebackend-mesa/wpebackend-mesa_0.1.bb
+++ b/recipes-wpe/wpebackend-mesa/wpebackend-mesa_0.1.bb
@@ -4,7 +4,7 @@ SECTION = "wpe"
 LICENSE = "BSD-2-Clause"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6ae4db0d4b812334e1539cd5aa6e2f46"
 
-DEPENDS += "wpewebkit glib-2.0 libxkbcommon wayland virtual/libgl"
+DEPENDS_append = " wpewebkit glib-2.0 libxkbcommon wayland virtual/libgl"
 
 SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEBackend-mesa.git"
 SRCREV = "3f9f87d5f42c27a22273d67db072bd7f2cba6135"
@@ -21,10 +21,8 @@ PACKAGECONFIG[experimental-wayland] = "-DWPE_MESA_EXPERIMENTAL_WAYLAND_EGL=ON,-D
 PACKAGECONFIG[tegra] = "-DWPE_MESA_DRM_TEGRA_SUPPORT=ON,-DWPE_MESA_DRM_TEGRA_SUPPORT=OFF,"
 
 do_install() {
-
-	install -d ${D}${libdir}
-	install -m 0755 ${B}/libWPEBackend-*.so ${D}${libdir}/
-
+    install -d "${D}${libdir}"
+    install -m 0755 "${B}"/libWPEBackend-*.so "${D}${libdir}"/
 }
 
 FILES_SOLIBSDEV = ""

--- a/recipes-wpe/wpeframework/include/wpeframework-plugins-rdk.inc
+++ b/recipes-wpe/wpeframework/include/wpeframework-plugins-rdk.inc
@@ -12,7 +12,6 @@ require packager.inc
 require securityagent.inc
 require tracecontrol.inc
 require webkitbrowser.inc
-require wpeframework-plugins.inc
 
 PACKAGECONFIG ??= "\
     ${@bb.utils.contains('DISTRO_FEATURES', 'clearkey', 'opencdmi_ck', '', d)} \

--- a/recipes-wpe/wpeframework/include/wpeframework-plugins.inc
+++ b/recipes-wpe/wpeframework/include/wpeframework-plugins.inc
@@ -1,7 +1,7 @@
 # Common for WPE Framework plugins
 require wpeframework-common.inc
 
-DEPENDS += " wpeframework-clientlibraries"
+DEPENDS_append = " wpeframework-clientlibraries"
 
 FILES_SOLIBSDEV = ""
 FILES_${PN} += "${libdir}/wpeframework/plugins/*.so"

--- a/recipes-wpe/wpeframework/wpeframework-clientlibraries_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-clientlibraries_git.bb
@@ -5,7 +5,7 @@ PR = "r0"
 
 inherit python3native
 require include/wpeframework-common.inc
-DEPENDS += " wpeframework-tools-native wpeframework-interfaces"
+DEPENDS_append = " wpeframework-tools-native wpeframework-interfaces"
 
 SRC_URI = "\
     git://github.com/rdkcentral/ThunderClientLibraries.git;protocol=git;branch=master \

--- a/recipes-wpe/wpeframework/wpeframework-interfaces_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-interfaces_git.bb
@@ -5,7 +5,7 @@ PR = "r0"
 
 inherit python3native
 require include/wpeframework-common.inc
-DEPENDS += " wpeframework-tools-native wpeframework"
+DEPENDS_append = " wpeframework-tools-native wpeframework"
 
 SRC_URI = "git://github.com/rdkcentral/ThunderInterfaces.git;protocol=git;branch=master"
 SRCREV = "1b2cbb8dfa823d29fba254932531c33743f7d358"

--- a/recipes-wpe/wpeframework/wpeframework-ocdm-playready-nexus-svp_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-ocdm-playready-nexus-svp_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=363ee002438e52dac11707343db81c4e"
 
 require include/wpeframework-plugins.inc
 
-DEPENDS += " broadcom-refsw"
+DEPENDS_append = " broadcom-refsw"
 
 SRC_URI = "git://code.rdkcentral.com/r/soc/broadcom/components/rdkcentral/OCDM-Playready-Nexus-SVP.git;protocol=https;branch=master"
 SRCREV = "69cedd51e040c0b592c77de59b4060937099d2f1"

--- a/recipes-wpe/wpeframework/wpeframework-ocdm-playready-nexus_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-ocdm-playready-nexus_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 require include/wpeframework-plugins.inc
 
-DEPENDS += " broadcom-refsw"
+DEPENDS_append = " broadcom-refsw"
 
 SRC_URI = "git://code.rdkcentral.com/r/soc/broadcom/components/rdkcentral/OCDM-Playready-Nexus.git;protocol=https;branch=master"
 SRCREV = "cdb2e784a03b2d01c03a12d008bf1d9e034f7b62"

--- a/recipes-wpe/wpeframework/wpeframework-ocdm-playready_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-ocdm-playready_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=66fe57b27abb01505f399ce4405cfea0"
 
 require include/wpeframework-plugins.inc
 
-DEPENDS += " playready"
+DEPENDS_append = " playready"
 
 SRC_URI = "\
     git://git@github.com/rdkcentral/OCDM-Playready.git;protocol=https;branch=PR2.5 \

--- a/recipes-wpe/wpeframework/wpeframework-ocdm-widevine-nexus-svp_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-ocdm-widevine-nexus-svp_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=feac6454ca1bb4ff09e7bc76d34f57ed"
 
 require include/wpeframework-plugins.inc
 
-DEPENDS += " broadcom-refsw"
+DEPENDS_append = " broadcom-refsw"
 
 SRC_URI = "git://code.rdkcentral.com/r/soc/broadcom/components/rdkcentral/OCDM-Widevine-Nexus-SVP.git;protocol=https;branch=master"
 SRCREV = "fa60a8b37af4da396a8ba108dc4f9f85b6eaf10e"

--- a/recipes-wpe/wpeframework/wpeframework-ocdm-widevine_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-ocdm-widevine_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=1384d4b11dad572771bc2dad384029a6"
 
 require include/wpeframework-plugins.inc
 
-DEPENDS += " widevine"
+DEPENDS_append = " widevine"
 
 SRC_URI = "git://git@github.com/rdkcentral/OCDM-Widevine.git;protocol=https;branch=development/widevine-15.3.0"
 

--- a/recipes-wpe/wpeframework/wpeframework-tools-native_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-tools-native_git.bb
@@ -3,7 +3,7 @@ SUMMARY = "Host/Native tooling for the Web Platform for Embedded Framework"
 require include/wpeframework.inc
 inherit cmake pkgconfig native python3native
 
-DEPENDS += " python3-native python3-jsonref-native"
+DEPENDS_append = " python3-native python3-jsonref-native"
 
 OECMAKE_SOURCEPATH = "${WORKDIR}/git/Tools"
 

--- a/recipes-wpe/wpeframework/wpeframework_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework_git.bb
@@ -3,11 +3,11 @@ SUMMARY = "Web Platform for Embedded Framework"
 require include/wpeframework.inc
 require include/wpeframework-common.inc
 
-DEPENDS += "zlib virtual/egl wpeframework-tools-native"
+DEPENDS_append = " zlib virtual/egl wpeframework-tools-native"
 
 DEPENDS_append_libc-musl = " libexecinfo"
 
-SRC_URI += "\
+SRC_URI_append = "\
     file://wpeframework-init \
     file://wpeframework.service.in \
 "

--- a/recipes-wpe/wpeframework/wpeframework_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework_git.bb
@@ -7,7 +7,7 @@ DEPENDS_append = " zlib virtual/egl wpeframework-tools-native"
 
 DEPENDS_append_libc-musl = " libexecinfo"
 
-SRC_URI_append = "\
+SRC_URI_append = " \
     file://wpeframework-init \
     file://wpeframework.service.in \
 "

--- a/recipes-wpe/wpeframework/wpeframework_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework_git.bb
@@ -91,9 +91,9 @@ WPEFRAMEWORK_EXTERN_EVENTS ??= "\
 "
 
 def getlayerrevision(d):
-    topdir = d.getVar('TOPDIR')
+    topdir = d.getVar('TOPDIR', d, True)
 
-    layers = (d.getVar("BBLAYERS") or "").split()
+    layers = (d.getVar("BBLAYERS", d, True) or "").split()
     for layer in layers:
         my_layer = layer.split('/')[-1]
         if my_layer == 'meta-wpe':

--- a/recipes-wpe/wpewebkit/wpewebkit.inc
+++ b/recipes-wpe/wpewebkit/wpewebkit.inc
@@ -33,9 +33,9 @@ PACKAGECONFIG ?= "\
     ${@bb.utils.contains('DISTRO_FEATURES', 'opencdm', 'opencdm', '', d)} \
     2dcanvas deviceorientation encryptedmedia fullscreenapi fetchapi gamepad indexeddb mediasource mediastatistics notifications nativevideo sampling-profiler subtitle subtlecrypto video webaudio webcrypto gst_gl remote-inspector openjpeg unified-builds service-worker \
     ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'systemd', '' ,d)} \
-    ${@bb.utils.contains('DISTRO_CODENAME', 'dunfell', 'woff2', '' ,d)} \
     ${WPE_PLATFORM} \
 "
+PACKAGECONFIG_append_dunfell = " woff2"
 
 # Mesa only offscreen target support for Westeros backend
 # FIXME Needs to be moved to mesa backend
@@ -142,8 +142,13 @@ INSANE_SKIP_${PN}-web-inspector-plugin = "dev-so"
 FILES_${PN}-qtwpe-qml-plugin += "${libdir}/qt5/qml/org/wpewebkit/qtwpe/*"
 INSANE_SKIP_${PN}-qtwpe-qml-plugin = "dev-so"
 
-GL_DEPENDENCY = " ${@oe.utils.ifelse(d.getVar('DISTRO_CODENAME', True) == 'dunfell', 'gstreamer1.0-plugins-base-opengl', 'gstreamer1.0-plugins-bad-opengl')}"
-MPG_DEPENDENCY = " ${@oe.utils.ifelse(d.getVar('DISTRO_CODENAME', True) == 'dunfell', 'gstreamer1.0-plugins-good-mpg123', 'gstreamer1.0-plugins-ugly-mpg123')}"
+GL_DEPENDENCY ?= "gstreamer1.0-plugins-base-opengl"
+GL_DEPENDENCY_morty = "gstreamer1.0-plugins-bad-opengl"
+GL_DEPENDENCY_dunfell = "gstreamer1.0-plugins-base-opengl"
+
+MPG_DEPENDENCY ?= "gstreamer1.0-plugins-good-mpg123"
+MPG_DEPENDENCY_morty = "gstreamer1.0-plugins-ugly-mpg123"
+MPG_DEPENDENCY_dunfell = "gstreamer1.0-plugins-good-mpg123"
 
 # Extra runtime depends
 RDEPENDS_${PN} += "\

--- a/recipes-wpe/wpewebkit/wpewebkit.inc
+++ b/recipes-wpe/wpewebkit/wpewebkit.inc
@@ -7,7 +7,7 @@ LICENSE = "BSD & LGPLv2+"
 LIC_FILES_CHKSUM = "file://Source/WebCore/LICENSE-LGPL-2.1;md5=a778a33ef338abbaf8b8a7c36b6eec80"
 
 # WPE WebKit Common
-DEPENDS += "\
+DEPENDS_append = "\
     libwpe \
     bison-native ccache-native glib-2.0-native gperf-native libxml2-native ninja-native ruby-native chrpath-replacement-native \
     cairo fontconfig freetype glib-2.0 gnutls harfbuzz icu jpeg pcre sqlite3 zlib \
@@ -33,6 +33,7 @@ PACKAGECONFIG ?= "\
     ${@bb.utils.contains('DISTRO_FEATURES', 'opencdm', 'opencdm', '', d)} \
     2dcanvas deviceorientation encryptedmedia fullscreenapi fetchapi gamepad indexeddb mediasource mediastatistics notifications nativevideo sampling-profiler subtitle subtlecrypto video webaudio webcrypto gst_gl remote-inspector openjpeg unified-builds service-worker \
     ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'systemd', '' ,d)} \
+    ${@bb.utils.contains('DISTRO_CODENAME', 'dunfell', 'woff2', '' ,d)} \
     ${WPE_PLATFORM} \
 "
 

--- a/recipes-wpe/wpewebkit/wpewebkit.inc
+++ b/recipes-wpe/wpewebkit/wpewebkit.inc
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://Source/WebCore/LICENSE-LGPL-2.1;md5=a778a33ef338abbaf
 # WPE WebKit Common
 DEPENDS += "\
     libwpe \
-    bison-native ccache-native glib-2.0-native gperf-native harfbuzz-native libxml2-native ninja-native ruby-native chrpath-replacement-native \
+    bison-native ccache-native glib-2.0-native gperf-native libxml2-native ninja-native ruby-native chrpath-replacement-native \
     cairo fontconfig freetype glib-2.0 gnutls harfbuzz icu jpeg pcre sqlite3 zlib \
     libepoxy libpng libsoup-2.4 libwebp libxml2 libxslt thunder\
     virtual/egl virtual/libgles2 \
@@ -20,8 +20,9 @@ CCACHE_DISABLE[unexport] = "1"
 
 S = "${WORKDIR}/git"
 
-inherit cmake pkgconfig perlnative python3native
-inherit ${@'cmake_qt5' if 'qt5-layer' in d.getVar('BBFILE_COLLECTIONS').split() else ''}
+inherit cmake pkgconfig perlnative
+inherit ${@oe.utils.ifelse(d.getVar('DISTRO_CODENAME', True) == 'morty', 'pythonnative', 'python3native')}
+inherit ${@'cmake_qt5' if 'qt5-layer' in d.getVar('BBFILE_COLLECTIONS', True).split() else ''}
 
 WPE_PLATFORM ?= "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'westeros westeros-sink', 'egl', d)}"
 WPE_PLATFORM ?= "${@bb.utils.contains('virtual/egl', 'broadcom-refsw', 'nexus', 'egl', d)}"
@@ -30,7 +31,7 @@ WPE_PLATFORM ?= "egl"
 
 PACKAGECONFIG ?= "\
     ${@bb.utils.contains('DISTRO_FEATURES', 'opencdm', 'opencdm', '', d)} \
-    2dcanvas deviceorientation encryptedmedia fullscreenapi fetchapi gamepad indexeddb mediasource mediastatistics notifications nativevideo sampling-profiler subtitle subtlecrypto video webaudio webcrypto woff2 gst_gl remote-inspector openjpeg unified-builds service-worker \
+    2dcanvas deviceorientation encryptedmedia fullscreenapi fetchapi gamepad indexeddb mediasource mediastatistics notifications nativevideo sampling-profiler subtitle subtlecrypto video webaudio webcrypto gst_gl remote-inspector openjpeg unified-builds service-worker \
     ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'systemd', '' ,d)} \
     ${WPE_PLATFORM} \
 "
@@ -43,7 +44,7 @@ PACKAGECONFIG[westeros-mesa] = "-DUSE_WPEWEBKIT_BACKEND_WESTEROS_MESA=ON,,"
 PACKAGECONFIG[intelce] = "-DUSE_WPEWEBKIT_PLATFORM_INTEL_CE=ON -DUSE_HOLE_PUNCH_GSTREAMER=ON,,"
 PACKAGECONFIG[nexus] = "-DUSE_WPEWEBKIT_PLATFORM_BCM_NEXUS=ON -DUSE_HOLE_PUNCH_GSTREAMER=ON,,"
 PACKAGECONFIG[qcomdb] = "-DUSE_WPEWEBKIT_PLATFORM_QCOM_DB=ON,,"
-PACKAGECONFIG[egl] = "-DUSE_GSTREAMER_GL=ON,-DUSE_GSTREAMER_GL=OFF,gstreamer1.0-plugins-base"
+PACKAGECONFIG[egl] = "-DUSE_GSTREAMER_GL=ON,-DUSE_GSTREAMER_GL=OFF,gstreamer1.0-plugins-base gstreamer1.0-plugins-bad"
 PACKAGECONFIG[westeros] = "-DUSE_WPEWEBKIT_PLATFORM_WESTEROS=ON,,westeros"
 
 # westeros-sink, override with egl if glimagesink is vsink
@@ -140,12 +141,17 @@ INSANE_SKIP_${PN}-web-inspector-plugin = "dev-so"
 FILES_${PN}-qtwpe-qml-plugin += "${libdir}/qt5/qml/org/wpewebkit/qtwpe/*"
 INSANE_SKIP_${PN}-qtwpe-qml-plugin = "dev-so"
 
+GL_DEPENDENCY = "gstreamer1.0-plugins-bad-opengl"
+GL_DEPENDENCY_dunfell = "gstreamer1.0-plugins-base-opengl"
+
+MPG_DEPENDENCY = "gstreamer1.0-plugins-ugly-mpg123"
+MPG_DEPENDENCY_dunfell = "gstreamer1.0-plugins-good-mpg123"
 # Extra runtime depends
 RDEPENDS_${PN} += "\
     virtual/wpebackend \
     ${@bb.utils.contains('PACKAGECONFIG', 'mediasource', 'gstreamer1.0-plugins-good-isomp4', '', d)} \
     ${@bb.utils.contains('PACKAGECONFIG', 'webaudio', 'gstreamer1.0-plugins-good-wavparse', '', d)} \
-    ${@bb.utils.contains('PACKAGECONFIG', 'gst_gl', 'gstreamer1.0-plugins-base-opengl', '', d)} \
+    ${@bb.utils.contains('PACKAGECONFIG', 'gst_gl', '${GL_DEPENDENCY}', '', d)} \
     ${@bb.utils.contains('PACKAGECONFIG', 'video', 'gstreamer1.0-plugins-base-app \
                                                     gstreamer1.0-plugins-base-playback \
                                                     gstreamer1.0-plugins-base-audioconvert \
@@ -163,7 +169,7 @@ RDEPENDS_${PN} += "\
                                                     gstreamer1.0-plugins-good-deinterlace \
                                                     gstreamer1.0-plugins-good-interleave \
                                                     gstreamer1.0-plugins-good-matroska \
-                                                    gstreamer1.0-plugins-good-mpg123 \
+                                                    ${MPG_DEPENDENCY} \
                                                     gstreamer1.0-plugins-bad-dashdemux \
                                                     gstreamer1.0-plugins-bad-hls \
                                                     gstreamer1.0-plugins-bad-mpegtsdemux \

--- a/recipes-wpe/wpewebkit/wpewebkit.inc
+++ b/recipes-wpe/wpewebkit/wpewebkit.inc
@@ -141,11 +141,9 @@ INSANE_SKIP_${PN}-web-inspector-plugin = "dev-so"
 FILES_${PN}-qtwpe-qml-plugin += "${libdir}/qt5/qml/org/wpewebkit/qtwpe/*"
 INSANE_SKIP_${PN}-qtwpe-qml-plugin = "dev-so"
 
-GL_DEPENDENCY = "gstreamer1.0-plugins-bad-opengl"
-GL_DEPENDENCY_dunfell = "gstreamer1.0-plugins-base-opengl"
+GL_DEPENDENCY = " ${@oe.utils.ifelse(d.getVar('DISTRO_CODENAME', True) == 'dunfell', 'gstreamer1.0-plugins-base-opengl', 'gstreamer1.0-plugins-bad-opengl')}"
+MPG_DEPENDENCY = " ${@oe.utils.ifelse(d.getVar('DISTRO_CODENAME', True) == 'dunfell', 'gstreamer1.0-plugins-good-mpg123', 'gstreamer1.0-plugins-ugly-mpg123')}"
 
-MPG_DEPENDENCY = "gstreamer1.0-plugins-ugly-mpg123"
-MPG_DEPENDENCY_dunfell = "gstreamer1.0-plugins-good-mpg123"
 # Extra runtime depends
 RDEPENDS_${PN} += "\
     virtual/wpebackend \

--- a/recipes-wpe/wpewebkit/wpewebkit_2.22.bb
+++ b/recipes-wpe/wpewebkit/wpewebkit_2.22.bb
@@ -10,7 +10,7 @@ SRC_URI = "\
     file://0001-Fix-for-missing-heap-vm-main.patch \
 "
 
-DEPENDS += "libgcrypt"
+DEPENDS_append = " libgcrypt"
 PACKAGECONFIG_append = " webcrypto"
 
 do_compile() {

--- a/recipes-wpe/wpewebkit/wpewebkit_20170728.bb
+++ b/recipes-wpe/wpewebkit/wpewebkit_20170728.bb
@@ -7,8 +7,10 @@ PR = "r2"
 
 SRCREV ?= "f9402295bed27deb780d38e33c20e397eccb009a"
 SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEWebKit.git;protocol=git;branch=wpe-20170728"
-SRC_URI += "file://0001-Fix-build-with-musl.patch"
-SRC_URI += "file://0002-Define-MESA_EGL_NO_X11_HEADERS-when-not-using-GLX.patch"
+SRC_URI_append = "\
+    file://0001-Fix-build-with-musl.patch \
+    file://0002-Define-MESA_EGL_NO_X11_HEADERS-when-not-using-GLX.patch \
+"
 
 do_compile() {
     ${STAGING_BINDIR_NATIVE}/ninja ${PARALLEL_MAKE} -C ${B} libWPEWebKit.so libWPEWebInspectorResources.so WPEWebProcess WPENetworkProcess WPEStorageProcess WPEWebDriver

--- a/recipes-wpe/wpewebkit/wpewebkit_20170728.bb
+++ b/recipes-wpe/wpewebkit/wpewebkit_20170728.bb
@@ -7,7 +7,7 @@ PR = "r2"
 
 SRCREV ?= "f9402295bed27deb780d38e33c20e397eccb009a"
 SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEWebKit.git;protocol=git;branch=wpe-20170728"
-SRC_URI_append = "\
+SRC_URI_append = " \
     file://0001-Fix-build-with-musl.patch \
     file://0002-Define-MESA_EGL_NO_X11_HEADERS-when-not-using-GLX.patch \
 "


### PR DESCRIPTION
1. bbclass named : bluetooth and features_check added to get these class support in morty version
2. cmake 3.7 recipe added to ensure minimum cmake available in morty is compatible with Thunder requirement
3. opkg patch updated to avoid warning during the time of applying patches
4. lib cobalt recipe updated to apply GCC patches only based on GCC version
5. libepoxy_1.4.0, openjpeg_2.3.1 recipe added to get wpewebkit expecting versions in morty build
6. GStreamer-1.10.4 used to ensure minimum available morty is compatible for wpewebkit requirements
7. WPEWebkit: 
    a. GStreamer OpenGL and MPG123 plugin selection added based on DISTRO_CODENAME to get the selection from corresponding providers
   b. woff2 selection added based on DISTRO_CODENAME
8. d.getVar implicit field added to avoid format check error from Morty version
9. DEPENDS += and SRC_URI+=  changed to _append
10. Some minor formatting changes