### PR TITLE
Enable WebAudio on WPEWebKit 2.22

### DIFF
--- a/recipes-wpe/wpewebkit/wpewebkit_2.22.bb
+++ b/recipes-wpe/wpewebkit/wpewebkit_2.22.bb
@@ -12,6 +12,7 @@ SRC_URI = "\
 "
 SRCREV ?= "57bbecb9421d206f40a3beb45b9d800288a39b1d"
 
+PACKAGECONFIG_append = " webaudio"
 PACKAGECONFIG_append = " webcrypto"
 
 do_compile() {


### PR DESCRIPTION
WebAudio is required by BBC ACT test suite.