### PR TITLE
Changes improving version handling for wpe* recipes

### DIFF
--- a/linter/linter.out
+++ b/linter/linter.out
@@ -60,38 +60,37 @@
 ../recipes-support/icu/icu.inc:10:error:oelint.vars.dependsappend:DEPENDS should only be appended, not overwritten
 ../recipes-support/icu/icu.inc:48:error:oelint.task.nomkdir:'mkdir' shall not be used in do_install. Use 'install'
 ../recipes-support/rdksplash/rdk-splash-ui_git.bb:14:warning:oelint.vars.pathhardcode.localstatedir:'${localstatedir}' should be used instead of '/var'
-../recipes-wpe/wpebackend-fdo/wpebackend-fdo_git.bb:20:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
+../recipes-wpe/wpebackend-fdo/wpebackend-fdo_git.bb:21:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
 ../recipes-wpe/wpebackend-mesa/wpebackend-mesa_0.1.bb:31:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
-../recipes-wpe/wpebackend-rdk/wpebackend-rdk_git.bb:72:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
+../recipes-wpe/wpebackend-rdk/wpebackend-rdk_git.bb:73:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
 ../recipes-wpe/wpeframework/include/remotecontrol.inc:14:warning:oelint.vars.pathhardcode.nonarch_base_libdir:'${nonarch_base_libdir}' should be used instead of '/lib'
 ../recipes-wpe/wpeframework/include/remotecontrol.inc:48:error:oelint.task.nocopy:'cp' shall not be used in do_install. Use 'install'
 ../recipes-wpe/wpeframework/include/webkitbrowser.inc:246:error:oelint.spaces.linecont:No spaces after line continuation
-../recipes-wpe/wpeframework/include/webkitbrowser.inc:271:warning:oelint.spaces.lineend:Line shall not end with a space
+../recipes-wpe/wpeframework/include/webkitbrowser.inc:272:warning:oelint.spaces.lineend:Line shall not end with a space
+../recipes-wpe/wpeframework/include/webkitbrowser.inc:273:warning:oelint.spaces.lineend:Line shall not end with a space
 ../recipes-wpe/wpeframework/include/webserver.inc:5:warning:oelint.vars.pathhardcode.localstatedir:'${localstatedir}' should be used instead of '/var'
-../recipes-wpe/wpeframework/include/wpeframework-common.inc:2:error:oelint.var.override:Variable 'S' is set by wpeframework.inc,wpeframework-common.inc
+../recipes-wpe/wpeframework/include/wpeframework-common.inc:2:error:oelint.var.override:Variable 'S' is set by wpeframework-common.inc,wpeframework.inc
 ../recipes-wpe/wpeframework/include/wpeframework-plugins-rdk.inc:42:warning:oelint.vars.filessetting.double:${libdir}/wpeframework/plugins/*.so is already set by default or in this recipe
 ../recipes-wpe/wpeframework/include/wpeframework-plugins-rdk.inc:45:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
 ../recipes-wpe/wpeframework/include/wpeframework-plugins-rdk.inc:46:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
-../recipes-wpe/wpeframework/include/wpeframework-plugins.inc:6:error:oelint.var.override:Variable 'FILES_SOLIBSDEV' is set by wpeframework-plugins-rdk.inc,wpeframework-plugins.inc
 ../recipes-wpe/wpeframework/include/wpeframework-plugins.inc:6:error:oelint.var.override:Variable 'FILES_SOLIBSDEV' is set by wpeframework-plugins.inc,wpeframework-plugins-rdk.inc
 ../recipes-wpe/wpeframework/include/wpeframework-plugins.inc:6:error:oelint.var.override:Variable 'FILES_SOLIBSDEV' is set by wpeframework-plugins.inc,wpeframework-plugins_git.bb
 ../recipes-wpe/wpeframework/include/wpeframework-plugins.inc:6:error:oelint.var.override:Variable 'FILES_SOLIBSDEV' is set by wpeframework-plugins_git.bb,wpeframework-plugins.inc
 ../recipes-wpe/wpeframework/include/wpeframework-plugins.inc:7:warning:oelint.vars.filessetting.double:${libdir}/wpeframework/plugins/*.so is already set by default or in this recipe
-../recipes-wpe/wpeframework/wpeframework-clientlibraries_git.bb:64:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
 ../recipes-wpe/wpeframework/wpeframework-clientlibraries_git.bb:65:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
-../recipes-wpe/wpeframework/wpeframework-interfaces_git.bb:35:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
+../recipes-wpe/wpeframework/wpeframework-clientlibraries_git.bb:66:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
 ../recipes-wpe/wpeframework/wpeframework-interfaces_git.bb:36:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
-../recipes-wpe/wpeframework/wpeframework-ocdm-clearkey_git.bb:12:warning:oelint.var.filesoverride:'FILES_${PN}' should not be overriden
-../recipes-wpe/wpeframework/wpeframework-ocdm-playready-nexus-svp_git.bb:15:warning:oelint.var.filesoverride:'FILES_${PN}' should not be overriden
-../recipes-wpe/wpeframework/wpeframework-ocdm-playready-nexus_git.bb:15:warning:oelint.var.filesoverride:'FILES_${PN}' should not be overriden
-../recipes-wpe/wpeframework/wpeframework-ocdm-widevine-nexus-svp_git.bb:15:warning:oelint.var.filesoverride:'FILES_${PN}' should not be overriden
-../recipes-wpe/wpeframework/wpeframework-ocdm-widevine_git.bb:15:warning:oelint.var.filesoverride:'FILES_${PN}' should not be overriden
-../recipes-wpe/wpeframework/wpeframework-plugin-launcher_git.bb:13:warning:oelint.newline.consecutive:Consecutive blank lines should be avoided
+../recipes-wpe/wpeframework/wpeframework-interfaces_git.bb:37:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
+../recipes-wpe/wpeframework/wpeframework-ocdm-clearkey_git.bb:13:warning:oelint.var.filesoverride:'FILES_${PN}' should not be overriden
+../recipes-wpe/wpeframework/wpeframework-ocdm-playready-nexus-svp_git.bb:16:warning:oelint.var.filesoverride:'FILES_${PN}' should not be overriden
+../recipes-wpe/wpeframework/wpeframework-ocdm-playready-nexus_git.bb:16:warning:oelint.var.filesoverride:'FILES_${PN}' should not be overriden
+../recipes-wpe/wpeframework/wpeframework-ocdm-widevine-nexus-svp_git.bb:16:warning:oelint.var.filesoverride:'FILES_${PN}' should not be overriden
+../recipes-wpe/wpeframework/wpeframework-ocdm-widevine_git.bb:16:warning:oelint.var.filesoverride:'FILES_${PN}' should not be overriden
 ../recipes-wpe/wpeframework/wpeframework-plugins_git.bb:73:warning:oelint.vars.pathhardcode.localstatedir:'${localstatedir}' should be used instead of '/var'
 ../recipes-wpe/wpeframework/wpeframework-plugins_git.bb:83:warning:oelint.vars.filessetting.double:${libdir}/wpeframework/plugins/*.so is already set by default or in this recipe
 ../recipes-wpe/wpeframework/wpeframework-plugins_git.bb:87:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
 ../recipes-wpe/wpeframework/wpeframework-plugins_git.bb:88:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
-../recipes-wpe/wpeframework/wpeframework-ui_git.bb:16:error:oelint.task.nomkdir:'mkdir' shall not be used in do_install. Use 'install'
+../recipes-wpe/wpeframework/wpeframework-ui_git.bb:17:error:oelint.task.nomkdir:'mkdir' shall not be used in do_install. Use 'install'
 ../recipes-wpe/wpeframework/wpeframework_git.bb:145:warning:oelint.var.filesoverride:'FILES_${PN}-initscript' should not be overriden
 ../recipes-wpe/wpeframework/wpeframework_git.bb:158:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
 ../recipes-wpe/wpeframework/wpeframework_git.bb:159:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
@@ -108,7 +107,8 @@
 ../recipes-wpe/wpewebkit/wpewebkit.inc:25:error:oelint.var.improperinherit:'==' is not a proper bbclass name
 ../recipes-wpe/wpewebkit/wpewebkit.inc:25:error:oelint.var.improperinherit:'True)' is not a proper bbclass name
 ../recipes-wpe/wpewebkit/wpewebkit.inc:39:error:oelint.vars.specific:'PACKAGECONFIG' is set specific to ['dunfell'], but isn't known from PACKAGES, MACHINE or resources
-../recipes-wpe/wpewebkit/wpewebkit_2.22.bb:233:warning:oelint.spaces.lineend:Line shall not end with a space
-../recipes-wpe/wpewebkit/wpewebkit_2.22.bb:30:error:oelint.task.nocopy:'cp' shall not be used in do_install. Use 'install'
-../recipes-wpe/wpewebkit/wpewebkit_2.22.bb:48:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
-../recipes-wpe/wpewebkit/wpewebkit_20170728.bb:23:error:oelint.task.nocopy:'cp' shall not be used in do_install. Use 'install'
+../recipes-wpe/wpewebkit/wpewebkit_2.22.bb:234:warning:oelint.spaces.lineend:Line shall not end with a space
+../recipes-wpe/wpewebkit/wpewebkit_2.22.bb:31:error:oelint.task.nocopy:'cp' shall not be used in do_install. Use 'install'
+../recipes-wpe/wpewebkit/wpewebkit_2.22.bb:49:error:oelint.vars.insaneskip:INSANE_SKIP should be avoided at any cost
+../recipes-wpe/wpewebkit/wpewebkit_20170728.bb:24:error:oelint.task.nocopy:'cp' shall not be used in do_install. Use 'install'
+xargs: oelint-adv: terminated with signal 9; aborting

--- a/recipes-wpe/libwpe/libwpe_1.0.0.bb
+++ b/recipes-wpe/libwpe/libwpe_1.0.0.bb
@@ -3,8 +3,9 @@ require libwpe.inc
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6ae4db0d4b812334e1539cd5aa6e2f46"
 
-SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEBackend.git"
-SRCREV = "4be4c7df5734d125148367a90da477c8d40d9eaf"
+RECIPE_BRANCH ?= "master"
+SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEBackend.git;branch=${RECIPE_BRANCH}"
+SRCREV ?= "4be4c7df5734d125148367a90da477c8d40d9eaf"
 S = "${WORKDIR}/git"
 
 CXXFLAGS += "-D_GLIBCXX_USE_CXX11_ABI=0"

--- a/recipes-wpe/wpebackend-fdo/wpebackend-fdo_git.bb
+++ b/recipes-wpe/wpebackend-fdo/wpebackend-fdo_git.bb
@@ -7,9 +7,10 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=1f62cef2e3645e3e74eb05fd389d7a66"
 
 DEPENDS_append = " glib-2.0 libwpe libxkbcommon virtual/libgl wayland"
 
+RECIPE_BRANCH ?= "master"
 PV = "1.0.0+git${SRCPV}"
-SRC_URI = "git://github.com/Igalia/WPEBackend-fdo.git;protocol=git;branch=master"
-SRCREV = "5a4b58c7d6a70068d13b8404a0c970b03a856119"
+SRC_URI = "git://github.com/Igalia/WPEBackend-fdo.git;protocol=git;branch=${RECIPE_BRANCH}"
+SRCREV ?= "5a4b58c7d6a70068d13b8404a0c970b03a856119"
 S = "${WORKDIR}/git"
 
 inherit cmake

--- a/recipes-wpe/wpebackend-mesa/wpebackend-mesa_0.1.bb
+++ b/recipes-wpe/wpebackend-mesa/wpebackend-mesa_0.1.bb
@@ -7,9 +7,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6ae4db0d4b812334e1539cd5aa6e2f46"
 
 DEPENDS_append = " wpewebkit glib-2.0 libxkbcommon wayland virtual/libgl"
 
-SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEBackend-mesa.git"
-SRCREV = "3f9f87d5f42c27a22273d67db072bd7f2cba6135"
-
+RECIPE_BRANCH ?= "master"
+SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEBackend-mesa.git;branch=${RECIPE_BRANCH}"
+SRCREV ?= "3f9f87d5f42c27a22273d67db072bd7f2cba6135"
 S = "${WORKDIR}/git"
 
 inherit cmake pkgconfig

--- a/recipes-wpe/wpebackend-rdk/wpebackend-rdk_git.bb
+++ b/recipes-wpe/wpebackend-rdk/wpebackend-rdk_git.bb
@@ -8,9 +8,10 @@ LIC_FILES_CHKSUM = "file://src/wayland/display.h;;beginline=5;endline=24;md5=b1c
 DEPENDS_append = " libwpe glib-2.0"
 PROVIDES += "virtual/wpebackend"
 
+RECIPE_BRANCH ?= "master"
 PV = "git${SRCPV}"
-SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEBackend-rdk.git;protocol=git;branch=master"
-SRCREV = "196f75360b8643b119d8d96208d914998e5d4fc9"
+SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEBackend-rdk.git;protocol=git;branch=${RECIPE_BRANCH}"
+SRCREV ?= "196f75360b8643b119d8d96208d914998e5d4fc9"
 S = "${WORKDIR}/git"
 
 inherit cmake pkgconfig

--- a/recipes-wpe/wpeframework/include/wpeframework.inc
+++ b/recipes-wpe/wpeframework/include/wpeframework.inc
@@ -4,11 +4,11 @@ SECTION = "wpe"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=85bcfede74b96d9a58c6ea5d4b607e58"
 
+RECIPE_BRANCH ?= "master"
 SRC_URI[md5sum] = "42b518b9ccd6852d1d709749bc96cb70"
 SRC_URI[sha256sum] = "f3c45b121cf6257eafabdc3a8008763aed1cd7da06dbabc59a9e4d2a5e4e6697"
-SRC_URI = "git://github.com/rdkcentral/Thunder.git;protocol=git;branch=master"
-SRCREV = "a3415280af850ef9687d6ff33c77dc6d7faf0b5e"
-
+SRC_URI = "git://github.com/rdkcentral/Thunder.git;protocol=git;branch=${RECIPE_BRANCH}"
+SRCREV ?= "a3415280af850ef9687d6ff33c77dc6d7faf0b5e"
 PR = "r0"
 S = "${WORKDIR}/git"
 

--- a/recipes-wpe/wpeframework/wpeframework-clientlibraries_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-clientlibraries_git.bb
@@ -10,11 +10,12 @@ require include/wpeframework-common.inc
 require include/compositor.inc
 
 PR = "r0"
+RECIPE_BRANCH ?= "master"
 SRC_URI = "\
-    git://github.com/rdkcentral/ThunderClientLibraries.git;protocol=git;branch=master \
+    git://github.com/rdkcentral/ThunderClientLibraries.git;protocol=git;branch=${RECIPE_BRANCH} \
     file://0001-cmake-become-more-easy-in-findgbm.patch \
 "
-SRCREV = "6438e1583c39199075ca0006e1fee69f5b27a260"
+SRCREV ?= "6438e1583c39199075ca0006e1fee69f5b27a260"
 
 inherit python3native
 WPE_CDMI_ADAPTER_IMPL ??= "${@bb.utils.contains('DISTRO_FEATURES', 'nexus_svp', 'opencdmi_brcm_svp', 'opencdm_gst', d)}"

--- a/recipes-wpe/wpeframework/wpeframework-interfaces_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-interfaces_git.bb
@@ -9,8 +9,9 @@ require include/wpeframework-common.inc
 DEPENDS_append = " wpeframework-tools-native wpeframework"
 
 PR = "r0"
-SRC_URI = "git://github.com/rdkcentral/ThunderInterfaces.git;protocol=git;branch=master"
-SRCREV = "1b2cbb8dfa823d29fba254932531c33743f7d358"
+RECIPE_BRANCH ?= "master"
+SRC_URI = "git://github.com/rdkcentral/ThunderInterfaces.git;protocol=git;branch=${RECIPE_BRANCH}"
+SRCREV ?= "1b2cbb8dfa823d29fba254932531c33743f7d358"
 
 inherit python3native
 

--- a/recipes-wpe/wpeframework/wpeframework-ocdm-clearkey_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-ocdm-clearkey_git.bb
@@ -6,8 +6,9 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=9c83fce561d6921e20681566f2550145"
 
 require include/wpeframework-plugins.inc
 
-SRC_URI = "git://git@github.com/rdkcentral/OCDM-Clearkey.git;protocol=https;branch=master"
-SRCREV = "1524b947f5c28100326415a2ac1d02f3974acdc8"
+RECIPE_BRANCH ?= "master"
+SRC_URI = "git://git@github.com/rdkcentral/OCDM-Clearkey.git;protocol=https;branch=${RECIPE_BRANCH}"
+SRCREV ?= "1524b947f5c28100326415a2ac1d02f3974acdc8"
 
 FILES_${PN} = "${datadir}/WPEFramework/OCDM/*.drm"
 

--- a/recipes-wpe/wpeframework/wpeframework-ocdm-playready-nexus-svp_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-ocdm-playready-nexus-svp_git.bb
@@ -9,8 +9,9 @@ require include/wpeframework-plugins.inc
 DEPENDS_append = " broadcom-refsw"
 
 PV = "3.0+gitr${SRCPV}"
-SRC_URI = "git://code.rdkcentral.com/r/soc/broadcom/components/rdkcentral/OCDM-Playready-Nexus-SVP.git;protocol=https;branch=master"
-SRCREV = "69cedd51e040c0b592c77de59b4060937099d2f1"
+RECIPE_BRANCH ?= "master"
+SRC_URI = "git://code.rdkcentral.com/r/soc/broadcom/components/rdkcentral/OCDM-Playready-Nexus-SVP.git;protocol=https;branch=${RECIPE_BRANCH}"
+SRCREV ?= "69cedd51e040c0b592c77de59b4060937099d2f1"
 
 FILES_${PN} = "${datadir}/WPEFramework/OCDM/*.drm"
 

--- a/recipes-wpe/wpeframework/wpeframework-ocdm-playready-nexus_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-ocdm-playready-nexus_git.bb
@@ -9,8 +9,9 @@ require include/wpeframework-plugins.inc
 DEPENDS_append = " broadcom-refsw"
 
 PV = "3.0+gitr${SRCPV}"
-SRC_URI = "git://code.rdkcentral.com/r/soc/broadcom/components/rdkcentral/OCDM-Playready-Nexus.git;protocol=https;branch=master"
-SRCREV = "cdb2e784a03b2d01c03a12d008bf1d9e034f7b62"
+RECIPE_BRANCH ?= "master"
+SRC_URI = "git://code.rdkcentral.com/r/soc/broadcom/components/rdkcentral/OCDM-Playready-Nexus.git;protocol=https;branch=${RECIPE_BRANCH}"
+SRCREV ?= "cdb2e784a03b2d01c03a12d008bf1d9e034f7b62"
 
 FILES_${PN} = "${datadir}/WPEFramework/OCDM/*.drm"
 

--- a/recipes-wpe/wpeframework/wpeframework-ocdm-playready_2.5+git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-ocdm-playready_2.5+git.bb
@@ -1,11 +1,12 @@
 require include/wpeframework-ocdm-playready.inc
 
 PV = "2.5+git${SRCPV}"
+RECIPE_BRANCH ?= "PR2.5"
 SRC_URI = "\
-    git://git@github.com/rdkcentral/OCDM-Playready.git;protocol=https;branch=PR2.5 \
+    git://git@github.com/rdkcentral/OCDM-Playready.git;protocol=https;branch=${RECIPE_BRANCH} \
     file://0001-OCDM-Playready-adjust-header-order-to-fix-build-issue.patch \
 "
-SRCREV = "9c530ee979d67aeb07c710f6c51026ae37807936"
+SRCREV ?= "9c530ee979d67aeb07c710f6c51026ae37807936"
 
 DEFAULT_PREFERENCE = "-1"
 

--- a/recipes-wpe/wpeframework/wpeframework-ocdm-playready_4.0+git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-ocdm-playready_4.0+git.bb
@@ -1,8 +1,9 @@
 require include/wpeframework-ocdm-playready.inc
 
 PV = "4.0+git${SRCPV}"
-SRC_URI = "git://git@github.com/rdkcentral/OCDM-Playready.git;protocol=https;branch=master"
-SRCREV = "7b14ebbe16717d27737e913c6120f848f6663d30"
+RECIPE_BRANCH ?= "master"
+SRC_URI = "git://git@github.com/rdkcentral/OCDM-Playready.git;protocol=https;branch=${RECIPE_BRANCH}"
+SRCREV ?= "7b14ebbe16717d27737e913c6120f848f6663d30"
 
 TARGET_CFLAGS += "-fpermissive"
 

--- a/recipes-wpe/wpeframework/wpeframework-ocdm-playready_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-ocdm-playready_git.bb
@@ -1,8 +1,9 @@
 require include/wpeframework-ocdm-playready.inc
 
 PV = "3.0+gitr${SRCPV}"
+RECIPE_BRANCH ?= "PR2.5"
 SRC_URI = "\
-    git://git@github.com/rdkcentral/OCDM-Playready.git;protocol=https;branch=PR2.5 \
+    git://git@github.com/rdkcentral/OCDM-Playready.git;protocol=https;branch=${RECIPE_BRANCH} \
     file://0001-OCDM-Playready-adjust-header-order-to-fix-build-issue.patch \
 "
-SRCREV = "9c530ee979d67aeb07c710f6c51026ae37807936"
+SRCREV ?= "9c530ee979d67aeb07c710f6c51026ae37807936"

--- a/recipes-wpe/wpeframework/wpeframework-ocdm-widevine-nexus-svp_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-ocdm-widevine-nexus-svp_git.bb
@@ -9,8 +9,9 @@ require include/wpeframework-plugins.inc
 DEPENDS_append = " broadcom-refsw"
 
 PV = "3.0+gitr${SRCPV}"
-SRC_URI = "git://code.rdkcentral.com/r/soc/broadcom/components/rdkcentral/OCDM-Widevine-Nexus-SVP.git;protocol=https;branch=master"
-SRCREV = "fa60a8b37af4da396a8ba108dc4f9f85b6eaf10e"
+RECIPE_BRANCH ?= "master"
+SRC_URI = "git://code.rdkcentral.com/r/soc/broadcom/components/rdkcentral/OCDM-Widevine-Nexus-SVP.git;protocol=https;branch=${RECIPE_BRANCH}"
+SRCREV ?= "fa60a8b37af4da396a8ba108dc4f9f85b6eaf10e"
 
 FILES_${PN} = "${datadir}/WPEFramework/OCDM/*.drm"
 

--- a/recipes-wpe/wpeframework/wpeframework-ocdm-widevine_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-ocdm-widevine_git.bb
@@ -9,8 +9,9 @@ require include/wpeframework-plugins.inc
 DEPENDS_append = " widevine"
 
 PV = "3.0+gitr${SRCPV}"
-SRC_URI = "git://git@github.com/rdkcentral/OCDM-Widevine.git;protocol=https;branch=development/widevine-15.3.0"
-SRCREV = "70b3acf9af4fa74631d1eb071596534b02bae206"
+RECIPE_BRANCH ?= "development/widevine-15.3.0"
+SRC_URI = "git://git@github.com/rdkcentral/OCDM-Widevine.git;protocol=https;branch=${RECIPE_BRANCH}"
+SRCREV ?= "70b3acf9af4fa74631d1eb071596534b02bae206"
 
 FILES_${PN} = "${datadir}/WPEFramework/OCDM/*.drm"
 

--- a/recipes-wpe/wpeframework/wpeframework-plugin-launcher_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-plugin-launcher_git.bb
@@ -7,7 +7,6 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 require include/wpeframework-plugins.inc
 
 PV = "3.0+gitr${SRCPV}"
-SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEPluginLauncher.git"
-SRCREV = "2f425ac9d08aa84927f88ee8f3576e9006b8783b"
-
-
+RECIPE_BRANCH ?= "master"
+SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEPluginLauncher.git;branch=${RECIPE_BRANCH}"
+SRCREV ?= "2f425ac9d08aa84927f88ee8f3576e9006b8783b"

--- a/recipes-wpe/wpeframework/wpeframework-plugins-rdk_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-plugins-rdk_git.bb
@@ -3,9 +3,10 @@ DESCRIPTION = "WPEFramework/Thunder Plugins RDK"
 HOMEPAGE = "https://github.com:/WebPlatformForEmbedded/ThunderNanoServicesRDK"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=39fb5e7bc6aded7b6d2a5f5aa553425f"
-PR = "r1"
 
-SRC_URI = "git://git@github.com:/WebPlatformForEmbedded/ThunderNanoServicesRDK.git;protocol=ssh;branch=master"
-SRCREV = "a78d700c88ad97a7171fd7352a41d4371296b7af"
+PR = "r1"
+RECIPE_BRANCH ?= "master"
+SRC_URI = "git://git@github.com:/WebPlatformForEmbedded/ThunderNanoServicesRDK.git;protocol=ssh;branch=${RECIPE_BRANCH}"
+SRCREV ?= "a78d700c88ad97a7171fd7352a41d4371296b7af"
 
 require include/wpeframework-plugins-rdk.inc

--- a/recipes-wpe/wpeframework/wpeframework-plugins_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-plugins_git.bb
@@ -3,19 +3,19 @@ DESCRIPTION = "Common plugins for Thunder framework"
 HOMEPAGE = "https://github.com/rdkcentral/ThunderNanoServices"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=47b1321b4411e96bb5aeb94521850d43"
-PR = "r1"
 
 require include/wpeframework-plugins.inc
 
 PV = "3.0+gitr${SRCPV}"
+PR = "r1"
+RECIPE_BRANCH ?= "master"
 SRC_URI = "\
-git://github.com/rdkcentral/ThunderNanoServices.git;protocol=git;branch=master \
+    git://github.com/rdkcentral/ThunderNanoServices.git;protocol=git;branch=${RECIPE_BRANCH} \
     file://index.html \
     file://osmc-devinput-remote.json \
     file://0001-westeros-preload-libwesteros_gl.so.0.0.0.patch \
 "
-
-SRCREV = "a06fdb2ba34e29035ceb01431f6d720d1e5b5e01"
+SRCREV ?= "a06fdb2ba34e29035ceb01431f6d720d1e5b5e01"
 
 # More complicated plugins are moved seperate includes
 

--- a/recipes-wpe/wpeframework/wpeframework-rdkservices_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-rdkservices_git.bb
@@ -3,10 +3,11 @@ DESCRIPTION = "WPEFramework Plugins from RDKServices from Thunder"
 HOMEPAGE = "https://github.com/rdkcentral/rdkservices"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=39fb5e7bc6aded7b6d2a5f5aa553425f"
+
 PR = "r1"
 # Note has to be tested once the latest thunder changes synced with rdkcentral/rdkservices repo
-SRC_URI = "git://git@github.com/rdkcentral/rdkservices.git;protocol=ssh;branch=main"
-SRCREV = "9d02a5006449b795394623ba023d98c10a60bcf2"
+RECIPE_BRANCH ?= "main"
+SRC_URI = "git://git@github.com/rdkcentral/rdkservices.git;protocol=ssh;branch=${RECIPE_BRANCH}"
+SRCREV ?= "9d02a5006449b795394623ba023d98c10a60bcf2"
 
 require include/wpeframework-plugins-rdk.inc
-

--- a/recipes-wpe/wpeframework/wpeframework-ui_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-ui_git.bb
@@ -7,8 +7,9 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=66fe57b27abb01505f399ce4405cfea0"
 require include/wpeframework-plugins.inc
 
 PV = "3.0+gitr${SRCPV}"
-SRC_URI = "git://github.com/rdkcentral/ThunderUI.git"
-SRCREV = "2684b88451267f8d61ab87687e9d76df9e53c552"
+RECIPE_BRANCH ?= "master"
+SRC_URI = "git://github.com/rdkcentral/ThunderUI.git;branch=${RECIPE_BRANCH}"
+SRCREV ?= "2684b88451267f8d61ab87687e9d76df9e53c552"
 
 do_configure[noexec] = "1"
 do_compile[noexec] = "1"

--- a/recipes-wpe/wpewebkit/wpewebkit_2.22.bb
+++ b/recipes-wpe/wpewebkit/wpewebkit_2.22.bb
@@ -4,8 +4,9 @@ DEPENDS_append = " libgcrypt"
 
 PV = "2.22+git${SRCPV}"
 PR = "r0"
+RECIPE_BRANCH ?= "wpe-2.22"
 SRC_URI = "\
-    git://github.com/WebPlatformForEmbedded/WPEWebKit.git;branch=wpe-2.22 \
+    git://github.com/WebPlatformForEmbedded/WPEWebKit.git;branch=${RECIPE_BRANCH} \
     file://0001-WPEWebkit-compile-fix.patch \
     file://0001-Fix-for-missing-heap-vm-main.patch \
 "

--- a/recipes-wpe/wpewebkit/wpewebkit_2.28.bb
+++ b/recipes-wpe/wpewebkit/wpewebkit_2.28.bb
@@ -3,8 +3,9 @@ require wpewebkit.inc
 
 PV = "2.28+git${SRCPV}"
 PR = "r0"
+RECIPE_BRANCH ?= "wpe-2.28"
 SRC_URI = "\
-    git://github.com/WebPlatformForEmbedded/WPEWebKit.git;branch=wpe-2.28 \
+    git://github.com/WebPlatformForEmbedded/WPEWebKit.git;branch=${RECIPE_BRANCH} \
     file://0001-Fix-for-missing-heap-vm-main.patch \
     file://0001-page-remove-constness-to-Orientation-and-Motion-cont.patch \
 "

--- a/recipes-wpe/wpewebkit/wpewebkit_2.30.bb
+++ b/recipes-wpe/wpewebkit/wpewebkit_2.30.bb
@@ -2,8 +2,9 @@ require wpewebkit.inc
 
 PV = "2.30+git${SRCPV}"
 PR = "r0"
+RECIPE_BRANCH ?= "wpe-2.30"
 SRC_URI = "\
-    git://github.com/WebPlatformForEmbedded/WPEWebKit.git;branch=wpe-2.30 \
+    git://github.com/WebPlatformForEmbedded/WPEWebKit.git;branch=${RECIPE_BRANCH} \
     file://216455_builds_with_ENABLE_SERVICE_WORKER_OFF.patch \
     file://0001-Fix-for-missing-heap-vm-main.patch \
     file://0001-page-remove-constness-to-Orientation-and-Motion-cont.patch \

--- a/recipes-wpe/wpewebkit/wpewebkit_20170728.bb
+++ b/recipes-wpe/wpewebkit/wpewebkit_20170728.bb
@@ -4,7 +4,8 @@ DEFAULT_PREFERENCE = "-1"
 
 PV = "20170728+git${SRCPV}"
 PR = "r2"
-SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEWebKit.git;protocol=git;branch=wpe-20170728"
+RECIPE_BRANCH ?= "wpe-20170728"
+SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEWebKit.git;protocol=git;branch=${RECIPE_BRANCH}"
 SRC_URI_append = " \
     file://0001-Fix-build-with-musl.patch \
     file://0002-Define-MESA_EGL_NO_X11_HEADERS-when-not-using-GLX.patch \


### PR DESCRIPTION
This commit introduce variables that are easier to override from outside
of the recipe. This way the version handling is improved.
Changes:
* RECIPE_BRANCH variable - use instead of hardcoded branch name
* All SRCREVS are at least a weak assignments