### PR TITLE
Adjust AAMP recipes to work with recent versions

### DIFF
--- a/recipes-multimedia/aamp/aamp/0003-Fix-finding-JavaScriptCore-includ-path.patch
+++ b/recipes-multimedia/aamp/aamp/0003-Fix-finding-JavaScriptCore-includ-path.patch
@@ -1,0 +1,33 @@
+From 1e5ea197f46073d9c643cf828adebde87e410ec7 Mon Sep 17 00:00:00 2001
+From: Lukasz Iwan <l.iwan@metrological.com>
+Date: Mon, 19 Sep 2022 10:56:08 +0200
+Subject: [PATCH] Fix finding JavaScriptCore includ path
+
+In our environment, JavaScriptCore, needed by AAMP for JS Bindings is located
+under /usr/include/wpe-0.1/WPE directory. AAMP in configuration step does not
+scan /usr/include recursively and expects this directory to be present there.
+This patch add subdirectories to scan in the /usr/include so the JavaScriptCore
+is properly found and added to include paths.
+---
+ CMakeLists.txt | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4769b7fa..75cfe0f5 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -53,8 +53,9 @@ if(CMAKE_QT5WEBKIT_JSBINDINGS)
+ 	include_directories(${STAGING_INCDIR}/webkit-apis/ForwardingHeaders)
+ elseif(CMAKE_WPEWEBKIT_JSBINDINGS)
+ 	message("CMAKE_QT5WEBKIT_JSBINDINGS not set, CMAKE_WPEWEBKIT_JSBINDINGS is set, Finding JavaScriptCore")
+-	find_path (STAGING_INCDIR JavaScriptCore)
+-	include_directories(${STAGING_INCDIR}/JavaScriptCore)
++	find_path (STAGING_INCDIR JavaScriptCore PATH_SUFFIXES wpe-0.1/WPE)
++    include_directories(${STAGING_INCDIR})
++    unset(STAGING_INCDIR CACHE)
+ else()
+ 	message("CMAKE_QT5WEBKIT_JSBINDINGS not set, CMAKE_WPEWEBKIT_JSBINDINGS not set")
+ endif()
+-- 
+2.35.1
+

--- a/recipes-multimedia/aamp/aamp_git.bb
+++ b/recipes-multimedia/aamp/aamp_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=175792518e4ac015ab6696d16c4f607e"
 # extra DEPENDS
 DEPENDS_append = " \
     curl libdash libxml2 cjson aampabr aampmetrics wpeframework \
-    gstreamer1.0 gstreamer1.0-plugins-base glib-2.0 util-linux wpeframework-clientlibraries \
+    gstreamer1.0 gstreamer1.0-plugins-base glib-2.0 util-linux wpeframework-clientlibraries wpewebkit \
 "
 
 PV = "0.1.gitr${SRCPV}"
@@ -17,6 +17,7 @@ SRC_URI = "\
     git://github.com/rdkcmf/rdk-aamp.git;protocol=https;branch=${RECIPE_BRANCH} \
     file://0001-rdk-aamp-disable-getsourceid-chech-temporarily-to-sendsyncevent.patch \
     file://0002-rdk-amp-align-ocdm-drm-adapter-interface.patch \
+    file://0003-Fix-finding-JavaScriptCore-includ-path.patch \
 "
 SRCREV ?= "a72fea4afc3bb8e81fab9f3e6e3604e3ab6f7930"
 
@@ -30,6 +31,9 @@ PACKAGECONFIG ??= "\
     ${@bb.utils.contains('DISTRO_FEATURES', 'playready', 'playready', '', d)} \
 "
 PACKAGECONFIG[opencdm] = "\
+    -DCMAKE_WPEWEBKIT_JSBINDINGS=ON \
+    -DCMAKE_CDM_DRM=ON \
+    -DCMAKE_USE_OPENCDM=ON \
     -DENABLE_SESSION_STATS=ON \
     -DCMAKE_DASH_DRM=ON \
     -DCMAKE_USE_OPENCDM_ADAPTER=ON \
@@ -39,8 +43,8 @@ PACKAGECONFIG[opencdm] = "\
 PACKAGECONFIG[playready] = "-DCMAKE_USE_PLAYREADY=ON,-DCMAKE_USE_PLAYREADY=OFF"
 
 PACKAGES = "${PN} ${PN}-dev ${PN}-dbg"
-FILES_${PN} += "${libdir}/lib*.so"
-FILES_${PN} += "${libdir}/aamp/lib*.so"
+FILES_${PN} += "${libdir}"
+FILES_${PN} += "${libdir}"
 
 # Fixme, something is pointing to a non-symlink and that pulls in -dev packages
 INSANE_SKIP_${PN} = "dev-deps"

--- a/recipes-multimedia/aamp/gst-plugins-rdk-aamp_git.bb
+++ b/recipes-multimedia/aamp/gst-plugins-rdk-aamp_git.bb
@@ -11,7 +11,6 @@ PV = "0.1.gitr${SRCPV}"
 RECIPE_BRANCH ?= "stable2"
 SRC_URI = "\
    git://github.com/rdkcmf/rdk-gst-plugins-rdk-aamp.git;protocol=https;branch=${RECIPE_BRANCH} \
-   file://0001_aamp_gst_ocdm_adapter.patch \
 "
 SRCREV ?= "8a0d9ef607ea254aff4b897137fd1f743db74c29"
 
@@ -20,9 +19,9 @@ S = "${WORKDIR}/git"
 inherit cmake
 
 PACKAGECONFIG ??= " ${@bb.utils.contains('DISTRO_FEATURES', 'opencdm', 'opencdm', '', d)}"
-PACKAGECONFIG[opencdm] = "-DCMAKE_DASH_DRM=ON -DCMAKE_USE_OPENCDM_ADAPTER=ON,,"
+PACKAGECONFIG[opencdm] = "-DCMAKE_DASH_DRM=ON -DCMAKE_CDM_DRM=ON -DCMAKE_USE_OPENCDM_ADAPTER=ON,,"
 
-FILES_${PN} = "${libdir}/gstreamer-1.0/libgstaamp.so"
+FILES_${PN} = "${libdir}"
 
 # Fixme, something is pointing to a non-symlink and that pulls in -dev packages
 INSANE_SKIP_${PN} = "dev-deps"

--- a/recipes-wpe/wpeframework/include/webkitbrowser.inc
+++ b/recipes-wpe/wpeframework/include/webkitbrowser.inc
@@ -301,3 +301,11 @@ PACKAGECONFIG[webkitbrowser] = "\
 
 PACKAGECONFIG[webkitbrowser_disable_dfg] = "-DPLUGIN_WEBKITBROWSER_ENABLE_DFG=OFF,,,"
 
+PACKAGECONFIG[webkitbrowser_aamp] = \
+                                "-DPLUGIN_WEBKITBROWSER_AAMP=ON \
+                                 -DPLUGIN_WEBKITBROWSER_AAMP_JSBINDINGS=ON \
+                                 ,-DPLUGIN_WEBKITBROWSER_AAMP=OFF \
+                                 -DPLUGIN_WEBKITBROWSER_AAMP_JSBINDINGS=OFF,"
+
+DEPENDS_append = "${@bb.utils.contains('PACKAGECONFIG','webkitbrowser_aamp',' aamp','',d)}"
+


### PR DESCRIPTION
Add some adjustments and patches to have the most recent AAMP build flags and be able to use AAMP within the InjectedBundle environment. 