### PR TITLE
Fix bad variable pass for python executable

### DIFF
--- a/linter/linter.out
+++ b/linter/linter.out
@@ -30,25 +30,25 @@
 ../recipes-core/packagegroups/packagegroup-wpe-boot.bb:21:error:oelint.vars.specific:'VIRTUAL-RUNTIME' is set specific to ['initscripts'], but isn't known from PACKAGES, MACHINE or resources
 ../recipes-core/packagegroups/packagegroup-wpe-boot.bb:28:warning:oelint.vars.dependsordered:'RDEPENDS_${PN}' entries should be ordered alphabetically
 ../recipes-core/packagegroups/packagegroup-wpe-boot.bb:9:warning:oelint.var.order.inherit:'inherit' should be placed before 'PACKAGE_ARCH'
+../recipes-core/packagegroups/packagegroup-wpeframework.bb:1:error:oelint.file.underscores:Filename should contain at least one '_'  in the end
+../recipes-core/packagegroups/packagegroup-wpeframework.bb:1:error:oelint.var.mandatoryvar.SUMMARY:Variable 'SUMMARY' should be set
 ../recipes-core/packagegroups/packagegroup-wpeframework-plugins-rdk.bb:1:error:oelint.file.underscores:Filename should contain at least one '_'  in the end
 ../recipes-core/packagegroups/packagegroup-wpeframework-plugins-rdk.bb:1:error:oelint.var.mandatoryvar.SUMMARY:Variable 'SUMMARY' should be set
 ../recipes-core/packagegroups/packagegroup-wpeframework-rdkservices.bb:1:error:oelint.file.underscores:Filename should contain at least one '_'  in the end
 ../recipes-core/packagegroups/packagegroup-wpeframework-rdkservices.bb:1:error:oelint.var.mandatoryvar.SUMMARY:Variable 'SUMMARY' should be set
-../recipes-core/packagegroups/packagegroup-wpeframework.bb:1:error:oelint.file.underscores:Filename should contain at least one '_'  in the end
-../recipes-core/packagegroups/packagegroup-wpeframework.bb:1:error:oelint.var.mandatoryvar.SUMMARY:Variable 'SUMMARY' should be set
 ../recipes-core/packagegroups/packagegroup-wpewebkit.bb:1:error:oelint.file.underscores:Filename should contain at least one '_'  in the end
 ../recipes-core/packagegroups/packagegroup-wpewebkit.bb:1:error:oelint.var.mandatoryvar.SUMMARY:Variable 'SUMMARY' should be set
 ../recipes-devtools/cjson/cjson_1.7.13.bb:24:warning:oelint.vars.filessetting.double:${libdir}/cmake is already set by default or in this recipe
-../recipes-devtools/cmake/cmake-native_3.7.2.bb:4:warning:oelint.var.order.DEPENDS:'DEPENDS' should be placed before 'inherit'
-../recipes-devtools/cmake/cmake-native_3.7.2.bb:4:warning:oelint.vars.dependsordered:'DEPENDS' entries should be ordered alphabetically
 ../recipes-devtools/cmake/cmake_3.7.2.bb:12:warning:oelint.task.noanonpython:Avoid anonymous python functions as they expensive and come with all sorts of side effects
 ../recipes-devtools/cmake/cmake_3.7.2.bb:36:error:oelint.task.nomkdir:'mkdir' shall not be used in do_install. Use 'install'
 ../recipes-devtools/cmake/cmake_3.7.2.bb:46:warning:oelint.vars.filessetting.hidden:${datadir}/cmake is already covered by FILES_${PN}-dev
 ../recipes-devtools/cmake/cmake_3.7.2.bb:5:warning:oelint.var.order.DEPENDS:'DEPENDS' should be placed before 'inherit'
 ../recipes-devtools/cmake/cmake_3.7.2.bb:5:warning:oelint.vars.dependsordered:'DEPENDS' entries should be ordered alphabetically
+../recipes-devtools/cmake/cmake-native_3.7.2.bb:4:warning:oelint.var.order.DEPENDS:'DEPENDS' should be placed before 'inherit'
+../recipes-devtools/cmake/cmake-native_3.7.2.bb:4:warning:oelint.vars.dependsordered:'DEPENDS' entries should be ordered alphabetically
+../recipes-devtools/python-jsonref/python3-jsonref_0.2.bb:1:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set
 ../recipes-devtools/python-jsonref/python-jsonref.inc:11:warning:oelint.spaces.lineend:Line shall not end with a space
 ../recipes-devtools/python-jsonref/python-jsonref.inc:1:warning:oelint.vars.summary80chars:'SUMMARY' should not be longer than 80 characters
-../recipes-devtools/python-jsonref/python3-jsonref_0.2.bb:1:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set
 ../recipes-extended/libcobalt/libcobalt_git.bb:12:warning:oelint.var.order.inherit:'inherit' should be placed before 'PACKAGES'
 ../recipes-extended/libcobalt/libcobalt_git.bb:13:error:oelint.vars.dependsappend:DEPENDS should only be appended, not overwritten
 ../recipes-extended/libcobalt/libcobalt_git.bb:13:warning:oelint.var.order.DEPENDS:'DEPENDS' should be placed before 'inherit'
@@ -122,9 +122,19 @@
 ../recipes-graphics/mesa/mesa.inc:37:error:oelint.vars.dependsappend:DEPENDS should only be appended, not overwritten
 ../recipes-graphics/mesa/mesa.inc:37:warning:oelint.var.order.DEPENDS:'DEPENDS' should be placed before 'SRC_URI'
 ../recipes-graphics/mesa/mesa.inc:37:warning:oelint.vars.dependsordered:'DEPENDS' entries should be ordered alphabetically
-../recipes-graphics/mesa/mesa.inc:39:error:oelint.var.override:Variable 'PROVIDES' is set by mesa.inc,mesa-gl_21.0.0.bb
+../recipes-graphics/mesa/mesa.inc:39:error:oelint.var.override:Variable 'PROVIDES' is set by mesa-gl_21.0.0.bb,mesa.inc
 ../recipes-graphics/mesa/mesa.inc:82:warning:oelint.var.order.PACKAGECONFIG:'PACKAGECONFIG' should be placed before 'BBCLASSEXTEND'
 ../recipes-graphics/openjpeg/openjpeg_2.3.1.bb:9:warning:oelint.vars.dependsordered:'DEPENDS' entries should be ordered alphabetically
+../recipes-graphics/westeros/westeros.bb:1:error:oelint.file.underscores:Filename should contain at least one '_'  in the end
+../recipes-graphics/westeros/westeros.bb:1:error:oelint.var.mandatoryvar.HOMEPAGE:Variable 'HOMEPAGE' should be set
+../recipes-graphics/westeros/westeros.bb:30:warning:oelint.var.order.S:'S' should be placed before 'PACKAGECONFIG'
+../recipes-graphics/westeros/westeros.bb:34:warning:oelint.var.order.DEPENDS:'DEPENDS' should be placed before 'S'
+../recipes-graphics/westeros/westeros.bb:42:warning:oelint.var.order.inherit:'inherit' should be placed before 'RDEPENDS_${PN}'
+../recipes-graphics/westeros/westeros.bb:44:error:oelint.var.override:Variable 'SECURITY_CFLAGS' is set by westeros.bb
+../recipes-graphics/westeros/westeros.bb:52:warning:oelint.vars.pathhardcode.libdir:'${libdir}' should be used instead of '/usr/lib'
+../recipes-graphics/westeros/westeros.bb:67:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
+../recipes-graphics/westeros/westeros.inc:10:warning:oelint.var.order.LIC_FILES_CHKSUM:'LIC_FILES_CHKSUM' should be placed before 'SRCREV'
+../recipes-graphics/westeros/westeros.inc:16:warning:oelint.vars.dependsordered:'DEPENDS' entries should be ordered alphabetically
 ../recipes-graphics/westeros/westeros-render-dispmanx.bb:15:error:oelint.var.override:Variable 'SECURITY_CFLAGS' is set by westeros-render-dispmanx.bb
 ../recipes-graphics/westeros/westeros-render-dispmanx.bb:15:warning:oelint.vars.spacesassignment:Suggest spaces around variable assignment. E.g. 'FOO = "BAR"'
 ../recipes-graphics/westeros/westeros-render-dispmanx.bb:16:warning:oelint.vars.spacesassignment:Suggest spaces around variable assignment. E.g. 'FOO = "BAR"'
@@ -140,19 +150,19 @@
 ../recipes-graphics/westeros/westeros-simplebuffer.bb:1:error:oelint.var.mandatoryvar.HOMEPAGE:Variable 'HOMEPAGE' should be set
 ../recipes-graphics/westeros/westeros-simplebuffer.bb:1:warning:oelint.file.requireinclude:Use 'require westeros.inc' instead of 'include westeros.inc'
 ../recipes-graphics/westeros/westeros-simplebuffer.bb:8:warning:oelint.var.order.DEPENDS:'DEPENDS' should be placed before 'S'
-../recipes-graphics/westeros/westeros-simplebuffer.bb:8:warning:oelint.vars.duplicate:Item 'wayland' was added multiple times to DEPENDS
 ../recipes-graphics/westeros/westeros-simplebuffer.bb:8:warning:oelint.vars.duplicate:Item 'wayland-native' was added multiple times to DEPENDS
+../recipes-graphics/westeros/westeros-simplebuffer.bb:8:warning:oelint.vars.duplicate:Item 'wayland' was added multiple times to DEPENDS
 ../recipes-graphics/westeros/westeros-simpleshell.bb:12:error:oelint.var.override:Variable 'SECURITY_CFLAGS' is set by westeros-simpleshell.bb
 ../recipes-graphics/westeros/westeros-simpleshell.bb:1:error:oelint.file.underscores:Filename should contain at least one '_'  in the end
 ../recipes-graphics/westeros/westeros-simpleshell.bb:1:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set
 ../recipes-graphics/westeros/westeros-simpleshell.bb:1:error:oelint.var.mandatoryvar.HOMEPAGE:Variable 'HOMEPAGE' should be set
 ../recipes-graphics/westeros/westeros-simpleshell.bb:1:warning:oelint.file.requireinclude:Use 'require westeros.inc' instead of 'include westeros.inc'
 ../recipes-graphics/westeros/westeros-simpleshell.bb:8:warning:oelint.var.order.DEPENDS:'DEPENDS' should be placed before 'S'
-../recipes-graphics/westeros/westeros-simpleshell.bb:8:warning:oelint.vars.duplicate:Item 'wayland' was added multiple times to DEPENDS
 ../recipes-graphics/westeros/westeros-simpleshell.bb:8:warning:oelint.vars.duplicate:Item 'wayland-native' was added multiple times to DEPENDS
+../recipes-graphics/westeros/westeros-simpleshell.bb:8:warning:oelint.vars.duplicate:Item 'wayland' was added multiple times to DEPENDS
 ../recipes-graphics/westeros/westeros-sink.bb:11:warning:oelint.var.order.DEPENDS:'DEPENDS' should be placed before 'inherit'
-../recipes-graphics/westeros/westeros-sink.bb:11:warning:oelint.vars.duplicate:Item 'wayland' was added multiple times to DEPENDS
 ../recipes-graphics/westeros/westeros-sink.bb:11:warning:oelint.vars.duplicate:Item 'wayland-native' was added multiple times to DEPENDS
+../recipes-graphics/westeros/westeros-sink.bb:11:warning:oelint.vars.duplicate:Item 'wayland' was added multiple times to DEPENDS
 ../recipes-graphics/westeros/westeros-sink.bb:1:error:oelint.file.underscores:Filename should contain at least one '_'  in the end
 ../recipes-graphics/westeros/westeros-sink.bb:1:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set
 ../recipes-graphics/westeros/westeros-sink.bb:1:error:oelint.var.mandatoryvar.HOMEPAGE:Variable 'HOMEPAGE' should be set
@@ -168,24 +178,14 @@
 ../recipes-graphics/westeros/westeros-soc-drm.bb:28:warning:oelint.var.order.inherit:'inherit' should be placed before 'RPROVIDES_${PN}'
 ../recipes-graphics/westeros/westeros-soc-drm.bb:30:warning:oelint.var.filesoverride:'FILES_${PN}' should not be overriden
 ../recipes-graphics/westeros/westeros-soc-drm.bb:3:warning:oelint.vars.summary80chars:'SUMMARY' should not be longer than 80 characters
-../recipes-graphics/westeros/westeros.bb:1:error:oelint.file.underscores:Filename should contain at least one '_'  in the end
-../recipes-graphics/westeros/westeros.bb:1:error:oelint.var.mandatoryvar.HOMEPAGE:Variable 'HOMEPAGE' should be set
-../recipes-graphics/westeros/westeros.bb:30:warning:oelint.var.order.S:'S' should be placed before 'PACKAGECONFIG'
-../recipes-graphics/westeros/westeros.bb:34:warning:oelint.var.order.DEPENDS:'DEPENDS' should be placed before 'S'
-../recipes-graphics/westeros/westeros.bb:42:warning:oelint.var.order.inherit:'inherit' should be placed before 'RDEPENDS_${PN}'
-../recipes-graphics/westeros/westeros.bb:44:error:oelint.var.override:Variable 'SECURITY_CFLAGS' is set by westeros.bb
-../recipes-graphics/westeros/westeros.bb:52:warning:oelint.vars.pathhardcode.libdir:'${libdir}' should be used instead of '/usr/lib'
-../recipes-graphics/westeros/westeros.bb:67:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
-../recipes-graphics/westeros/westeros.inc:10:warning:oelint.var.order.LIC_FILES_CHKSUM:'LIC_FILES_CHKSUM' should be placed before 'SRCREV'
-../recipes-graphics/westeros/westeros.inc:16:warning:oelint.vars.dependsordered:'DEPENDS' entries should be ordered alphabetically
 ../recipes-graphics/woff2/woff2_1.0.2.bb:11:error:oelint.vars.dependsappend:DEPENDS should only be appended, not overwritten
 ../recipes-graphics/woff2/woff2_1.0.2.bb:14:warning:oelint.var.order.SRC_URI:'SRC_URI' should be placed before 'S'
 ../recipes-graphics/woff2/woff2_1.0.2.bb:1:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set
 ../recipes-graphics/woff2/woff2_1.0.2.bb:2:warning:oelint.vars.mispell:'DESCRIPTIOM' is unknown, maybe you mean 'DESCRIPTION'
+../recipes-multimedia/aamp/aampabr_git.bb:21:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
 ../recipes-multimedia/aamp/aamp_git.bb:25:error:oelint.vars.specific:'AAMP_USE_THUNDER_OCDM_API' is set specific to ['0'], but isn't known from PACKAGES, MACHINE or resources
 ../recipes-multimedia/aamp/aamp_git.bb:39:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
 ../recipes-multimedia/aamp/aamp_git.bb:8:warning:oelint.vars.dependsordered:'DEPENDS' entries should be ordered alphabetically
-../recipes-multimedia/aamp/aampabr_git.bb:21:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
 ../recipes-multimedia/aamp/gst-plugins-rdk-aamp_git.bb:21:warning:oelint.var.filesoverride:'FILES_${PN}' should not be overriden
 ../recipes-multimedia/aamp/gst-plugins-rdk-aamp_git.bb:24:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
 ../recipes-multimedia/cenc/gstreamer1.0-plugins-cencdecrypt_git.bb:19:warning:oelint.var.filesoverride:'FILES_${PN}' should not be overriden
@@ -195,6 +195,14 @@
 ../recipes-multimedia/gstreamer/gst-plugins-package.inc:52:warning:oelint.var.filesoverride:'FILES_${PN}' should not be overriden
 ../recipes-multimedia/gstreamer/gst-plugins-package.inc:53:warning:oelint.var.filesoverride:'FILES_${PN}-apps' should not be overriden
 ../recipes-multimedia/gstreamer/gst-plugins-package.inc:54:warning:oelint.var.filesoverride:'FILES_${PN}-glib' should not be overriden
+../recipes-multimedia/gstreamer/gstreamer1.0_1.10.4.bb:17:warning:oelint.vars.srcurifile:First item of SRC_URI should not be a file:// fetcher, if multiple fetcher are used
+../recipes-multimedia/gstreamer/gstreamer1.0.inc:17:warning:oelint.var.order.SRC_URI:'SRC_URI' should be placed before 'inherit'
+../recipes-multimedia/gstreamer/gstreamer1.0.inc:46:error:oelint.vars.specific:'RRECOMMENDS_${PN}' is set specific to ['qemux86'], but isn't known from PACKAGES, MACHINE or resources
+../recipes-multimedia/gstreamer/gstreamer1.0.inc:47:error:oelint.vars.specific:'RRECOMMENDS_${PN}' is set specific to ['qemux86-64'], but isn't known from PACKAGES, MACHINE or resources
+../recipes-multimedia/gstreamer/gstreamer1.0.inc:67:error:oelint.vars.inconspaces:Assignment should be 'VAR += "foo"' not 'VAR += " foo"'
+../recipes-multimedia/gstreamer/gstreamer1.0.inc:9:error:oelint.vars.dependsappend:DEPENDS should only be appended, not overwritten
+../recipes-multimedia/gstreamer/gstreamer1.0.inc:9:warning:oelint.vars.dependsordered:'DEPENDS' entries should be ordered alphabetically
+../recipes-multimedia/gstreamer/gstreamer1.0-omx_1.10.4.bb:1:warning:oelint.file.requireinclude:Use 'require gstreamer1.0-omx.inc' instead of 'include gstreamer1.0-omx.inc'
 ../recipes-multimedia/gstreamer/gstreamer1.0-omx.inc:10:warning:oelint.vars.dependsordered:'DEPENDS' entries should be ordered alphabetically
 ../recipes-multimedia/gstreamer/gstreamer1.0-omx.inc:17:error:oelint.vars.specific:'GSTREAMER_OMX_TARGET' is set specific to ['1'], but isn't known from PACKAGES, MACHINE or resources
 ../recipes-multimedia/gstreamer/gstreamer1.0-omx.inc:18:error:oelint.vars.specific:'GSTREAMER_OMX_CORE_NAME' is set specific to ['1'], but isn't known from PACKAGES, MACHINE or resources
@@ -206,7 +214,7 @@
 ../recipes-multimedia/gstreamer/gstreamer1.0-omx.inc:30:warning:oelint.task.noanonpython:Avoid anonymous python functions as they expensive and come with all sorts of side effects
 ../recipes-multimedia/gstreamer/gstreamer1.0-omx.inc:42:warning:oelint.tabs.notabs:Don't use tabs use spaces
 ../recipes-multimedia/gstreamer/gstreamer1.0-omx.inc:46:error:oelint.vars.inconspaces:Assignment should be 'VAR += "foo"' not 'VAR += " foo"'
-../recipes-multimedia/gstreamer/gstreamer1.0-omx_1.10.4.bb:1:warning:oelint.file.requireinclude:Use 'require gstreamer1.0-omx.inc' instead of 'include gstreamer1.0-omx.inc'
+../recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.10.4.bb:9:warning:oelint.vars.srcurifile:First item of SRC_URI should not be a file:// fetcher, if multiple fetcher are used
 ../recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad.inc:33:warning:oelint.vars.spacesassignment:Suggest spaces around variable assignment. E.g. 'FOO = "BAR"'
 ../recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad.inc:34:warning:oelint.vars.spacesassignment:Suggest spaces around variable assignment. E.g. 'FOO = "BAR"'
 ../recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad.inc:35:warning:oelint.vars.spacesassignment:Suggest spaces around variable assignment. E.g. 'FOO = "BAR"'
@@ -248,10 +256,9 @@
 ../recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad.inc:75:warning:oelint.vars.spacesassignment:Suggest spaces around variable assignment. E.g. 'FOO = "BAR"'
 ../recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad.inc:93:error:oelint.vars.inconspaces:Assignment should be 'VAR += "foo"' not 'VAR += " foo"'
 ../recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad.inc:9:warning:oelint.var.order.SRC_URI:'SRC_URI' should be placed before 'inherit'
-../recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.10.4.bb:9:warning:oelint.vars.srcurifile:First item of SRC_URI should not be a file:// fetcher, if multiple fetcher are used
+../recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.10.4.bb:3:warning:oelint.vars.srcurifile:First item of SRC_URI should not be a file:// fetcher, if multiple fetcher are used
 ../recipes-multimedia/gstreamer/gstreamer1.0-plugins-base.inc:10:warning:oelint.var.order.LICENSE:'LICENSE' should be placed before 'SRC_URI'
 ../recipes-multimedia/gstreamer/gstreamer1.0-plugins-base.inc:41:error:oelint.vars.inconspaces:Assignment should be 'VAR += "foo"' not 'VAR += " foo"'
-../recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.10.4.bb:3:warning:oelint.vars.srcurifile:First item of SRC_URI should not be a file:// fetcher, if multiple fetcher are used
 ../recipes-multimedia/gstreamer/gstreamer1.0-plugins-good.inc:18:warning:oelint.vars.spacesassignment:Suggest spaces around variable assignment. E.g. 'FOO = "BAR"'
 ../recipes-multimedia/gstreamer/gstreamer1.0-plugins-good.inc:19:warning:oelint.vars.spacesassignment:Suggest spaces around variable assignment. E.g. 'FOO = "BAR"'
 ../recipes-multimedia/gstreamer/gstreamer1.0-plugins-good.inc:20:warning:oelint.vars.spacesassignment:Suggest spaces around variable assignment. E.g. 'FOO = "BAR"'
@@ -273,6 +280,8 @@
 ../recipes-multimedia/gstreamer/gstreamer1.0-plugins-good.inc:38:warning:oelint.vars.spacesassignment:Suggest spaces around variable assignment. E.g. 'FOO = "BAR"'
 ../recipes-multimedia/gstreamer/gstreamer1.0-plugins-good.inc:40:error:oelint.vars.inconspaces:Assignment should be 'VAR += "foo"' not 'VAR += " foo"'
 ../recipes-multimedia/gstreamer/gstreamer1.0-plugins-good.inc:5:warning:oelint.vars.dependsordered:'DEPENDS' entries should be ordered alphabetically
+../recipes-multimedia/gstreamer/gstreamer1.0-plugins.inc:33:warning:oelint.tabs.notabs:Don't use tabs use spaces
+../recipes-multimedia/gstreamer/gstreamer1.0-plugins.inc:51:error:oelint.vars.inconspaces:Assignment should be 'VAR += "foo"' not 'VAR += " foo"'
 ../recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly.inc:17:warning:oelint.vars.spacesassignment:Suggest spaces around variable assignment. E.g. 'FOO = "BAR"'
 ../recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly.inc:18:warning:oelint.vars.spacesassignment:Suggest spaces around variable assignment. E.g. 'FOO = "BAR"'
 ../recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly.inc:19:warning:oelint.vars.spacesassignment:Suggest spaces around variable assignment. E.g. 'FOO = "BAR"'
@@ -283,39 +292,30 @@
 ../recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly.inc:25:warning:oelint.vars.spacesassignment:Suggest spaces around variable assignment. E.g. 'FOO = "BAR"'
 ../recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly.inc:26:warning:oelint.vars.spacesassignment:Suggest spaces around variable assignment. E.g. 'FOO = "BAR"'
 ../recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly.inc:28:error:oelint.vars.inconspaces:Assignment should be 'VAR += "foo"' not 'VAR += " foo"'
-../recipes-multimedia/gstreamer/gstreamer1.0-plugins.inc:33:warning:oelint.tabs.notabs:Don't use tabs use spaces
-../recipes-multimedia/gstreamer/gstreamer1.0-plugins.inc:51:error:oelint.vars.inconspaces:Assignment should be 'VAR += "foo"' not 'VAR += " foo"'
-../recipes-multimedia/gstreamer/gstreamer1.0.inc:17:warning:oelint.var.order.SRC_URI:'SRC_URI' should be placed before 'inherit'
-../recipes-multimedia/gstreamer/gstreamer1.0.inc:46:error:oelint.vars.specific:'RRECOMMENDS_${PN}' is set specific to ['qemux86'], but isn't known from PACKAGES, MACHINE or resources
-../recipes-multimedia/gstreamer/gstreamer1.0.inc:47:error:oelint.vars.specific:'RRECOMMENDS_${PN}' is set specific to ['qemux86-64'], but isn't known from PACKAGES, MACHINE or resources
-../recipes-multimedia/gstreamer/gstreamer1.0.inc:67:error:oelint.vars.inconspaces:Assignment should be 'VAR += "foo"' not 'VAR += " foo"'
-../recipes-multimedia/gstreamer/gstreamer1.0.inc:9:error:oelint.vars.dependsappend:DEPENDS should only be appended, not overwritten
-../recipes-multimedia/gstreamer/gstreamer1.0.inc:9:warning:oelint.vars.dependsordered:'DEPENDS' entries should be ordered alphabetically
-../recipes-multimedia/gstreamer/gstreamer1.0_1.10.4.bb:17:warning:oelint.vars.srcurifile:First item of SRC_URI should not be a file:// fetcher, if multiple fetcher are used
 ../recipes-multimedia/libdash/libdash_3.0.bb:32:warning:oelint.tabs.notabs:Don't use tabs use spaces
 ../recipes-multimedia/libdash/libdash_3.0.bb:55:warning:oelint.var.order.PACKAGES:'PACKAGES' should be placed before 'FILES_${PN}'
 ../recipes-multimedia/libdash/libdash_3.0.bb:57:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
 ../recipes-multimedia/libdash/libdash_3.0.bb:6:error:oelint.var.override:Variable 'LICENSE' is set by libdash_3.0.bb
 ../recipes-multimedia/libdash/libdash_3.0.bb:7:warning:oelint.var.order.SECTION:'SECTION' should be placed before 'LICENSE'
+../recipes-support/icu/icu_65.1.bb:21:warning:oelint.tabs.notabs:Don't use tabs use spaces
+../recipes-support/icu/icu_65.1.bb:31:error:oelint.vars.inconspaces:Assignment should be 'VAR_append = " foo"' not 'VAR_append = "foo"'
+../recipes-support/icu/icu_65.1.bb:31:error:oelint.vars.listappend:Append to list should end with a blank
 ../recipes-support/icu/icu.inc:10:error:oelint.vars.dependsappend:DEPENDS should only be appended, not overwritten
 ../recipes-support/icu/icu.inc:38:warning:oelint.tabs.notabs:Don't use tabs use spaces
 ../recipes-support/icu/icu.inc:48:warning:oelint.tabs.notabs:Don't use tabs use spaces
 ../recipes-support/icu/icu.inc:57:warning:oelint.tabs.notabs:Don't use tabs use spaces
 ../recipes-support/icu/icu.inc:9:error:oelint.vars.dependsappend:DEPENDS should only be appended, not overwritten
-../recipes-support/icu/icu_65.1.bb:21:warning:oelint.tabs.notabs:Don't use tabs use spaces
-../recipes-support/icu/icu_65.1.bb:31:error:oelint.vars.inconspaces:Assignment should be 'VAR_append = " foo"' not 'VAR_append = "foo"'
-../recipes-support/icu/icu_65.1.bb:31:error:oelint.vars.listappend:Append to list should end with a blank
 ../recipes-support/rdksplash/rdk-splash-ui_git.bb:12:warning:oelint.vars.pathhardcode.localstatedir:'${localstatedir}' should be used instead of '/var'
 ../recipes-support/rdksplash/rdk-splash-ui_git.bb:1:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set
 ../recipes-support/rdksplash/rdk-splash-ui_git.bb:1:error:oelint.var.mandatoryvar.HOMEPAGE:Variable 'HOMEPAGE' should be set
-../recipes-wpe/libwpe/libwpe.inc:10:warning:oelint.var.order.inherit:'inherit' should be placed before 'RPROVIDES_${PN}'
-../recipes-wpe/libwpe/libwpe.inc:1:warning:oelint.vars.summary80chars:'SUMMARY' should not be longer than 80 characters
-../recipes-wpe/libwpe/libwpe.inc:5:error:oelint.vars.dependsappend:DEPENDS should only be appended, not overwritten
-../recipes-wpe/libwpe/libwpe.inc:5:warning:oelint.vars.dependsordered:'DEPENDS' entries should be ordered alphabetically
 ../recipes-wpe/libwpe/libwpe_1.0.0.bb:1:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set
 ../recipes-wpe/libwpe/libwpe_1.0.0.bb:5:warning:oelint.var.order.LICENSE:'LICENSE' should be placed before 'S'
 ../recipes-wpe/libwpe/libwpe_1.6.0.bb:1:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set
 ../recipes-wpe/libwpe/libwpe_1.8.0.bb:1:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set
+../recipes-wpe/libwpe/libwpe.inc:10:warning:oelint.var.order.inherit:'inherit' should be placed before 'RPROVIDES_${PN}'
+../recipes-wpe/libwpe/libwpe.inc:1:warning:oelint.vars.summary80chars:'SUMMARY' should not be longer than 80 characters
+../recipes-wpe/libwpe/libwpe.inc:5:error:oelint.vars.dependsappend:DEPENDS should only be appended, not overwritten
+../recipes-wpe/libwpe/libwpe.inc:5:warning:oelint.vars.dependsordered:'DEPENDS' entries should be ordered alphabetically
 ../recipes-wpe/wpebackend-fdo/wpebackend-fdo_git.bb:11:warning:oelint.var.order.PV:'PV' should be placed before 'inherit'
 ../recipes-wpe/wpebackend-fdo/wpebackend-fdo_git.bb:16:warning:oelint.newline.consecutive:Consecutive blank lines should be avoided
 ../recipes-wpe/wpebackend-fdo/wpebackend-fdo_git.bb:1:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set
@@ -362,20 +362,20 @@
 ../recipes-wpe/wpeframework/include/wpeframework-common.inc:2:error:oelint.var.override:Variable 'HOMEPAGE' is set by wpeframework.inc,wpeframework-common.inc
 ../recipes-wpe/wpeframework/include/wpeframework-common.inc:5:error:oelint.var.override:Variable 'S' is set by wpeframework.inc,wpeframework-common.inc
 ../recipes-wpe/wpeframework/include/wpeframework-common.inc:6:error:oelint.var.override:Variable 'PV' is set by wpeframework-common.inc,wpeframework-ocdm-playready_2.5+git.bb
-../recipes-wpe/wpeframework/include/wpeframework-common.inc:6:error:oelint.var.override:Variable 'PV' is set by wpeframework-common.inc,wpeframework-ocdm-playready_4.0+git.bb
 ../recipes-wpe/wpeframework/include/wpeframework-common.inc:6:error:oelint.var.override:Variable 'PV' is set by wpeframework.inc,wpeframework-common.inc
+../recipes-wpe/wpeframework/include/wpeframework-common.inc:6:error:oelint.var.override:Variable 'PV' is set by wpeframework-ocdm-playready_4.0+git.bb,wpeframework-common.inc
 ../recipes-wpe/wpeframework/include/wpeframework-common.inc:6:warning:oelint.var.order.PV:'PV' should be placed before 'S'
+../recipes-wpe/wpeframework/include/wpeframework.inc:13:warning:oelint.var.order.PV:'PV' should be placed before 'SRCREV'
+../recipes-wpe/wpeframework/include/wpeframework.inc:2:error:oelint.var.override:Variable 'SECTION' is set by wpeframework.inc,wpeframework-common.inc
+../recipes-wpe/wpeframework/include/wpeframework.inc:5:warning:oelint.var.order.HOMEPAGE:'HOMEPAGE' should be placed before 'LIC_FILES_CHKSUM'
 ../recipes-wpe/wpeframework/include/wpeframework-ocdm-playready.inc:13:warning:oelint.var.filesoverride:'FILES_${PN}' should not be overriden
+../recipes-wpe/wpeframework/include/wpeframework-plugins.inc:6:error:oelint.var.override:Variable 'FILES_SOLIBSDEV' is set by wpeframework-plugins.inc,wpeframework-plugins_git.bb
+../recipes-wpe/wpeframework/include/wpeframework-plugins.inc:6:error:oelint.var.override:Variable 'FILES_SOLIBSDEV' is set by wpeframework-plugins.inc,wpeframework-plugins-rdk.inc
+../recipes-wpe/wpeframework/include/wpeframework-plugins.inc:7:warning:oelint.vars.filessetting.double:${libdir}/wpeframework/plugins/*.so is already set by default or in this recipe
 ../recipes-wpe/wpeframework/include/wpeframework-plugins-rdk.inc:31:error:oelint.vars.inconspaces:Assignment should be 'VAR_append = " foo"' not 'VAR_append = "foo"'
 ../recipes-wpe/wpeframework/include/wpeframework-plugins-rdk.inc:42:warning:oelint.vars.filessetting.double:${libdir}/wpeframework/plugins/*.so is already set by default or in this recipe
 ../recipes-wpe/wpeframework/include/wpeframework-plugins-rdk.inc:45:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
 ../recipes-wpe/wpeframework/include/wpeframework-plugins-rdk.inc:46:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
-../recipes-wpe/wpeframework/include/wpeframework-plugins.inc:6:error:oelint.var.override:Variable 'FILES_SOLIBSDEV' is set by wpeframework-plugins.inc,wpeframework-plugins-rdk.inc
-../recipes-wpe/wpeframework/include/wpeframework-plugins.inc:6:error:oelint.var.override:Variable 'FILES_SOLIBSDEV' is set by wpeframework-plugins.inc,wpeframework-plugins_git.bb
-../recipes-wpe/wpeframework/include/wpeframework-plugins.inc:7:warning:oelint.vars.filessetting.double:${libdir}/wpeframework/plugins/*.so is already set by default or in this recipe
-../recipes-wpe/wpeframework/include/wpeframework.inc:13:warning:oelint.var.order.PV:'PV' should be placed before 'SRCREV'
-../recipes-wpe/wpeframework/include/wpeframework.inc:2:error:oelint.var.override:Variable 'SECTION' is set by wpeframework.inc,wpeframework-common.inc
-../recipes-wpe/wpeframework/include/wpeframework.inc:5:warning:oelint.var.order.HOMEPAGE:'HOMEPAGE' should be placed before 'LIC_FILES_CHKSUM'
 ../recipes-wpe/wpeframework/wpeframework-clientlibraries_git.bb:17:warning:oelint.file.requireinclude:Use 'require include/compositor.inc' instead of 'include include/compositor.inc'
 ../recipes-wpe/wpeframework/wpeframework-clientlibraries_git.bb:1:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set
 ../recipes-wpe/wpeframework/wpeframework-clientlibraries_git.bb:51:error:oelint.vars.valuequoted:Variable value should be quoted
@@ -383,6 +383,13 @@
 ../recipes-wpe/wpeframework/wpeframework-clientlibraries_git.bb:64:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
 ../recipes-wpe/wpeframework/wpeframework-clientlibraries_git.bb:8:warning:oelint.var.order.DEPENDS:'DEPENDS' should be placed before 'inherit'
 ../recipes-wpe/wpeframework/wpeframework-clientlibraries_git.bb:8:warning:oelint.vars.dependsordered:'DEPENDS' entries should be ordered alphabetically
+../recipes-wpe/wpeframework/wpeframework_git.bb:145:warning:oelint.var.filesoverride:'FILES_${PN}-initscript' should not be overriden
+../recipes-wpe/wpeframework/wpeframework_git.bb:158:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
+../recipes-wpe/wpeframework/wpeframework_git.bb:159:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
+../recipes-wpe/wpeframework/wpeframework_git.bb:17:warning:oelint.var.order.PROVIDES:'PROVIDES' should be placed before 'inherit'
+../recipes-wpe/wpeframework/wpeframework_git.bb:1:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set
+../recipes-wpe/wpeframework/wpeframework_git.bb:22:warning:oelint.var.order.PACKAGECONFIG:'PACKAGECONFIG' should be placed before 'RPROVIDES_${PN}'
+../recipes-wpe/wpeframework/wpeframework_git.bb:6:warning:oelint.vars.dependsordered:'DEPENDS' entries should be ordered alphabetically
 ../recipes-wpe/wpeframework/wpeframework-interfaces_git.bb:1:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set
 ../recipes-wpe/wpeframework/wpeframework-interfaces_git.bb:31:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
 ../recipes-wpe/wpeframework/wpeframework-interfaces_git.bb:32:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
@@ -390,10 +397,6 @@
 ../recipes-wpe/wpeframework/wpeframework-interfaces_git.bb:8:warning:oelint.vars.dependsordered:'DEPENDS' entries should be ordered alphabetically
 ../recipes-wpe/wpeframework/wpeframework-ocdm-clearkey_git.bb:10:warning:oelint.var.filesoverride:'FILES_${PN}' should not be overriden
 ../recipes-wpe/wpeframework/wpeframework-ocdm-clearkey_git.bb:1:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set
-../recipes-wpe/wpeframework/wpeframework-ocdm-playready-nexus-svp_git.bb:12:warning:oelint.var.filesoverride:'FILES_${PN}' should not be overriden
-../recipes-wpe/wpeframework/wpeframework-ocdm-playready-nexus-svp_git.bb:1:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set
-../recipes-wpe/wpeframework/wpeframework-ocdm-playready-nexus_git.bb:12:warning:oelint.var.filesoverride:'FILES_${PN}' should not be overriden
-../recipes-wpe/wpeframework/wpeframework-ocdm-playready-nexus_git.bb:1:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set
 ../recipes-wpe/wpeframework/wpeframework-ocdm-playready_2.5+git.bb:8:warning:oelint.var.order.PV:'PV' should be placed before 'SRCREV'
 ../recipes-wpe/wpeframework/wpeframework-ocdm-playready_4.0+git.bb:3:error:oelint.vars.inconspaces:Assignment should be 'VAR_append = " foo"' not 'VAR_append = "foo"'
 ../recipes-wpe/wpeframework/wpeframework-ocdm-playready_4.0+git.bb:3:error:oelint.vars.listappend:Append to list should end with a blank
@@ -402,14 +405,17 @@
 ../recipes-wpe/wpeframework/wpeframework-ocdm-playready_4.0+git.bb:9:error:oelint.vars.inconspaces:Assignment should be 'VAR += "foo"' not 'VAR += " foo"'
 ../recipes-wpe/wpeframework/wpeframework-ocdm-playready_git.bb:19:warning:oelint.var.filesoverride:'FILES_${PN}' should not be overriden
 ../recipes-wpe/wpeframework/wpeframework-ocdm-playready_git.bb:1:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set
-../recipes-wpe/wpeframework/wpeframework-ocdm-widevine-nexus-svp_git.bb:12:warning:oelint.var.filesoverride:'FILES_${PN}' should not be overriden
-../recipes-wpe/wpeframework/wpeframework-ocdm-widevine-nexus-svp_git.bb:1:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set
+../recipes-wpe/wpeframework/wpeframework-ocdm-playready-nexus_git.bb:12:warning:oelint.var.filesoverride:'FILES_${PN}' should not be overriden
+../recipes-wpe/wpeframework/wpeframework-ocdm-playready-nexus_git.bb:1:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set
+../recipes-wpe/wpeframework/wpeframework-ocdm-playready-nexus-svp_git.bb:12:warning:oelint.var.filesoverride:'FILES_${PN}' should not be overriden
+../recipes-wpe/wpeframework/wpeframework-ocdm-playready-nexus-svp_git.bb:1:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set
 ../recipes-wpe/wpeframework/wpeframework-ocdm-widevine_git.bb:13:warning:oelint.var.filesoverride:'FILES_${PN}' should not be overriden
 ../recipes-wpe/wpeframework/wpeframework-ocdm-widevine_git.bb:1:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set
+../recipes-wpe/wpeframework/wpeframework-ocdm-widevine-nexus-svp_git.bb:12:warning:oelint.var.filesoverride:'FILES_${PN}' should not be overriden
+../recipes-wpe/wpeframework/wpeframework-ocdm-widevine-nexus-svp_git.bb:1:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set
 ../recipes-wpe/wpeframework/wpeframework-plugin-launcher_git.bb:10:warning:oelint.newline.consecutive:Consecutive blank lines should be avoided
 ../recipes-wpe/wpeframework/wpeframework-plugin-launcher_git.bb:1:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set
 ../recipes-wpe/wpeframework/wpeframework-plugin-launcher_git.bb:1:warning:oelint.vars.summary80chars:'SUMMARY' should not be longer than 80 characters
-../recipes-wpe/wpeframework/wpeframework-plugins-rdk_git.bb:1:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set
 ../recipes-wpe/wpeframework/wpeframework-plugins_git.bb:19:warning:oelint.file.requireinclude:Use 'require include/bluetooth.inc' instead of 'include include/bluetooth.inc'
 ../recipes-wpe/wpeframework/wpeframework-plugins_git.bb:1:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set
 ../recipes-wpe/wpeframework/wpeframework-plugins_git.bb:20:warning:oelint.file.requireinclude:Use 'require include/cobalt.inc' instead of 'include include/cobalt.inc'
@@ -447,19 +453,27 @@
 ../recipes-wpe/wpeframework/wpeframework-plugins_git.bb:80:warning:oelint.vars.filessetting.double:${libdir}/wpeframework/plugins/*.so is already set by default or in this recipe
 ../recipes-wpe/wpeframework/wpeframework-plugins_git.bb:84:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
 ../recipes-wpe/wpeframework/wpeframework-plugins_git.bb:85:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
+../recipes-wpe/wpeframework/wpeframework-plugins-rdk_git.bb:1:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set
 ../recipes-wpe/wpeframework/wpeframework-rdkservices_git.bb:1:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set
 ../recipes-wpe/wpeframework/wpeframework-tools-native_git.bb:1:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set
 ../recipes-wpe/wpeframework/wpeframework-tools-native_git.bb:6:warning:oelint.var.order.DEPENDS:'DEPENDS' should be placed before 'inherit'
 ../recipes-wpe/wpeframework/wpeframework-tools-native_git.bb:6:warning:oelint.vars.dependsordered:'DEPENDS' entries should be ordered alphabetically
 ../recipes-wpe/wpeframework/wpeframework-ui_git.bb:13:error:oelint.task.nomkdir:'mkdir' shall not be used in do_install. Use 'install'
 ../recipes-wpe/wpeframework/wpeframework-ui_git.bb:1:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set
-../recipes-wpe/wpeframework/wpeframework_git.bb:145:warning:oelint.var.filesoverride:'FILES_${PN}-initscript' should not be overriden
-../recipes-wpe/wpeframework/wpeframework_git.bb:158:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
-../recipes-wpe/wpeframework/wpeframework_git.bb:159:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
-../recipes-wpe/wpeframework/wpeframework_git.bb:17:warning:oelint.var.order.PROVIDES:'PROVIDES' should be placed before 'inherit'
-../recipes-wpe/wpeframework/wpeframework_git.bb:1:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set
-../recipes-wpe/wpeframework/wpeframework_git.bb:22:warning:oelint.var.order.PACKAGECONFIG:'PACKAGECONFIG' should be placed before 'RPROVIDES_${PN}'
-../recipes-wpe/wpeframework/wpeframework_git.bb:6:warning:oelint.vars.dependsordered:'DEPENDS' entries should be ordered alphabetically
+../recipes-wpe/wpewebkit/wpewebkit_20170728.bb:1:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set
+../recipes-wpe/wpewebkit/wpewebkit_20170728.bb:24:error:oelint.task.nocopy:'cp' shall not be used in do_install. Use 'install'
+../recipes-wpe/wpewebkit/wpewebkit_20170728.bb:9:warning:oelint.var.order.SRC_URI:'SRC_URI' should be placed before 'SRCREV'
+../recipes-wpe/wpewebkit/wpewebkit_2.22.bb:13:warning:oelint.var.order.DEPENDS:'DEPENDS' should be placed before 'SRC_URI'
+../recipes-wpe/wpewebkit/wpewebkit_2.22.bb:1:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set
+../recipes-wpe/wpewebkit/wpewebkit_2.22.bb:232:warning:oelint.spaces.lineend:Line shall not end with a space
+../recipes-wpe/wpewebkit/wpewebkit_2.22.bb:30:error:oelint.task.nocopy:'cp' shall not be used in do_install. Use 'install'
+../recipes-wpe/wpewebkit/wpewebkit_2.22.bb:48:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
+../recipes-wpe/wpewebkit/wpewebkit_2.22.bb:48:error:oelint.vars.valuequoted:Variable value should be quoted
+../recipes-wpe/wpewebkit/wpewebkit_2.22.bb:7:warning:oelint.var.order.SRC_URI:'SRC_URI' should be placed before 'SRCREV'
+../recipes-wpe/wpewebkit/wpewebkit_2.28.bb:1:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set
+../recipes-wpe/wpewebkit/wpewebkit_2.28.bb:8:warning:oelint.var.order.SRC_URI:'SRC_URI' should be placed before 'SRCREV'
+../recipes-wpe/wpewebkit/wpewebkit_2.30.bb:1:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set
+../recipes-wpe/wpewebkit/wpewebkit_2.30.bb:7:warning:oelint.var.order.SRC_URI:'SRC_URI' should be placed before 'SRCREV'
 ../recipes-wpe/wpewebkit/wpewebkit.inc:10:error:oelint.vars.inconspaces:Assignment should be 'VAR_append = " foo"' not 'VAR_append = "foo"'
 ../recipes-wpe/wpewebkit/wpewebkit.inc:10:error:oelint.vars.listappend:Append to list should end with a blank
 ../recipes-wpe/wpewebkit/wpewebkit.inc:10:warning:oelint.vars.dependsordered:'DEPENDS' entries should be ordered alphabetically
@@ -474,22 +488,8 @@
 ../recipes-wpe/wpewebkit/wpewebkit.inc:155:warning:oelint.vars.dependsordered:'RDEPENDS_${PN}' entries should be ordered alphabetically
 ../recipes-wpe/wpewebkit/wpewebkit.inc:195:warning:oelint.vars.duplicate:Item 'virtual/wpebackend' was added multiple times to RDEPENDS_${PN}
 ../recipes-wpe/wpewebkit/wpewebkit.inc:1:warning:oelint.vars.summary80chars:'SUMMARY' should not be longer than 80 characters
-../recipes-wpe/wpewebkit/wpewebkit.inc:24:error:oelint.var.improperinherit:''morty' is not a proper bbclass name
 ../recipes-wpe/wpewebkit/wpewebkit.inc:24:error:oelint.var.improperinherit:'==' is not a proper bbclass name
+../recipes-wpe/wpewebkit/wpewebkit.inc:24:error:oelint.var.improperinherit:''morty' is not a proper bbclass name
 ../recipes-wpe/wpewebkit/wpewebkit.inc:24:error:oelint.var.improperinherit:'True)' is not a proper bbclass name
 ../recipes-wpe/wpewebkit/wpewebkit.inc:38:error:oelint.vars.specific:'PACKAGECONFIG' is set specific to ['dunfell'], but isn't known from PACKAGES, MACHINE or resources
 ../recipes-wpe/wpewebkit/wpewebkit.inc:53:warning:oelint.vars.spacesassignment:Suggest spaces around variable assignment. E.g. 'FOO = "BAR"'
-../recipes-wpe/wpewebkit/wpewebkit_2.22.bb:13:warning:oelint.var.order.DEPENDS:'DEPENDS' should be placed before 'SRC_URI'
-../recipes-wpe/wpewebkit/wpewebkit_2.22.bb:1:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set
-../recipes-wpe/wpewebkit/wpewebkit_2.22.bb:232:warning:oelint.spaces.lineend:Line shall not end with a space
-../recipes-wpe/wpewebkit/wpewebkit_2.22.bb:30:error:oelint.task.nocopy:'cp' shall not be used in do_install. Use 'install'
-../recipes-wpe/wpewebkit/wpewebkit_2.22.bb:48:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
-../recipes-wpe/wpewebkit/wpewebkit_2.22.bb:48:error:oelint.vars.valuequoted:Variable value should be quoted
-../recipes-wpe/wpewebkit/wpewebkit_2.22.bb:7:warning:oelint.var.order.SRC_URI:'SRC_URI' should be placed before 'SRCREV'
-../recipes-wpe/wpewebkit/wpewebkit_2.28.bb:1:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set
-../recipes-wpe/wpewebkit/wpewebkit_2.28.bb:8:warning:oelint.var.order.SRC_URI:'SRC_URI' should be placed before 'SRCREV'
-../recipes-wpe/wpewebkit/wpewebkit_2.30.bb:1:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set
-../recipes-wpe/wpewebkit/wpewebkit_2.30.bb:7:warning:oelint.var.order.SRC_URI:'SRC_URI' should be placed before 'SRCREV'
-../recipes-wpe/wpewebkit/wpewebkit_20170728.bb:1:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set
-../recipes-wpe/wpewebkit/wpewebkit_20170728.bb:24:error:oelint.task.nocopy:'cp' shall not be used in do_install. Use 'install'
-../recipes-wpe/wpewebkit/wpewebkit_20170728.bb:9:warning:oelint.var.order.SRC_URI:'SRC_URI' should be placed before 'SRCREV'

--- a/recipes-wpe/wpewebkit/wpewebkit.inc
+++ b/recipes-wpe/wpewebkit/wpewebkit.inc
@@ -108,7 +108,7 @@ EXTRA_OECMAKE += "\
     -DCMAKE_BUILD_TYPE=Release \
     -DPORT=WPE \
     -G Ninja \
-    -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} \
+    -DPYTHON_EXECUTABLE=${PYTHON} \
 "
 
 EXTRANATIVEPATH += "chrpath-native"


### PR DESCRIPTION
The `PYTHON_EXECUTABLE` variable is exported by the `pythonnative` class, but not `python3native` which causes a configuration error while building with python3-native.