### PR TITLE
Align Thunder and Plugins recipes with master

### DIFF
--- a/recipes-multimedia/cenc/gstreamer1.0-plugins-cencdecrypt_git.bb
+++ b/recipes-multimedia/cenc/gstreamer1.0-plugins-cencdecrypt_git.bb
@@ -8,6 +8,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=b5b0a376d65d47d649918a3b70e90857"
 DEPENDS = " \
     gstreamer1.0 \
     gstreamer1.0-plugins-base \
+    wpeframework-tools-native \
     wpeframework \
     wpeframework-clientlibraries \
     curl \

--- a/recipes-wpe/wpeframework/include/wpeframework-common.inc
+++ b/recipes-wpe/wpeframework/include/wpeframework-common.inc
@@ -12,4 +12,4 @@ LDFLAGS_append = " -fuse-ld=bfd"
 # Yocto root is under /home/root
 WPEFRAMEWORK_PERSISTENT_PATH ??= "/home/root/"
 WPEFRAMEWORK_VOLATILE_PATH ??= ""
-DEPENDS += "git-replacement-native"
+DEPENDS += "git-replacement-native wpeframework-tools-native"

--- a/recipes-wpe/wpeframework/include/wpeframework-plugins-rdk.inc
+++ b/recipes-wpe/wpeframework/include/wpeframework-plugins-rdk.inc
@@ -4,12 +4,14 @@ require wpeframework-plugins.inc
 # Plugins configs are moved to seperate includes
 require deviceidentification.inc
 require deviceinfo.inc
+require displayinfo.inc
 require locationsync.inc
 require messagecontrol.inc
 require messenger.inc
 require monitor.inc
 require ocdm.inc
 require packager.inc
+require playerinfo.inc
 require securityagent.inc
 require tracecontrol.inc
 require warningreportingcontrol.inc

--- a/recipes-wpe/wpeframework/include/wpeframework.inc
+++ b/recipes-wpe/wpeframework/include/wpeframework.inc
@@ -8,7 +8,7 @@ RECIPE_BRANCH ?= "master"
 SRC_URI[md5sum] = "42b518b9ccd6852d1d709749bc96cb70"
 SRC_URI[sha256sum] = "f3c45b121cf6257eafabdc3a8008763aed1cd7da06dbabc59a9e4d2a5e4e6697"
 SRC_URI = "git://github.com/rdkcentral/Thunder.git;protocol=git;branch=${RECIPE_BRANCH};protocol=https"
-SRCREV ?= "6db98343021f64274c9d1ac27487b33bff683b4c"
+SRCREV ?= "2b98f41ba1b3668bb5c97845072bc7ef2553ea6a"
 PR = "r0"
 S = "${WORKDIR}/git"
 

--- a/recipes-wpe/wpeframework/wpeframework-clientlibraries_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-clientlibraries_git.bb
@@ -4,7 +4,7 @@ HOMEPAGE = "https://github.com/rdkcentral/ThunderClientLibraries"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=847677038847363222ffb66cfa6406c2"
 
-DEPENDS_append = " wpeframework-tools-native wpeframework-interfaces"
+DEPENDS_append = " wpeframework-interfaces"
 
 require include/wpeframework-common.inc
 require include/compositor.inc
@@ -14,7 +14,7 @@ PV = "3.0+gitr${SRCPV}"
 RECIPE_BRANCH ?= "master"
 
 SRC_URI = "git://github.com/rdkcentral/ThunderClientLibraries.git;protocol=git;branch=${RECIPE_BRANCH};protocol=https"
-SRCREV ?= "4703e48744f00fdc84f7234a01ec5691b9160670"
+SRCREV ?= "a19c8474ce65e7af6bbb8ce4acd5c4de31682f33"
 
 inherit python3native
 WPE_CDMI_ADAPTER_IMPL ??= "${@bb.utils.contains('DISTRO_FEATURES', 'nexus_svp', 'opencdmi_brcm_svp', 'opencdm_gst', d)}"

--- a/recipes-wpe/wpeframework/wpeframework-interfaces_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-interfaces_git.bb
@@ -6,14 +6,14 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=2f6c18f99faffa0e5d4ff478705c53f8"
 
 require include/wpeframework-common.inc
-DEPENDS_append = " wpeframework-tools-native wpeframework"
+DEPENDS_append = " wpeframework"
 
 PR = "r0"
 PV = "3.0+gitr${SRCPV}"
 RECIPE_BRANCH ?= "master"
 
 SRC_URI = "git://github.com/rdkcentral/ThunderInterfaces.git;protocol=git;branch=${RECIPE_BRANCH};protocol=https"
-SRCREV ?= "ca6f90c62ebfd6dafba7a018eb1e0bd06d418262"
+SRCREV ?= "96b4554555a2738b1664e82d98ac947d2dc9dfb7"
 
 inherit python3native
 

--- a/recipes-wpe/wpeframework/wpeframework-libraries_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-libraries_git.bb
@@ -12,9 +12,8 @@ PV = "3.0+gitr${SRCPV}"
 PR = "r1"
 RECIPE_BRANCH ?= "main"
 SRC_URI = "git://git@github.com:/WebPlatformForEmbedded/ThunderLibraries.git;protocol=ssh;branch=${RECIPE_BRANCH}"
-SRCREV ?= "02021c90130953a2638aad69b1d851cf5050bee8"
+SRCREV ?= "4408be5a034d4903baa9d20dd926a516566609b2"
 
-#inherit python3native
 
 PACKAGECONFIG ??= "\
     ${@bb.utils.contains('MACHINE_FEATURES', 'bluetooth', 'bluetooth', '', d)} \

--- a/recipes-wpe/wpeframework/wpeframework-ocdm-playready_4.0+git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-ocdm-playready_4.0+git.bb
@@ -3,7 +3,7 @@ require include/wpeframework-ocdm-playready.inc
 PV = "4.0+git${SRCPV}"
 RECIPE_BRANCH ?= "master"
 SRC_URI = "git://git@github.com/rdkcentral/OCDM-Playready.git;protocol=https;branch=${RECIPE_BRANCH}"
-SRCREV ?= "bf1d4afd0873ff5e38be303a1176d1a4ab3850a3"
+SRCREV ?= "c88e8bbc07782637997558b4f6d96db2ae75ffa5"
 
 TARGET_CFLAGS += "-fpermissive"
 

--- a/recipes-wpe/wpeframework/wpeframework-plugins-rdk_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-plugins-rdk_git.bb
@@ -8,7 +8,7 @@ PR = "r1"
 PV = "3.0+git${SRCPV}"
 RECIPE_BRANCH ?= "master"
 SRC_URI = "git://git@github.com:/WebPlatformForEmbedded/ThunderNanoServicesRDK.git;protocol=ssh;branch=${RECIPE_BRANCH}"
-SRCREV ?= "65eb1c658391580447c7c93b890cfee772e058bf"
+SRCREV ?= "e5a6ff8b9d495c2711438b6641a652ae1ea11e35"
 require include/wpeframework-plugins-rdk.inc
 
 ASNEEDED = ""

--- a/recipes-wpe/wpeframework/wpeframework-plugins_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework-plugins_git.bb
@@ -15,7 +15,7 @@ SRC_URI = "\
     file://osmc-devinput-remote.json \
     file://0001-westeros-preload-libwesteros_gl.so.0.0.0.patch \
 "
-SRCREV ?= "ac99272ac39f28c339ebfef3d501a54daefa2095"
+SRCREV ?= "7c1947cfb769d0fac2efc0fb07b152171c901ac1"
 
 # More complicated plugins are moved seperate includes
 
@@ -26,7 +26,6 @@ require include/compositor.inc
 require include/dhcpserver.inc
 require include/dictionary.inc
 require include/dialserver.inc
-require include/displayinfo.inc
 require include/filetransfer.inc
 require include/firmwarecontrol.inc
 require include/inputswitch.inc
@@ -34,7 +33,6 @@ require include/ioconnector.inc
 require include/languageadministrator.inc
 require include/network.inc
 require include/performancemonitor.inc
-require include/playerinfo.inc
 require include/power.inc
 require include/processcontainers.inc
 require include/processmonitor.inc

--- a/recipes-wpe/wpeframework/wpeframework_git.bb
+++ b/recipes-wpe/wpeframework/wpeframework_git.bb
@@ -5,7 +5,7 @@ require include/wpeframework.inc
 require include/wpeframework-common.inc
 require include/wpeframework-deprecated.inc
 
-DEPENDS_append = " zlib virtual/egl wpeframework-tools-native"
+DEPENDS_append = " zlib virtual/egl"
 DEPENDS_append_libc-musl = " libexecinfo"
 
 PROVIDES += "thunder"
@@ -20,6 +20,7 @@ WPEFRAMEWORK_ETHERNETCARD_NAME ??= "eth0"
 WPEFRAMEWORK_SOFT_KILL_CHECK_WAIT_TIME ??= "10"
 WPEFRAMEWORK_HARD_KILL_CHECK_WAIT_TIME ??= "4"
 
+WPEFRAMEWORK_TRACING_LEVEL ??= "0"
 WPEFRAMEWORK_INITSCRIPT_SYSTEMD_EXTRA_DEPENDS ??= ""
 WPEFRAMEWORK_INITSCRIPT_SYSTEM_ROOT_PATH ??= "home/root"
 WPEFRAMEWORK_INITSCRIPT_SYSTEMD_SERVICE ??= "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}"
@@ -70,6 +71,13 @@ PACKAGECONFIG[disabletracing] = "-DDISABLE_TRACING=ON,-DDISABLE_TRACING=OFF,"
 PACKAGECONFIG[exceptionhandling] = "-DEXCEPTIONS_ENABLE=ON,-DEXCEPTIONS_ENABLE=OFF,"
 PACKAGECONFIG[exceptioncatching] = "-DEXCEPTION_CATCHING=ON,-DEXCEPTION_CATCHING=OFF,"
 PACKAGECONFIG[warningreporting] = "-DWARNING_REPORTING=ON,-DWARNING_REPORTING=OFF,"
+
+PACKAGECONFIG[messaging] = " \
+    -DTRACING=OFF \
+    -DMESSAGING=ON \
+    , -DTRACING=ON -DENABLED_TRACING_LEVEL=${WPEFRAMEWORK_TRACING_LEVEL} \
+    -DMESSAGING=OFF, \
+"
 PACKAGECONFIG[initscriptsupport] = " \
     -DENABLE_INITSCRIPT_SUPPORT=ON \
     -DSYSTEMD_SERVICE="${WPEFRAMEWORK_INITSCRIPT_SYSTEMD_SERVICE}" \


### PR DESCRIPTION
Changes include 
Thunder:
[StubGen] 
Use qualified call to the Invoke method, Forward declare IShell and ISubSystem enums and Support pointer to const interface as output parameter
[JsonGen]
Support cross-reference from JSON meta to C++ header 
JSON-RPC spec compliance and Generate version information code 
[CMake] 
New Config generator support and switch off legacy config generator
[HELLGRIND] 
Address the issues reported by Hellgrind
[Core] Fix also the admin file of the SharedBuffer
Enhance the Callstack handling reporting.
Make sure the framework automatically accepts auto generated versioning calls.
Warning option enhancement and expose the plugin Search path and the System path from thunder config

ThunderNanoServices & ThunderNanoServicesRDK
Moving PlayerInfo and DeviceInfo to ThunderNanoServicesRDK

ThunderClientLibraries
Extend EDID capabilities with CAE info blocks
[compositor-client]: Enable mouse cursor for RPI.
[DisplayInfo] C Interface for EDID Parser 
Copying cursor functionality from dispmanx to VC6

ThunderInterfaces
Extend IWebBrowser interface for XRE/X1 usecases 
Enable .json meta to C++ interface cross referencing 
[IZIGWAVE] Align Zigbee group possibilities with join (accept) functionality

ThunderLibraries
[Support 32-bit UUIDs]

OCDM-Playready
Warning fixes